### PR TITLE
Use slightly different directories depending on platform and pass them to fronted

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -3,7 +3,7 @@ package app
 import "runtime"
 
 const (
-	AppName = "radiance"
+	Name = "lantern"
 
 	// Placeholders to use in the request headers.
 	ClientVersion = "7.6.47"

--- a/backend/headers.go
+++ b/backend/headers.go
@@ -38,7 +38,7 @@ func NewRequestWithHeaders(ctx context.Context, method, url string, body io.Read
 	req.Header.Set(versionHeader, app.Version)
 	req.Header.Set(userIdHeader, strconv.FormatInt(user.LegacyID(), 10))
 	req.Header.Set(platformHeader, app.Platform)
-	req.Header.Set(appNameHeader, app.AppName)
+	req.Header.Set(appNameHeader, app.Name)
 	req.Header.Set(deviceIdHeader, user.DeviceID())
 	return req, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -8,16 +8,17 @@ replace github.com/sagernet/sing-box => github.com/getlantern/sing-box-minimal v
 
 require (
 	github.com/1Password/srp v0.2.0
-	github.com/Jigsaw-Code/outline-sdk v0.0.18
-	github.com/Jigsaw-Code/outline-sdk/x v0.0.1
+	github.com/Jigsaw-Code/outline-sdk v0.0.19
+	github.com/Jigsaw-Code/outline-sdk/x v0.0.2
 	github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52
 	github.com/getlantern/appdir v0.0.0-20250324200952-507a0625eb01
 	github.com/getlantern/cmux/v2 v2.0.0-20230301223233-dac79088a4c0
 	github.com/getlantern/errors v1.0.4
 	github.com/getlantern/eventual/v2 v2.0.2
+	github.com/getlantern/fronted v0.0.0-20250324204348-a0f02f9a2843
 	github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65
 	github.com/getlantern/jibber_jabber v0.0.0-20210901195950-68955124cc42
-	github.com/getlantern/kindling v0.0.0-20250224181615-944349e3e260
+	github.com/getlantern/kindling v0.0.0-20250324213140-12dec99b91eb
 	github.com/getlantern/lantern-algeneva v0.0.0-20240930181006-6d3c00db1d5d
 	github.com/getlantern/timezone v0.0.0-20210901200113-3f9de9d360c9
 	github.com/gobwas/ws v1.4.0
@@ -35,7 +36,6 @@ require (
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/caddyserver/zerossl v0.1.3 // indirect
 	github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 // indirect
-	github.com/getlantern/fronted v0.0.0-20250219040712-771dbc843542 // indirect
 	github.com/getlantern/keepcurrent v0.0.0-20240126172110-2e0264ca385d // indirect
 	github.com/getlantern/tlsdialer/v3 v3.0.3 // indirect
 	github.com/goccy/go-yaml v1.15.13 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/Jigsaw-Code/outline-sdk v0.0.18
 	github.com/Jigsaw-Code/outline-sdk/x v0.0.1
 	github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52
-	github.com/getlantern/appdir v0.0.0-20250313193928-1704611498b5
+	github.com/getlantern/appdir v0.0.0-20250324194811-e0e0e3595791
 	github.com/getlantern/cmux/v2 v2.0.0-20230301223233-dac79088a4c0
 	github.com/getlantern/errors v1.0.4
 	github.com/getlantern/eventual/v2 v2.0.2

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/Jigsaw-Code/outline-sdk v0.0.18
 	github.com/Jigsaw-Code/outline-sdk/x v0.0.1
 	github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52
-	github.com/getlantern/appdir v0.0.0-20250324194811-e0e0e3595791
+	github.com/getlantern/appdir v0.0.0-20250324200952-507a0625eb01
 	github.com/getlantern/cmux/v2 v2.0.0-20230301223233-dac79088a4c0
 	github.com/getlantern/errors v1.0.4
 	github.com/getlantern/eventual/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52 h1:w2/RqYPw7PbTYfUMS2aToD5DMKLBnQed+fkTEYTKAqQ=
 github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52/go.mod h1:PrNR8tMXO26YNs8K9653XCUH7u2Kv4OdfFC3Ke1GsX0=
-github.com/getlantern/appdir v0.0.0-20250313193928-1704611498b5 h1:CH0zDr8FUoDSErSGg6aE8ocQHJU0WLc67gu+i/Ql4jU=
-github.com/getlantern/appdir v0.0.0-20250313193928-1704611498b5/go.mod h1:3vR6+jQdWfWojZ77w+htCqEF5MO/Y2twJOpAvFuM9po=
+github.com/getlantern/appdir v0.0.0-20250324194811-e0e0e3595791 h1:FrB9FlPJ5iD0cJFZfNvZ5feC6HgLAGW0rqx3/gEtjn0=
+github.com/getlantern/appdir v0.0.0-20250324194811-e0e0e3595791/go.mod h1:3vR6+jQdWfWojZ77w+htCqEF5MO/Y2twJOpAvFuM9po=
 github.com/getlantern/byteexec v0.0.0-20170405023437-4cfb26ec74f4/go.mod h1:4WCQkaCIwta0KlF9bQZA1jYqp8bzIS2PeCqjnef8nZ8=
 github.com/getlantern/byteexec v0.0.0-20220903142956-e6ed20032cfd h1:0xt9OTbV50a/+ZarMcr86ybWiN1v+bbwzdnVuXHzR/o=
 github.com/getlantern/byteexec v0.0.0-20220903142956-e6ed20032cfd/go.mod h1:oD9q9NB1LNBLHk3WAwza4tivxV7tm7jKFlCNCAv3+M8=

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52 h1:w2/RqYPw7PbTYfUMS2aToD5DMKLBnQed+fkTEYTKAqQ=
 github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52/go.mod h1:PrNR8tMXO26YNs8K9653XCUH7u2Kv4OdfFC3Ke1GsX0=
-github.com/getlantern/appdir v0.0.0-20250324194811-e0e0e3595791 h1:FrB9FlPJ5iD0cJFZfNvZ5feC6HgLAGW0rqx3/gEtjn0=
-github.com/getlantern/appdir v0.0.0-20250324194811-e0e0e3595791/go.mod h1:3vR6+jQdWfWojZ77w+htCqEF5MO/Y2twJOpAvFuM9po=
+github.com/getlantern/appdir v0.0.0-20250324200952-507a0625eb01 h1:Mmeh4/DA1OKN9tVWRAvTL5efFx4c7v9/55hoK17NclA=
+github.com/getlantern/appdir v0.0.0-20250324200952-507a0625eb01/go.mod h1:3vR6+jQdWfWojZ77w+htCqEF5MO/Y2twJOpAvFuM9po=
 github.com/getlantern/byteexec v0.0.0-20170405023437-4cfb26ec74f4/go.mod h1:4WCQkaCIwta0KlF9bQZA1jYqp8bzIS2PeCqjnef8nZ8=
 github.com/getlantern/byteexec v0.0.0-20220903142956-e6ed20032cfd h1:0xt9OTbV50a/+ZarMcr86ybWiN1v+bbwzdnVuXHzR/o=
 github.com/getlantern/byteexec v0.0.0-20220903142956-e6ed20032cfd/go.mod h1:oD9q9NB1LNBLHk3WAwza4tivxV7tm7jKFlCNCAv3+M8=

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 github.com/1Password/srp v0.2.0 h1:PZKAafEyExnwevliL6d2+FDhJXZ0phxqiG2OeIaj9Xk=
 github.com/1Password/srp v0.2.0/go.mod h1:LIGqQ7eEA0UJT98j7sXk60QWVpHJ3g00BX6LOm9kYTc=
-github.com/Jigsaw-Code/outline-sdk v0.0.18 h1:xGzbag/jWGVQl5wGy0szr1jb+P8nVDFMcR2mWmgQnqc=
-github.com/Jigsaw-Code/outline-sdk v0.0.18/go.mod h1:CFDKyGZA4zatKE4vMLe8TyQpZCyINOeRFbMAmYHxodw=
-github.com/Jigsaw-Code/outline-sdk/x v0.0.1 h1:DW8Ja4iWKPqYpnahBXQ/eg1WVDw/F3Pktbz1mBWTZXw=
-github.com/Jigsaw-Code/outline-sdk/x v0.0.1/go.mod h1:aFUEz6Z/eD0NS3c3fEIX+JO2D9aIrXCmWTb1zJFlItw=
+github.com/Jigsaw-Code/outline-sdk v0.0.19 h1:/OpMz+3B/9ypjq/UyEvwZSflzJ4jXFginUOZeN0UssM=
+github.com/Jigsaw-Code/outline-sdk v0.0.19/go.mod h1:CFDKyGZA4zatKE4vMLe8TyQpZCyINOeRFbMAmYHxodw=
+github.com/Jigsaw-Code/outline-sdk/x v0.0.2 h1:NUJwSzL2XdvmcVtoY9xwU6LwptI9kZOaVWI9kTMvVng=
+github.com/Jigsaw-Code/outline-sdk/x v0.0.2/go.mod h1:8vMQ+QKz62lVkUcPDc276yvopDreniYZQPvhqOn27b0=
 github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/alitto/pond/v2 v2.1.5 h1:2pp/KAPcb02NSpHsjjnxnrTDzogMLsq+vFf/L0DB84A=
@@ -64,8 +64,8 @@ github.com/getlantern/fdcount v0.0.0-20210503151800-5decd65b3731/go.mod h1:XZwE+
 github.com/getlantern/filepersist v0.0.0-20160317154340-c5f0cd24e799/go.mod h1:8DGAx0LNUfXNnEH+fXI0s3OCBA/351kZCiz/8YSK3i8=
 github.com/getlantern/filepersist v0.0.0-20210901195658-ed29a1cb0b7c h1:mcz27xtAkb1OuOLBct/uFfL1p3XxAIcFct82GbT+UZM=
 github.com/getlantern/filepersist v0.0.0-20210901195658-ed29a1cb0b7c/go.mod h1:8DGAx0LNUfXNnEH+fXI0s3OCBA/351kZCiz/8YSK3i8=
-github.com/getlantern/fronted v0.0.0-20250219040712-771dbc843542 h1:MjZxNaypCs40gmVJp38z25ySftio8PNpeNa35OXFvCg=
-github.com/getlantern/fronted v0.0.0-20250219040712-771dbc843542/go.mod h1:/4g6lEMXHzkF/6WBr3vod4wh3tos632qSZGh7L/fIdg=
+github.com/getlantern/fronted v0.0.0-20250324204348-a0f02f9a2843 h1:Fp+7CCK+lpfpMzd6YikkSm8ssUU2ZYcCHAZlquf+w5I=
+github.com/getlantern/fronted v0.0.0-20250324204348-a0f02f9a2843/go.mod h1:/4g6lEMXHzkF/6WBr3vod4wh3tos632qSZGh7L/fIdg=
 github.com/getlantern/golog v0.0.0-20190809085441-26e09e6dd330/go.mod h1:zx/1xUUeYPy3Pcmet8OSXLbF47l+3y6hIPpyLWoR9oc=
 github.com/getlantern/golog v0.0.0-20210606115803-bce9f9fe5a5f/go.mod h1:ZyIjgH/1wTCl+B+7yH1DqrWp6MPJqESmwmEQ89ZfhvA=
 github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65 h1:NlQedYmPI3pRAXJb+hLVVDGqfvvXGRPV8vp7XOjKAZ0=
@@ -87,8 +87,8 @@ github.com/getlantern/keyman v0.0.0-20180207174507-f55e7280e93a/go.mod h1:FMf0g7
 github.com/getlantern/keyman v0.0.0-20200819205636-76fef27c39f1/go.mod h1:FMf0g72BHs14jVcD8i8ubEk4sMB6JdidBn67d44i3ws=
 github.com/getlantern/keyman v0.0.0-20230503155501-4e864ca2175b h1:iyEuk8ARQC9HfraqC4r3leBhU55R1TV7bAiyPYE54kA=
 github.com/getlantern/keyman v0.0.0-20230503155501-4e864ca2175b/go.mod h1:ZJ+yDaZkJ/JU9j7EQa3UUh6ouedrNDDLA5OiowS1Iuk=
-github.com/getlantern/kindling v0.0.0-20250224181615-944349e3e260 h1:D7tiAtRCwOzQjDZuGOrV4nKGTjs/8tZe371Jo9HTyYU=
-github.com/getlantern/kindling v0.0.0-20250224181615-944349e3e260/go.mod h1:q8vxuYTiy+cEx9Bt9M0REEvn/Y/m2iUliaWtRRwPooY=
+github.com/getlantern/kindling v0.0.0-20250324213140-12dec99b91eb h1:IbQdIj16D/RXPgKNXDkUe91hBfd32D3F2fNFNjv3Qeg=
+github.com/getlantern/kindling v0.0.0-20250324213140-12dec99b91eb/go.mod h1:+18SvvV6dP5iBut/cdI1ywG1nPFq4ASp5iEjPJXHVAU=
 github.com/getlantern/lantern-algeneva v0.0.0-20240930181006-6d3c00db1d5d h1:ACBwPR4du54Qw+X5ajsbMqOFR8euGZRdMGkvTDS7I60=
 github.com/getlantern/lantern-algeneva v0.0.0-20240930181006-6d3c00db1d5d/go.mod h1:bDcK4RWBjBO+bBPLTCmaEyYK+n0/w0TrzvSCJOQmkgk=
 github.com/getlantern/mockconn v0.0.0-20191023022503-481dbcceeb58/go.mod h1:+F5GJ7qGpQ03DBtcOEyQpM30ix4BLswdaojecFtsdy8=

--- a/issue/issue_test.go
+++ b/issue/issue_test.go
@@ -18,8 +18,8 @@ func TestSendReport(t *testing.T) {
 		kindling.WithDomainFronting(f),
 		kindling.WithProxyless("api.iantem.io"),
 	)
-	user := user.New(k.NewHTTPClient())
-	reporter, err := NewIssueReporter(k.NewHTTPClient(), user)
+	u := user.New(k.NewHTTPClient())
+	reporter, err := NewIssueReporter(k.NewHTTPClient(), u)
 	require.NoError(t, err)
 	// Grab a temporary directory
 	dir, err := os.MkdirTemp("", "lantern")

--- a/issue/issue_test.go
+++ b/issue/issue_test.go
@@ -4,14 +4,18 @@ import (
 	"os"
 	"testing"
 
+	"github.com/getlantern/fronted"
 	"github.com/getlantern/kindling"
 	"github.com/getlantern/radiance/user"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSendReport(t *testing.T) {
+	f := fronted.NewFronted(
+		fronted.WithConfigURL("https://raw.githubusercontent.com/getlantern/lantern-binaries/refs/heads/main/fronted.yaml.gz"),
+	)
 	k := kindling.NewKindling(
-		kindling.WithDomainFronting("https://raw.githubusercontent.com/getlantern/lantern-binaries/refs/heads/main/fronted.yaml.gz", ""),
+		kindling.WithDomainFronting(f),
 		kindling.WithProxyless("api.iantem.io"),
 	)
 	user := user.New(k.NewHTTPClient())

--- a/radiance.go
+++ b/radiance.go
@@ -79,7 +79,8 @@ func NewRadiance(dataDir string, platIfce libbox.PlatformInterface) (*Radiance, 
 		return nil, fmt.Errorf("failed to setup directories: %w", err)
 	}
 
-	logPath := filepath.Join(logDir, app.LogFileName)
+	logsDir = logDir
+	logPath := filepath.Join(logsDir, app.LogFileName)
 	var logWriter io.Writer
 	log, logWriter, err = newLog(logPath)
 	if err != nil {

--- a/radiance.go
+++ b/radiance.go
@@ -63,7 +63,7 @@ type Radiance struct {
 	activeConfig *atomic.Value
 
 	connected   bool
-	statusMutex sync.Locker
+	statusMutex *sync.Mutex
 	stopChan    chan struct{}
 
 	user *user.User
@@ -118,7 +118,6 @@ func NewRadiance(dataDir string, platIfce libbox.PlatformInterface) (*Radiance, 
 		confHandler:   config.NewConfigHandler(configPollInterval, k.NewHTTPClient(), user, dataDirPath),
 		activeConfig:  new(atomic.Value),
 		connected:     false,
-		statusMutex:   new(sync.Mutex),
 		stopChan:      make(chan struct{}),
 		user:          user,
 		issueReporter: issueReporter,

--- a/radiance.go
+++ b/radiance.go
@@ -94,13 +94,11 @@ func NewRadiance(dataDir string, platIfce libbox.PlatformInterface) (*Radiance, 
 		return nil, err
 	}
 
-	f, err := newFronted(logWriter, reporting.PanicListener,
-		"https://raw.githubusercontent.com/getlantern/lantern-binaries/refs/heads/main/fronted.yaml.gz",
-		"", filepath.Join(dataDirPath, "fronted_cache.json"))
+	// TODO: Ideally we would know the user locale to set the country on fronted startup.
+	f, err := newFronted(logWriter, reporting.PanicListener, filepath.Join(dataDirPath, "fronted_cache.json"))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create fronted: %w", err)
 	}
-	// TODO: Ideally we would know the user locale here on radiance startup.
 	k := kindling.NewKindling(
 		kindling.WithPanicListener(reporting.PanicListener),
 		kindling.WithDomainFronting(f),
@@ -299,8 +297,9 @@ func newLog(logPath string) (*slog.Logger, io.Writer, error) {
 	return logger, logWriter, nil
 }
 
-func newFronted(logWriter io.Writer, panicListener func(string), configURL, countryCode, cacheFile string) (fronted.Fronted, error) {
+func newFronted(logWriter io.Writer, panicListener func(string), cacheFile string) (fronted.Fronted, error) {
 	// Parse the domain from the URL.
+	configURL := "https://raw.githubusercontent.com/getlantern/lantern-binaries/refs/heads/main/fronted.yaml.gz"
 	u, err := url.Parse(configURL)
 	if err != nil {
 		log.Error("Failed to parse URL", "error", err)
@@ -324,6 +323,6 @@ func newFronted(logWriter io.Writer, panicListener func(string), configURL, coun
 		fronted.WithCacheFile(cacheFile),
 		fronted.WithHTTPClient(httpClient),
 		fronted.WithConfigURL(configURL),
-		fronted.WithCountryCode(countryCode),
+		//fronted.WithCountryCode(countryCode),
 	), nil
 }

--- a/radiance.go
+++ b/radiance.go
@@ -30,13 +30,9 @@ import (
 	"github.com/getlantern/radiance/user"
 )
 
-var (
-	logsDir string
+var log *slog.Logger
 
-	log *slog.Logger
-
-	configPollInterval = 10 * time.Minute
-)
+const configPollInterval = 10 * time.Minute
 
 //go:generate mockgen -destination=radiance_mock_test.go -package=radiance github.com/getlantern/radiance httpServer,configHandler
 
@@ -66,6 +62,7 @@ type Radiance struct {
 	user *user.User
 
 	issueReporter *issue.IssueReporter
+	logsDir       string
 }
 
 // NewRadiance creates a new Radiance VPN client. platIfce is the platform interface used to
@@ -79,8 +76,7 @@ func NewRadiance(dataDir string, platIfce libbox.PlatformInterface) (*Radiance, 
 		return nil, fmt.Errorf("failed to setup directories: %w", err)
 	}
 
-	logsDir = logDir
-	logPath := filepath.Join(logsDir, app.LogFileName)
+	logPath := filepath.Join(logDir, app.LogFileName)
 	var logWriter io.Writer
 	log, logWriter, err = newLog(logPath)
 	if err != nil {
@@ -116,6 +112,7 @@ func NewRadiance(dataDir string, platIfce libbox.PlatformInterface) (*Radiance, 
 		stopChan:      make(chan struct{}),
 		user:          u,
 		issueReporter: issueReporter,
+		logsDir:       logDir,
 	}, nil
 }
 
@@ -257,7 +254,7 @@ func (r *Radiance) ReportIssue(email string, report *IssueReport) error {
 	}
 
 	return r.issueReporter.Report(
-		logsDir,
+		r.logsDir,
 		email,
 		typeInt,
 		report.Description,

--- a/radiance.go
+++ b/radiance.go
@@ -104,8 +104,8 @@ func NewRadiance(dataDir string, platIfce libbox.PlatformInterface) (*Radiance, 
 		kindling.WithDomainFronting(f),
 		kindling.WithProxyless("api.iantem.io"),
 	)
-	user := user.New(k.NewHTTPClient())
-	issueReporter, err := issue.NewIssueReporter(k.NewHTTPClient(), user)
+	u := user.New(k.NewHTTPClient())
+	issueReporter, err := issue.NewIssueReporter(k.NewHTTPClient(), u)
 	if err != nil {
 		return nil, err
 	}
@@ -113,11 +113,11 @@ func NewRadiance(dataDir string, platIfce libbox.PlatformInterface) (*Radiance, 
 	return &Radiance{
 		vpnClient: vpnC,
 
-		confHandler:   config.NewConfigHandler(configPollInterval, k.NewHTTPClient(), user, dataDirPath),
+		confHandler:   config.NewConfigHandler(configPollInterval, k.NewHTTPClient(), u, dataDirPath),
 		activeConfig:  new(atomic.Value),
 		connected:     atomic.Bool{},
 		stopChan:      make(chan struct{}),
-		user:          user,
+		user:          u,
 		issueReporter: issueReporter,
 	}, nil
 }

--- a/radiance.go
+++ b/radiance.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	logDir string
+	logsDir string
 
 	log *slog.Logger
 
@@ -258,7 +258,7 @@ func (r *Radiance) ReportIssue(email string, report IssueReport) error {
 	}
 
 	return r.issueReporter.Report(
-		logDir,
+		logsDir,
 		email,
 		typeInt,
 		report.Description,
@@ -268,13 +268,13 @@ func (r *Radiance) ReportIssue(email string, report IssueReport) error {
 		country)
 }
 
-func setupDirs(baseDir string) (string, string, error) {
+func setupDirs(baseDir string) (dataDir, logDir string, err error) {
 	// On Windows, Mac, and Linux, we can easily determine the user directories in Go. Typically mobile will have
 	// to pass the base directory to use.
 	if baseDir == "" {
 		return appdir.General(app.Name), appdir.Logs(app.Name), nil
 	}
-	logDir := filepath.Join(baseDir, "logs")
+	logDir = filepath.Join(baseDir, "logs")
 	if err := os.MkdirAll(logDir, 0o755); err != nil {
 		return "", "", fmt.Errorf("failed to setup data directory: %w", err)
 	}

--- a/radiance_test.go
+++ b/radiance_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestNewRadiance(t *testing.T) {
 	t.Run("it should create a new Radiance instance successfully", func(t *testing.T) {
-		r, err := NewRadiance("", nil)
+		r, err := NewRadiance(t.TempDir(), nil)
 		assert.NotNil(t, r)
 		assert.NoError(t, err)
 		assert.False(t, r.connected)

--- a/radiance_test.go
+++ b/radiance_test.go
@@ -12,14 +12,18 @@ import (
 )
 
 func TestNewRadiance(t *testing.T) {
-	// TODO: update tests to reflect current implementation of NewRadiance
-	t.Run("it should return a new Radiance instance", func(t *testing.T) {
+	t.Run("it should create a new Radiance instance successfully", func(t *testing.T) {
 		r, err := NewRadiance("", nil)
+		assert.NotNil(t, r)
 		assert.NoError(t, err)
-		require.NotNil(t, r)
-		assert.NotNil(t, r.confHandler)
 		assert.False(t, r.connected)
+		assert.NotNil(t, r.vpnClient)
+		assert.NotNil(t, r.confHandler)
+		assert.NotNil(t, r.activeConfig)
 		assert.NotNil(t, r.statusMutex)
+		assert.NotNil(t, r.stopChan)
+		assert.NotNil(t, r.user)
+		assert.NotNil(t, r.issueReporter)
 	})
 }
 

--- a/radiance_test.go
+++ b/radiance_test.go
@@ -135,7 +135,7 @@ func TestReportIssue(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r, err := NewRadiance("", nil)
+			r, err := NewRadiance(t.TempDir(), nil)
 			require.NoError(t, err)
 			err = r.ReportIssue(tt.email, tt.report)
 			tt.assert(t, err)

--- a/radiance_test.go
+++ b/radiance_test.go
@@ -137,7 +137,7 @@ func TestReportIssue(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r, err := NewRadiance(t.TempDir(), nil)
 			require.NoError(t, err)
-			err = r.ReportIssue(tt.email, tt.report)
+			err = r.ReportIssue(tt.email, &tt.report)
 			tt.assert(t, err)
 		})
 	}

--- a/radiance_test.go
+++ b/radiance_test.go
@@ -16,7 +16,7 @@ func TestNewRadiance(t *testing.T) {
 		r, err := NewRadiance(t.TempDir(), nil)
 		assert.NotNil(t, r)
 		assert.NoError(t, err)
-		assert.False(t, r.connected)
+		assert.False(t, r.connected.Load())
 		assert.NotNil(t, r.vpnClient)
 		assert.NotNil(t, r.confHandler)
 		assert.NotNil(t, r.activeConfig)
@@ -48,7 +48,7 @@ func TestGetActiveServer(t *testing.T) {
 			setup: func(ctrl *gomock.Controller) *Radiance {
 				r, err := NewRadiance("", nil)
 				assert.NoError(t, err)
-				r.connected = true
+				r.connected.Store(true)
 				return r
 			},
 			assert: func(t *testing.T, server *Server, err error) {
@@ -61,7 +61,7 @@ func TestGetActiveServer(t *testing.T) {
 			setup: func(ctrl *gomock.Controller) *Radiance {
 				r, err := NewRadiance("", nil)
 				assert.NoError(t, err)
-				r.connected = true
+				r.connected.Store(true)
 				r.activeConfig.Store(&config.Config{
 					Addr:     "1.2.3.4",
 					Protocol: "random",

--- a/radiance_test.go
+++ b/radiance_test.go
@@ -1,6 +1,7 @@
 package radiance
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -136,4 +137,27 @@ func TestReportIssue(t *testing.T) {
 			tt.assert(t, err)
 		})
 	}
+}
+func TestSetupDirs(t *testing.T) {
+	t.Run("it should return default directories when baseDir is empty", func(t *testing.T) {
+		dataDir, logDir, err := setupDirs("")
+		assert.NoError(t, err)
+		assert.NotEmpty(t, dataDir)
+		assert.NotEmpty(t, logDir)
+	})
+
+	t.Run("it should create and return directories when baseDir is provided", func(t *testing.T) {
+		baseDir := t.TempDir()
+		dataDir, logDir, err := setupDirs(baseDir)
+		assert.NoError(t, err)
+		assert.Equal(t, baseDir, dataDir)
+		assert.Equal(t, filepath.Join(baseDir, "logs"), logDir)
+		assert.DirExists(t, logDir)
+	})
+
+	t.Run("it should return error when it fails to create directories", func(t *testing.T) {
+		baseDir := "/invalid/path"
+		_, _, err := setupDirs(baseDir)
+		assert.Error(t, err)
+	})
 }

--- a/radiance_test.go
+++ b/radiance_test.go
@@ -35,7 +35,7 @@ func TestGetActiveServer(t *testing.T) {
 		{
 			name: "it should return nil when VPN is disconnected",
 			setup: func(ctrl *gomock.Controller) (*Radiance, error) {
-				return NewRadiance("", nil)
+				return NewRadiance(t.TempDir(), nil)
 			},
 			assert: func(t *testing.T, server *Server, err error) {
 				assert.Nil(t, server)
@@ -45,7 +45,7 @@ func TestGetActiveServer(t *testing.T) {
 		{
 			name: "it should return error when there is no current config",
 			setup: func(ctrl *gomock.Controller) (*Radiance, error) {
-				r, err := NewRadiance("", nil)
+				r, err := NewRadiance(t.TempDir(), nil)
 				assert.NoError(t, err)
 				r.connected.Store(true)
 				return r, err
@@ -58,7 +58,7 @@ func TestGetActiveServer(t *testing.T) {
 		{
 			name: "it should return the active server when VPN is connected",
 			setup: func(ctrl *gomock.Controller) (*Radiance, error) {
-				r, err := NewRadiance("", nil)
+				r, err := NewRadiance(t.TempDir(), nil)
 				assert.NoError(t, err)
 				r.connected.Store(true)
 				r.activeConfig.Store(&config.Config{

--- a/radiance_test.go
+++ b/radiance_test.go
@@ -20,7 +20,6 @@ func TestNewRadiance(t *testing.T) {
 		assert.NotNil(t, r.vpnClient)
 		assert.NotNil(t, r.confHandler)
 		assert.NotNil(t, r.activeConfig)
-		assert.NotNil(t, r.statusMutex)
 		assert.NotNil(t, r.stopChan)
 		assert.NotNil(t, r.user)
 		assert.NotNil(t, r.issueReporter)


### PR DESCRIPTION
The previous setup would use a generic directory under HOME for all platforms for both data and logs, but we want things like `~/Library/Logs/Lantern` on MacOS and `%AppData%` on Windows.