### PR TITLE
AmneziaWG as a separate protocol

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,12 @@
 module github.com/getlantern/radiance
 
-go 1.23.1
+go 1.23.6
+
+toolchain go1.24.1
 
 replace github.com/sagernet/sing-box => github.com/getlantern/sing-box-minimal v1.11.6-0.20250319162213-b56a0b17a972
+
+replace github.com/sagernet/wireguard-go => github.com/getlantern/wireguard-go v0.0.1-beta.5.0.20250310145906-45220d8aec77
 
 //replace github.com/sagernet/sing-box => ../sing-box-minimal
 
@@ -52,6 +56,7 @@ require (
 	github.com/pivotal-cf-experimental/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21 // indirect
 	github.com/refraction-networking/utls v1.6.7 // indirect
 	github.com/sagernet/cloudflare-tls v0.0.0-20231208171750-a4483c1b7cd1 // indirect
+	github.com/tevino/abool/v2 v2.1.0 // indirect
 	github.com/tkuchiki/go-timezone v0.2.0 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/getlantern/tlsdialer/v3 v3.0.3 h1:OXzzAqO8YojBOu2Kk8wquX2zbFmgJjji41R
 github.com/getlantern/tlsdialer/v3 v3.0.3/go.mod h1:hwA0X81pnrgx7GEwddaGWSxqr6eLBm7A0rrUMK2J7KY=
 github.com/getlantern/waitforserver v1.0.1 h1:xBjqJ3GgEk9JMWnDgRSiNHXINi6Lv2tGNjJR0hCkHFY=
 github.com/getlantern/waitforserver v1.0.1/go.mod h1:K1oSA8lNKgQ9iC00OFpMfMNm4UMrsxoGCdHf0NT9LGs=
+github.com/getlantern/wireguard-go v0.0.1-beta.5.0.20250310145906-45220d8aec77 h1:BEYHpyQzW64Mof30bVolWi7D6gIEUJTyh8rcjHwJZnA=
+github.com/getlantern/wireguard-go v0.0.1-beta.5.0.20250310145906-45220d8aec77/go.mod h1:akc2Wh+rX9bFFNnHJGsQ8VIV3eJI1LXJYgx2Y+8lcW8=
 github.com/getsentry/sentry-go v0.31.1 h1:ELVc0h7gwyhnXHDouXkhqTFSO5oslsRDk0++eyE0KJ4=
 github.com/getsentry/sentry-go v0.31.1/go.mod h1:CYNcMMz73YigoHljQRG+qPF+eMq8gG72XcGN/p71BAY=
 github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
@@ -304,8 +306,6 @@ github.com/sagernet/smux v0.0.0-20231208180855-7041f6ea79e7 h1:DImB4lELfQhplLTxe
 github.com/sagernet/smux v0.0.0-20231208180855-7041f6ea79e7/go.mod h1:FP9X2xjT/Az1EsG/orYYoC+5MojWnuI7hrffz8fGwwo=
 github.com/sagernet/utls v1.6.7 h1:Ep3+aJ8FUGGta+II2IEVNUc3EDhaRCZINWkj/LloIA8=
 github.com/sagernet/utls v1.6.7/go.mod h1:Uua1TKO/FFuAhLr9rkaVnnrTmmiItzDjv1BUb2+ERwM=
-github.com/sagernet/wireguard-go v0.0.1-beta.5 h1:aBEsxJUMEONwOZqKPIkuAcv4zJV5p6XlzEN04CF0FXc=
-github.com/sagernet/wireguard-go v0.0.1-beta.5/go.mod h1:jGXij2Gn2wbrWuYNUmmNhf1dwcZtvyAvQoe8Xd8MbUo=
 github.com/sagernet/ws v0.0.0-20231204124109-acfe8907c854 h1:6uUiZcDRnZSAegryaUGwPC/Fj13JSHwiTftrXhMmYOc=
 github.com/sagernet/ws v0.0.0-20231204124109-acfe8907c854/go.mod h1:LtfoSK3+NG57tvnVEHgcuBW9ujgE8enPSgzgwStwCAA=
 github.com/shadowsocks/go-shadowsocks2 v0.1.5 h1:PDSQv9y2S85Fl7VBeOMF9StzeXZyK1HakRm86CUbr28=
@@ -322,6 +322,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/tevino/abool/v2 v2.1.0 h1:7w+Vf9f/5gmKT4m4qkayb33/92M+Um45F2BkHOR+L/c=
+github.com/tevino/abool/v2 v2.1.0/go.mod h1:+Lmlqk6bHDWHqN1cbxqhwEAwMPXgc8I1SDEamtseuXY=
 github.com/things-go/go-socks5 v0.0.5 h1:qvKaGcBkfDrUL33SchHN93srAmYGzb4CxSM2DPYufe8=
 github.com/things-go/go-socks5 v0.0.5/go.mod h1:mtzInf8v5xmsBpHZVbIw2YQYhc4K0jRwzfsH64Uh0IQ=
 github.com/tkuchiki/go-timezone v0.2.0 h1:yyZVHtQRVZ+wvlte5HXvSpBkR0dPYnPEIgq9qqAqltk=

--- a/option/amnezia.go
+++ b/option/amnezia.go
@@ -6,6 +6,7 @@ import (
 	"net/netip"
 )
 
+/*************  ADDED FOR AMNEZIA  *************/
 /*
 WireGuardAdvancedSecurityOptions provides advanced security options for WireGuard required to activate AmneziaWG.
 
@@ -33,6 +34,7 @@ type WireGuardAdvancedSecurityOptions struct {
 	UnderloadPacketMagicHeader uint32 `json:"underload_packet_magic_header,omitempty"` // h3
 	TransportPacketMagicHeader uint32 `json:"transport_packet_magic_header,omitempty"` // h4
 }
+/********************  END  ********************/
 type WireGuardEndpointOptions struct {
 	System     bool                             `json:"system,omitempty"`
 	Name       string                           `json:"name,omitempty"`
@@ -43,7 +45,7 @@ type WireGuardEndpointOptions struct {
 	Peers      []WireGuardPeer                  `json:"peers,omitempty"`
 	UDPTimeout badoption.Duration               `json:"udp_timeout,omitempty"`
 	Workers    int                              `json:"workers,omitempty"`
-	WireGuardAdvancedSecurityOptions
+	WireGuardAdvancedSecurityOptions	/**  ADDED FOR AMNEZIA  **/
 	O.DialerOptions
 }
 

--- a/option/amnezia.go
+++ b/option/amnezia.go
@@ -1,0 +1,83 @@
+package option
+
+import (
+	O "github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing/common/json/badoption"
+	"net/netip"
+)
+
+/*
+WireGuardAdvancedSecurityOptions provides advanced security options for WireGuard required to activate AmneziaWG.
+
+In AmneziaWG, random bytes are appended to every auth packet to alter their size.
+
+Thus, "init and response handshake packets" have added "junk" at the beginning of their data, the size of which
+is determined by the values S1 and S2.
+
+By default, the initiating handshake packet has a fixed size (148 bytes). After adding the junk, its size becomes 148 bytes + S1.
+AmneziaWG also incorporates another trick for more reliable masking. Before initiating a session, Amnezia sends a
+
+certain number of "junk" packets to thoroughly confuse DPI systems. The number of these packets and their
+minimum and maximum byte sizes can also be adjusted in the settings, using parameters Jc, Jmin, and Jmax.
+
+*/
+
+type WireGuardAdvancedSecurityOptions struct {
+	JunkPacketCount            int    `json:"junk_packet_count,omitempty"`             // jc
+	JunkPacketMinSize          int    `json:"junk_packet_min_size,omitempty"`          // jmin
+	JunkPacketMaxSize          int    `json:"junk_packet_max_size,omitempty"`          // jmax
+	InitPacketJunkSize         int    `json:"init_packet_junk_size,omitempty"`         // s1
+	ResponsePacketJunkSize     int    `json:"response_packet_junk_size,omitempty"`     // s2
+	InitPacketMagicHeader      uint32 `json:"init_packet_magic_header,omitempty"`      // h1
+	ResponsePacketMagicHeader  uint32 `json:"response_packet_magic_header,omitempty"`  // h2
+	UnderloadPacketMagicHeader uint32 `json:"underload_packet_magic_header,omitempty"` // h3
+	TransportPacketMagicHeader uint32 `json:"transport_packet_magic_header,omitempty"` // h4
+}
+type WireGuardEndpointOptions struct {
+	System     bool                             `json:"system,omitempty"`
+	Name       string                           `json:"name,omitempty"`
+	MTU        uint32                           `json:"mtu,omitempty"`
+	Address    badoption.Listable[netip.Prefix] `json:"address"`
+	PrivateKey string                           `json:"private_key"`
+	ListenPort uint16                           `json:"listen_port,omitempty"`
+	Peers      []WireGuardPeer                  `json:"peers,omitempty"`
+	UDPTimeout badoption.Duration               `json:"udp_timeout,omitempty"`
+	Workers    int                              `json:"workers,omitempty"`
+	WireGuardAdvancedSecurityOptions
+	O.DialerOptions
+}
+
+type WireGuardPeer struct {
+	Address                     string                           `json:"address,omitempty"`
+	Port                        uint16                           `json:"port,omitempty"`
+	PublicKey                   string                           `json:"public_key,omitempty"`
+	PreSharedKey                string                           `json:"pre_shared_key,omitempty"`
+	AllowedIPs                  badoption.Listable[netip.Prefix] `json:"allowed_ips,omitempty"`
+	PersistentKeepaliveInterval uint16                           `json:"persistent_keepalive_interval,omitempty"`
+	Reserved                    []uint8                          `json:"reserved,omitempty"`
+}
+
+type LegacyWireGuardOutboundOptions struct {
+	O.DialerOptions
+	SystemInterface bool                             `json:"system_interface,omitempty"`
+	GSO             bool                             `json:"gso,omitempty"`
+	InterfaceName   string                           `json:"interface_name,omitempty"`
+	LocalAddress    badoption.Listable[netip.Prefix] `json:"local_address"`
+	PrivateKey      string                           `json:"private_key"`
+	Peers           []LegacyWireGuardPeer            `json:"peers,omitempty"`
+	O.ServerOptions
+	PeerPublicKey string        `json:"peer_public_key"`
+	PreSharedKey  string        `json:"pre_shared_key,omitempty"`
+	Reserved      []uint8       `json:"reserved,omitempty"`
+	Workers       int           `json:"workers,omitempty"`
+	MTU           uint32        `json:"mtu,omitempty"`
+	Network       O.NetworkList `json:"network,omitempty"`
+}
+
+type LegacyWireGuardPeer struct {
+	O.ServerOptions
+	PublicKey    string                           `json:"public_key,omitempty"`
+	PreSharedKey string                           `json:"pre_shared_key,omitempty"`
+	AllowedIPs   badoption.Listable[netip.Prefix] `json:"allowed_ips,omitempty"`
+	Reserved     []uint8                          `json:"reserved,omitempty"`
+}

--- a/protocol/amnezia/endpoint.go
+++ b/protocol/amnezia/endpoint.go
@@ -1,0 +1,216 @@
+package amnezia
+
+import (
+	"context"
+	O "github.com/sagernet/sing-box/option"
+	"net"
+	"net/netip"
+	"time"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/adapter/endpoint"
+	"github.com/sagernet/sing-box/common/dialer"
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing-dns"
+	"github.com/sagernet/sing/common"
+	"github.com/sagernet/sing/common/bufio"
+	E "github.com/sagernet/sing/common/exceptions"
+	"github.com/sagernet/sing/common/logger"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+
+	"github.com/getlantern/radiance/option"
+	"github.com/getlantern/radiance/transport/amnezia"
+)
+
+func RegisterEndpoint(registry *endpoint.Registry) {
+	endpoint.Register[option.WireGuardEndpointOptions](registry, C.TypeWireGuard, NewEndpoint)
+}
+
+var (
+	_ adapter.Endpoint                = (*Endpoint)(nil)
+	_ adapter.InterfaceUpdateListener = (*Endpoint)(nil)
+)
+
+type Endpoint struct {
+	endpoint.Adapter
+	ctx            context.Context
+	router         adapter.Router
+	logger         logger.ContextLogger
+	localAddresses []netip.Prefix
+	endpoint       *amnezia.Endpoint
+}
+
+func NewEndpoint(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, options option.WireGuardEndpointOptions) (adapter.Endpoint, error) {
+	ep := &Endpoint{
+		Adapter:        endpoint.NewAdapterWithDialerOptions(C.TypeWireGuard, tag, []string{N.NetworkTCP, N.NetworkUDP}, options.DialerOptions),
+		ctx:            ctx,
+		router:         router,
+		logger:         logger,
+		localAddresses: options.Address,
+	}
+	if options.Detour == "" {
+		options.IsWireGuardListener = true
+	}
+	outboundDialer, err := dialer.New(ctx, options.DialerOptions)
+	if err != nil {
+		return nil, err
+	}
+	var udpTimeout time.Duration
+	if options.UDPTimeout != 0 {
+		udpTimeout = time.Duration(options.UDPTimeout)
+	} else {
+		udpTimeout = C.UDPTimeout
+	}
+	wgEndpoint, err := amnezia.NewEndpoint(amnezia.EndpointOptions{
+		Context:    ctx,
+		Logger:     logger,
+		System:     options.System,
+		Handler:    ep,
+		UDPTimeout: udpTimeout,
+		Dialer:     outboundDialer,
+		CreateDialer: func(interfaceName string) N.Dialer {
+			return common.Must1(dialer.NewDefault(ctx, O.DialerOptions{
+				BindInterface: interfaceName,
+			}))
+		},
+		Name:       options.Name,
+		MTU:        options.MTU,
+		Address:    options.Address,
+		PrivateKey: options.PrivateKey,
+		ListenPort: options.ListenPort,
+		ResolvePeer: func(domain string) (netip.Addr, error) {
+			endpointAddresses, lookupErr := router.Lookup(ctx, domain, dns.DomainStrategy(options.DomainStrategy))
+			if lookupErr != nil {
+				return netip.Addr{}, lookupErr
+			}
+			return endpointAddresses[0], nil
+		},
+		Peers: common.Map(options.Peers, func(it option.WireGuardPeer) amnezia.PeerOptions {
+			return amnezia.PeerOptions{
+				Endpoint:                    M.ParseSocksaddrHostPort(it.Address, it.Port),
+				PublicKey:                   it.PublicKey,
+				PreSharedKey:                it.PreSharedKey,
+				AllowedIPs:                  it.AllowedIPs,
+				PersistentKeepaliveInterval: it.PersistentKeepaliveInterval,
+				Reserved:                    it.Reserved,
+			}
+		}),
+		Workers:                          options.Workers,
+		WireGuardAdvancedSecurityOptions: options.WireGuardAdvancedSecurityOptions,
+	})
+	if err != nil {
+		return nil, err
+	}
+	ep.endpoint = wgEndpoint
+	return ep, nil
+}
+
+func (w *Endpoint) Start(stage adapter.StartStage) error {
+	switch stage {
+	case adapter.StartStateStart:
+		return w.endpoint.Start(false)
+	case adapter.StartStatePostStart:
+		return w.endpoint.Start(true)
+	}
+	return nil
+}
+
+func (w *Endpoint) Close() error {
+	return w.endpoint.Close()
+}
+
+func (w *Endpoint) InterfaceUpdated() {
+	w.endpoint.BindUpdate()
+	return
+}
+
+func (w *Endpoint) PrepareConnection(network string, source M.Socksaddr, destination M.Socksaddr) error {
+	return w.router.PreMatch(adapter.InboundContext{
+		Inbound:     w.Tag(),
+		InboundType: w.Type(),
+		Network:     network,
+		Source:      source,
+		Destination: destination,
+	})
+}
+
+func (w *Endpoint) NewConnectionEx(ctx context.Context, conn net.Conn, source M.Socksaddr, destination M.Socksaddr, onClose N.CloseHandlerFunc) {
+	var metadata adapter.InboundContext
+	metadata.Inbound = w.Tag()
+	metadata.InboundType = w.Type()
+	metadata.Source = source
+	for _, localPrefix := range w.localAddresses {
+		if localPrefix.Contains(destination.Addr) {
+			metadata.OriginDestination = destination
+			if destination.Addr.Is4() {
+				destination.Addr = netip.AddrFrom4([4]uint8{127, 0, 0, 1})
+			} else {
+				destination.Addr = netip.IPv6Loopback()
+			}
+			break
+		}
+	}
+	metadata.Destination = destination
+	w.logger.InfoContext(ctx, "inbound connection from ", source)
+	w.logger.InfoContext(ctx, "inbound connection to ", metadata.Destination)
+	w.router.RouteConnectionEx(ctx, conn, metadata, onClose)
+}
+
+func (w *Endpoint) NewPacketConnectionEx(ctx context.Context, conn N.PacketConn, source M.Socksaddr, destination M.Socksaddr, onClose N.CloseHandlerFunc) {
+	var metadata adapter.InboundContext
+	metadata.Inbound = w.Tag()
+	metadata.InboundType = w.Type()
+	metadata.Source = source
+	metadata.Destination = destination
+	for _, localPrefix := range w.localAddresses {
+		if localPrefix.Contains(destination.Addr) {
+			metadata.OriginDestination = destination
+			if destination.Addr.Is4() {
+				metadata.Destination.Addr = netip.AddrFrom4([4]uint8{127, 0, 0, 1})
+			} else {
+				metadata.Destination.Addr = netip.IPv6Loopback()
+			}
+			conn = bufio.NewNATPacketConn(bufio.NewNetPacketConn(conn), metadata.OriginDestination, metadata.Destination)
+		}
+	}
+	w.logger.InfoContext(ctx, "inbound packet connection from ", source)
+	w.logger.InfoContext(ctx, "inbound packet connection to ", destination)
+	w.router.RoutePacketConnectionEx(ctx, conn, metadata, onClose)
+}
+
+func (w *Endpoint) DialContext(ctx context.Context, network string, destination M.Socksaddr) (net.Conn, error) {
+	switch network {
+	case N.NetworkTCP:
+		w.logger.InfoContext(ctx, "outbound connection to ", destination)
+	case N.NetworkUDP:
+		w.logger.InfoContext(ctx, "outbound packet connection to ", destination)
+	}
+	if destination.IsFqdn() {
+		destinationAddresses, err := w.router.LookupDefault(ctx, destination.Fqdn)
+		if err != nil {
+			return nil, err
+		}
+		return N.DialSerial(ctx, w.endpoint, network, destination, destinationAddresses)
+	} else if !destination.Addr.IsValid() {
+		return nil, E.New("invalid destination: ", destination)
+	}
+	return w.endpoint.DialContext(ctx, network, destination)
+}
+
+func (w *Endpoint) ListenPacket(ctx context.Context, destination M.Socksaddr) (net.PacketConn, error) {
+	w.logger.InfoContext(ctx, "outbound packet connection to ", destination)
+	if destination.IsFqdn() {
+		destinationAddresses, err := w.router.LookupDefault(ctx, destination.Fqdn)
+		if err != nil {
+			return nil, err
+		}
+		packetConn, _, err := N.ListenSerial(ctx, w.endpoint, destination, destinationAddresses)
+		if err != nil {
+			return nil, err
+		}
+		return packetConn, err
+	}
+	return w.endpoint.ListenPacket(ctx, destination)
+}

--- a/protocol/amnezia/endpoint.go
+++ b/protocol/amnezia/endpoint.go
@@ -98,7 +98,7 @@ func NewEndpoint(ctx context.Context, router adapter.Router, logger log.ContextL
 			}
 		}),
 		Workers:                          options.Workers,
-		WireGuardAdvancedSecurityOptions: options.WireGuardAdvancedSecurityOptions,
+		WireGuardAdvancedSecurityOptions: options.WireGuardAdvancedSecurityOptions, /**  ADDED FOR AMNEZIA  **/
 	})
 	if err != nil {
 		return nil, err

--- a/protocol/amnezia/outbound.go
+++ b/protocol/amnezia/outbound.go
@@ -1,0 +1,185 @@
+// Package amnezia implements the AmneziaWG dialer outbound.
+/*
+To activate advanced security mode for WireGuard (powered by AmneziaWG), please add the following fields to the configuration:
+
+{
+  ...
+  "private_key": "....",
+  "jc": 0, // JunkPacketCount
+  "jmin": 0, // JunkPacketMinSize
+  "jmax":  0, // JunkPacketMaxSize
+  "s1": 0, // InitPacketJunkSize
+  "s2":  0, // ResponsePacketJunkSize
+  "h1": 0, // InitPacketMagicHeader
+  "h2":  0, // ResponsePacketMagicHeader
+  "h3": 0, // UnderloadPacketMagicHeader
+  "h4":  0, // TransportPacketMagicHeader
+}
+
+Setting any of these values with a non-zero value will activate the corresponding security feature. If neither of these values is set, the default WireGuard security will be used.
+*/
+package amnezia
+
+import (
+	"context"
+	"net"
+	"net/netip"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/adapter/outbound"
+	"github.com/sagernet/sing-box/common/dialer"
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/experimental/deprecated"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing-box/transport/wireguard"
+	"github.com/sagernet/sing-dns"
+	"github.com/sagernet/sing/common"
+	E "github.com/sagernet/sing/common/exceptions"
+	"github.com/sagernet/sing/common/logger"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+)
+
+func RegisterOutbound(registry *outbound.Registry) {
+	outbound.Register[option.LegacyWireGuardOutboundOptions](registry, C.TypeWireGuard, NewOutbound)
+}
+
+var (
+	_ adapter.Endpoint                = (*Endpoint)(nil)
+	_ adapter.InterfaceUpdateListener = (*Endpoint)(nil)
+)
+
+type Outbound struct {
+	outbound.Adapter
+	ctx            context.Context
+	router         adapter.Router
+	logger         logger.ContextLogger
+	localAddresses []netip.Prefix
+	endpoint       *wireguard.Endpoint
+}
+
+func NewOutbound(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, options option.LegacyWireGuardOutboundOptions) (adapter.Outbound, error) {
+	deprecated.Report(ctx, deprecated.OptionWireGuardOutbound)
+	if options.GSO {
+		deprecated.Report(ctx, deprecated.OptionWireGuardGSO)
+	}
+	outbound := &Outbound{
+		Adapter:        outbound.NewAdapterWithDialerOptions(C.TypeWireGuard, tag, []string{N.NetworkTCP, N.NetworkUDP}, options.DialerOptions),
+		ctx:            ctx,
+		router:         router,
+		logger:         logger,
+		localAddresses: options.LocalAddress,
+	}
+	if options.Detour == "" {
+		options.IsWireGuardListener = true
+	} else if options.GSO {
+		return nil, E.New("gso is conflict with detour")
+	}
+	outboundDialer, err := dialer.New(ctx, options.DialerOptions)
+	if err != nil {
+		return nil, err
+	}
+	peers := common.Map(options.Peers, func(it option.LegacyWireGuardPeer) wireguard.PeerOptions {
+		return wireguard.PeerOptions{
+			Endpoint:     it.ServerOptions.Build(),
+			PublicKey:    it.PublicKey,
+			PreSharedKey: it.PreSharedKey,
+			AllowedIPs:   it.AllowedIPs,
+			// PersistentKeepaliveInterval: time.Duration(it.PersistentKeepaliveInterval),
+			Reserved: it.Reserved,
+		}
+	})
+	if len(peers) == 0 {
+		peers = []wireguard.PeerOptions{{
+			Endpoint:     options.ServerOptions.Build(),
+			PublicKey:    options.PeerPublicKey,
+			PreSharedKey: options.PreSharedKey,
+			AllowedIPs:   []netip.Prefix{netip.PrefixFrom(netip.IPv4Unspecified(), 0), netip.PrefixFrom(netip.IPv6Unspecified(), 0)},
+			Reserved:     options.Reserved,
+		}}
+	}
+	wgEndpoint, err := wireguard.NewEndpoint(wireguard.EndpointOptions{
+		Context: ctx,
+		Logger:  logger,
+		System:  options.SystemInterface,
+		Dialer:  outboundDialer,
+		CreateDialer: func(interfaceName string) N.Dialer {
+			return common.Must1(dialer.NewDefault(ctx, option.DialerOptions{
+				BindInterface: interfaceName,
+			}))
+		},
+		Name:       options.InterfaceName,
+		MTU:        options.MTU,
+		Address:    options.LocalAddress,
+		PrivateKey: options.PrivateKey,
+		ResolvePeer: func(domain string) (netip.Addr, error) {
+			endpointAddresses, lookupErr := router.Lookup(ctx, domain, dns.DomainStrategy(options.DomainStrategy))
+			if lookupErr != nil {
+				return netip.Addr{}, lookupErr
+			}
+			return endpointAddresses[0], nil
+		},
+		Peers:   peers,
+		Workers: options.Workers,
+	})
+	if err != nil {
+		return nil, err
+	}
+	outbound.endpoint = wgEndpoint
+	return outbound, nil
+}
+
+func (o *Outbound) Start(stage adapter.StartStage) error {
+	switch stage {
+	case adapter.StartStateStart:
+		return o.endpoint.Start(false)
+	case adapter.StartStatePostStart:
+		return o.endpoint.Start(true)
+	}
+	return nil
+}
+
+func (o *Outbound) Close() error {
+	return o.endpoint.Close()
+}
+
+func (o *Outbound) InterfaceUpdated() {
+	o.endpoint.BindUpdate()
+	return
+}
+
+func (o *Outbound) DialContext(ctx context.Context, network string, destination M.Socksaddr) (net.Conn, error) {
+	switch network {
+	case N.NetworkTCP:
+		o.logger.InfoContext(ctx, "outbound connection to ", destination)
+	case N.NetworkUDP:
+		o.logger.InfoContext(ctx, "outbound packet connection to ", destination)
+	}
+	if destination.IsFqdn() {
+		destinationAddresses, err := o.router.LookupDefault(ctx, destination.Fqdn)
+		if err != nil {
+			return nil, err
+		}
+		return N.DialSerial(ctx, o.endpoint, network, destination, destinationAddresses)
+	} else if !destination.Addr.IsValid() {
+		return nil, E.New("invalid destination: ", destination)
+	}
+	return o.endpoint.DialContext(ctx, network, destination)
+}
+
+func (o *Outbound) ListenPacket(ctx context.Context, destination M.Socksaddr) (net.PacketConn, error) {
+	o.logger.InfoContext(ctx, "outbound packet connection to ", destination)
+	if destination.IsFqdn() {
+		destinationAddresses, err := o.router.LookupDefault(ctx, destination.Fqdn)
+		if err != nil {
+			return nil, err
+		}
+		packetConn, _, err := N.ListenSerial(ctx, o.endpoint, destination, destinationAddresses)
+		if err != nil {
+			return nil, err
+		}
+		return packetConn, err
+	}
+	return o.endpoint.ListenPacket(ctx, destination)
+}

--- a/protocol/register.go
+++ b/protocol/register.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"github.com/getlantern/radiance/protocol/amnezia"
 	"github.com/sagernet/sing-box/adapter/endpoint"
 	"github.com/sagernet/sing-box/adapter/inbound"
 	"github.com/sagernet/sing-box/adapter/outbound"
@@ -32,6 +33,9 @@ func registerInbounds(registry *inbound.Registry) {
 func registerOutbounds(registry *outbound.Registry) {
 	algeneva.RegisterOutbound(registry)
 	outline.RegisterOutbound(registry)
+	amnezia.RegisterOutbound(registry)
 }
 
-func registerEndpoints(registry *endpoint.Registry) {}
+func registerEndpoints(registry *endpoint.Registry) {
+	amnezia.RegisterEndpoint(registry)
+}

--- a/transport/amnezia/client_bind.go
+++ b/transport/amnezia/client_bind.go
@@ -1,0 +1,259 @@
+package amnezia
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"sync"
+	"time"
+
+	"github.com/sagernet/sing/common"
+	"github.com/sagernet/sing/common/bufio"
+	E "github.com/sagernet/sing/common/exceptions"
+	"github.com/sagernet/sing/common/logger"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+	"github.com/sagernet/sing/service"
+	"github.com/sagernet/sing/service/pause"
+	"github.com/sagernet/wireguard-go/conn"
+)
+
+var _ conn.Bind = (*ClientBind)(nil)
+
+type ClientBind struct {
+	ctx                 context.Context
+	logger              logger.Logger
+	pauseManager        pause.Manager
+	bindCtx             context.Context
+	bindDone            context.CancelFunc
+	dialer              N.Dialer
+	reservedForEndpoint map[netip.AddrPort][3]uint8
+	connAccess          sync.Mutex
+	conn                *wireConn
+	done                chan struct{}
+	isConnect           bool
+	connectAddr         netip.AddrPort
+	reserved            [3]uint8
+}
+
+func NewClientBind(ctx context.Context, logger logger.Logger, dialer N.Dialer, isConnect bool, connectAddr netip.AddrPort, reserved [3]uint8) *ClientBind {
+	return &ClientBind{
+		ctx:                 ctx,
+		logger:              logger,
+		pauseManager:        service.FromContext[pause.Manager](ctx),
+		dialer:              dialer,
+		reservedForEndpoint: make(map[netip.AddrPort][3]uint8),
+		done:                make(chan struct{}),
+		isConnect:           isConnect,
+		connectAddr:         connectAddr,
+		reserved:            reserved,
+	}
+}
+
+func (c *ClientBind) connect() (*wireConn, error) {
+	serverConn := c.conn
+	if serverConn != nil {
+		select {
+		case <-serverConn.done:
+			serverConn = nil
+		default:
+			return serverConn, nil
+		}
+	}
+	c.connAccess.Lock()
+	defer c.connAccess.Unlock()
+	select {
+	case <-c.done:
+		return nil, net.ErrClosed
+	default:
+	}
+	serverConn = c.conn
+	if serverConn != nil {
+		select {
+		case <-serverConn.done:
+			serverConn = nil
+		default:
+			return serverConn, nil
+		}
+	}
+	if c.isConnect {
+		udpConn, err := c.dialer.DialContext(c.bindCtx, N.NetworkUDP, M.SocksaddrFromNetIP(c.connectAddr))
+		if err != nil {
+			return nil, err
+		}
+		c.conn = &wireConn{
+			PacketConn: bufio.NewUnbindPacketConn(udpConn),
+			done:       make(chan struct{}),
+		}
+	} else {
+		udpConn, err := c.dialer.ListenPacket(c.bindCtx, M.Socksaddr{Addr: netip.IPv4Unspecified()})
+		if err != nil {
+			return nil, err
+		}
+		c.conn = &wireConn{
+			PacketConn: bufio.NewPacketConn(udpConn),
+			done:       make(chan struct{}),
+		}
+	}
+	return c.conn, nil
+}
+
+func (c *ClientBind) Open(port uint16) (fns []conn.ReceiveFunc, actualPort uint16, err error) {
+	select {
+	case <-c.done:
+		c.done = make(chan struct{})
+	default:
+	}
+	c.bindCtx, c.bindDone = context.WithCancel(c.ctx)
+	return []conn.ReceiveFunc{c.receive}, 0, nil
+}
+
+func (c *ClientBind) receive(packets [][]byte, sizes []int, eps []conn.Endpoint) (count int, err error) {
+	udpConn, err := c.connect()
+	if err != nil {
+		select {
+		case <-c.done:
+			return
+		default:
+		}
+		c.logger.Error(E.Cause(err, "connect to server"))
+		err = nil
+		c.pauseManager.WaitActive()
+		time.Sleep(time.Second)
+		return
+	}
+	n, addr, err := udpConn.ReadFrom(packets[0])
+	if err != nil {
+		udpConn.Close()
+		select {
+		case <-c.done:
+		default:
+			c.logger.Error(E.Cause(err, "read packet"))
+			err = nil
+		}
+		return
+	}
+	sizes[0] = n
+	if n > 3 {
+		b := packets[0]
+		common.ClearArray(b[1:4])
+	}
+	eps[0] = remoteEndpoint(M.AddrPortFromNet(addr))
+	count = 1
+	return
+}
+
+func (c *ClientBind) Close() error {
+	select {
+	case <-c.done:
+	default:
+		close(c.done)
+	}
+	if c.bindDone != nil {
+		c.bindDone()
+	}
+	c.connAccess.Lock()
+	defer c.connAccess.Unlock()
+	common.Close(common.PtrOrNil(c.conn))
+	return nil
+}
+
+func (c *ClientBind) SetMark(mark uint32) error {
+	return nil
+}
+
+func (c *ClientBind) Send(bufs [][]byte, ep conn.Endpoint) error {
+	udpConn, err := c.connect()
+	if err != nil {
+		c.pauseManager.WaitActive()
+		time.Sleep(time.Second)
+		return err
+	}
+	destination := netip.AddrPort(ep.(remoteEndpoint))
+	for _, b := range bufs {
+		if len(b) > 3 {
+			reserved, loaded := c.reservedForEndpoint[destination]
+			if !loaded {
+				reserved = c.reserved
+			}
+			copy(b[1:4], reserved[:])
+		}
+		_, err = udpConn.WriteToUDPAddrPort(b, destination)
+		if err != nil {
+			udpConn.Close()
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *ClientBind) ParseEndpoint(s string) (conn.Endpoint, error) {
+	ap, err := netip.ParseAddrPort(s)
+	if err != nil {
+		return nil, err
+	}
+	return remoteEndpoint(ap), nil
+}
+
+func (c *ClientBind) BatchSize() int {
+	return 1
+}
+
+func (c *ClientBind) SetReservedForEndpoint(destination netip.AddrPort, reserved [3]byte) {
+	c.reservedForEndpoint[destination] = reserved
+}
+
+type wireConn struct {
+	net.PacketConn
+	conn   net.Conn
+	access sync.Mutex
+	done   chan struct{}
+}
+
+func (w *wireConn) WriteToUDPAddrPort(b []byte, addr netip.AddrPort) (int, error) {
+	if w.conn != nil {
+		return w.conn.Write(b)
+	}
+	return w.PacketConn.WriteTo(b, M.SocksaddrFromNetIP(addr).UDPAddr())
+}
+
+func (w *wireConn) Close() error {
+	w.access.Lock()
+	defer w.access.Unlock()
+	select {
+	case <-w.done:
+		return net.ErrClosed
+	default:
+	}
+	w.PacketConn.Close()
+	close(w.done)
+	return nil
+}
+
+var _ conn.Endpoint = (*remoteEndpoint)(nil)
+
+type remoteEndpoint netip.AddrPort
+
+func (e remoteEndpoint) ClearSrc() {
+}
+
+func (e remoteEndpoint) SrcToString() string {
+	return ""
+}
+
+func (e remoteEndpoint) DstToString() string {
+	return (netip.AddrPort)(e).String()
+}
+
+func (e remoteEndpoint) DstToBytes() []byte {
+	b, _ := (netip.AddrPort)(e).MarshalBinary()
+	return b
+}
+
+func (e remoteEndpoint) DstIP() netip.Addr {
+	return (netip.AddrPort)(e).Addr()
+}
+
+func (e remoteEndpoint) SrcIP() netip.Addr {
+	return netip.Addr{}
+}

--- a/transport/amnezia/device.go
+++ b/transport/amnezia/device.go
@@ -1,0 +1,43 @@
+package amnezia
+
+import (
+	"context"
+	"net/netip"
+	"time"
+
+	"github.com/sagernet/sing-tun"
+	"github.com/sagernet/sing/common/logger"
+	N "github.com/sagernet/sing/common/network"
+	"github.com/sagernet/wireguard-go/device"
+	wgTun "github.com/sagernet/wireguard-go/tun"
+)
+
+type Device interface {
+	wgTun.Device
+	N.Dialer
+	Start() error
+	SetDevice(device *device.Device)
+}
+
+type DeviceOptions struct {
+	Context        context.Context
+	Logger         logger.ContextLogger
+	System         bool
+	Handler        tun.Handler
+	UDPTimeout     time.Duration
+	CreateDialer   func(interfaceName string) N.Dialer
+	Name           string
+	MTU            uint32
+	Address        []netip.Prefix
+	AllowedAddress []netip.Prefix
+}
+
+func NewDevice(options DeviceOptions) (Device, error) {
+	if !options.System {
+		return newStackDevice(options)
+	} else if options.Handler == nil {
+		return newSystemDevice(options)
+	} else {
+		return newSystemStackDevice(options)
+	}
+}

--- a/transport/amnezia/device_stack.go
+++ b/transport/amnezia/device_stack.go
@@ -1,0 +1,284 @@
+//go:build with_gvisor
+
+package amnezia
+
+import (
+	"context"
+	"net"
+	"os"
+
+	"github.com/sagernet/gvisor/pkg/buffer"
+	"github.com/sagernet/gvisor/pkg/tcpip"
+	"github.com/sagernet/gvisor/pkg/tcpip/adapters/gonet"
+	"github.com/sagernet/gvisor/pkg/tcpip/header"
+	"github.com/sagernet/gvisor/pkg/tcpip/network/ipv4"
+	"github.com/sagernet/gvisor/pkg/tcpip/network/ipv6"
+	"github.com/sagernet/gvisor/pkg/tcpip/stack"
+	"github.com/sagernet/gvisor/pkg/tcpip/transport/tcp"
+	"github.com/sagernet/gvisor/pkg/tcpip/transport/udp"
+	"github.com/sagernet/sing-tun"
+	E "github.com/sagernet/sing/common/exceptions"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+	"github.com/sagernet/wireguard-go/device"
+	wgTun "github.com/sagernet/wireguard-go/tun"
+)
+
+var _ Device = (*stackDevice)(nil)
+
+type stackDevice struct {
+	stack      *stack.Stack
+	mtu        uint32
+	events     chan wgTun.Event
+	outbound   chan *stack.PacketBuffer
+	done       chan struct{}
+	dispatcher stack.NetworkDispatcher
+	addr4      tcpip.Address
+	addr6      tcpip.Address
+}
+
+func newStackDevice(options DeviceOptions) (*stackDevice, error) {
+	tunDevice := &stackDevice{
+		mtu:      options.MTU,
+		events:   make(chan wgTun.Event, 1),
+		outbound: make(chan *stack.PacketBuffer, 256),
+		done:     make(chan struct{}),
+	}
+	ipStack, err := tun.NewGVisorStack((*wireEndpoint)(tunDevice))
+	if err != nil {
+		return nil, err
+	}
+	for _, prefix := range options.Address {
+		addr := tun.AddressFromAddr(prefix.Addr())
+		protoAddr := tcpip.ProtocolAddress{
+			AddressWithPrefix: tcpip.AddressWithPrefix{
+				Address:   addr,
+				PrefixLen: prefix.Bits(),
+			},
+		}
+		if prefix.Addr().Is4() {
+			tunDevice.addr4 = addr
+			protoAddr.Protocol = ipv4.ProtocolNumber
+		} else {
+			tunDevice.addr6 = addr
+			protoAddr.Protocol = ipv6.ProtocolNumber
+		}
+		gErr := ipStack.AddProtocolAddress(tun.DefaultNIC, protoAddr, stack.AddressProperties{})
+		if gErr != nil {
+			return nil, E.New("parse local address ", protoAddr.AddressWithPrefix, ": ", gErr.String())
+		}
+	}
+	tunDevice.stack = ipStack
+	if options.Handler != nil {
+		ipStack.SetTransportProtocolHandler(tcp.ProtocolNumber, tun.NewTCPForwarder(options.Context, ipStack, options.Handler).HandlePacket)
+		ipStack.SetTransportProtocolHandler(udp.ProtocolNumber, tun.NewUDPForwarder(options.Context, ipStack, options.Handler, options.UDPTimeout).HandlePacket)
+	}
+	return tunDevice, nil
+}
+
+func (w *stackDevice) DialContext(ctx context.Context, network string, destination M.Socksaddr) (net.Conn, error) {
+	addr := tcpip.FullAddress{
+		NIC:  tun.DefaultNIC,
+		Port: destination.Port,
+		Addr: tun.AddressFromAddr(destination.Addr),
+	}
+	bind := tcpip.FullAddress{
+		NIC: tun.DefaultNIC,
+	}
+	var networkProtocol tcpip.NetworkProtocolNumber
+	if destination.IsIPv4() {
+		networkProtocol = header.IPv4ProtocolNumber
+		bind.Addr = w.addr4
+	} else {
+		networkProtocol = header.IPv6ProtocolNumber
+		bind.Addr = w.addr6
+	}
+	switch N.NetworkName(network) {
+	case N.NetworkTCP:
+		tcpConn, err := DialTCPWithBind(ctx, w.stack, bind, addr, networkProtocol)
+		if err != nil {
+			return nil, err
+		}
+		return tcpConn, nil
+	case N.NetworkUDP:
+		udpConn, err := gonet.DialUDP(w.stack, &bind, &addr, networkProtocol)
+		if err != nil {
+			return nil, err
+		}
+		return udpConn, nil
+	default:
+		return nil, E.Extend(N.ErrUnknownNetwork, network)
+	}
+}
+
+func (w *stackDevice) ListenPacket(ctx context.Context, destination M.Socksaddr) (net.PacketConn, error) {
+	bind := tcpip.FullAddress{
+		NIC: tun.DefaultNIC,
+	}
+	var networkProtocol tcpip.NetworkProtocolNumber
+	if destination.IsIPv4() {
+		networkProtocol = header.IPv4ProtocolNumber
+		bind.Addr = w.addr4
+	} else {
+		networkProtocol = header.IPv6ProtocolNumber
+		bind.Addr = w.addr6
+	}
+	udpConn, err := gonet.DialUDP(w.stack, &bind, nil, networkProtocol)
+	if err != nil {
+		return nil, err
+	}
+	return udpConn, nil
+}
+
+func (w *stackDevice) SetDevice(device *device.Device) {
+}
+
+func (w *stackDevice) Start() error {
+	w.events <- wgTun.EventUp
+	return nil
+}
+
+func (w *stackDevice) File() *os.File {
+	return nil
+}
+
+func (w *stackDevice) Read(bufs [][]byte, sizes []int, offset int) (count int, err error) {
+	select {
+	case packetBuffer, ok := <-w.outbound:
+		if !ok {
+			return 0, os.ErrClosed
+		}
+		defer packetBuffer.DecRef()
+		p := bufs[0]
+		p = p[offset:]
+		n := 0
+		for _, slice := range packetBuffer.AsSlices() {
+			n += copy(p[n:], slice)
+		}
+		sizes[0] = n
+		count = 1
+		return
+	case <-w.done:
+		return 0, os.ErrClosed
+	}
+}
+
+func (w *stackDevice) Write(bufs [][]byte, offset int) (count int, err error) {
+	for _, b := range bufs {
+		b = b[offset:]
+		if len(b) == 0 {
+			continue
+		}
+		var networkProtocol tcpip.NetworkProtocolNumber
+		switch header.IPVersion(b) {
+		case header.IPv4Version:
+			networkProtocol = header.IPv4ProtocolNumber
+		case header.IPv6Version:
+			networkProtocol = header.IPv6ProtocolNumber
+		}
+		packetBuffer := stack.NewPacketBuffer(stack.PacketBufferOptions{
+			Payload: buffer.MakeWithData(b),
+		})
+		w.dispatcher.DeliverNetworkPacket(networkProtocol, packetBuffer)
+		packetBuffer.DecRef()
+		count++
+	}
+	return
+}
+
+func (w *stackDevice) Flush() error {
+	return nil
+}
+
+func (w *stackDevice) MTU() (int, error) {
+	return int(w.mtu), nil
+}
+
+func (w *stackDevice) Name() (string, error) {
+	return "sing-box", nil
+}
+
+func (w *stackDevice) Events() <-chan wgTun.Event {
+	return w.events
+}
+
+func (w *stackDevice) Close() error {
+	close(w.done)
+	close(w.events)
+	w.stack.Close()
+	for _, endpoint := range w.stack.CleanupEndpoints() {
+		endpoint.Abort()
+	}
+	w.stack.Wait()
+	return nil
+}
+
+func (w *stackDevice) BatchSize() int {
+	return 1
+}
+
+var _ stack.LinkEndpoint = (*wireEndpoint)(nil)
+
+type wireEndpoint stackDevice
+
+func (ep *wireEndpoint) MTU() uint32 {
+	return ep.mtu
+}
+
+func (ep *wireEndpoint) SetMTU(mtu uint32) {
+}
+
+func (ep *wireEndpoint) MaxHeaderLength() uint16 {
+	return 0
+}
+
+func (ep *wireEndpoint) LinkAddress() tcpip.LinkAddress {
+	return ""
+}
+
+func (ep *wireEndpoint) SetLinkAddress(addr tcpip.LinkAddress) {
+}
+
+func (ep *wireEndpoint) Capabilities() stack.LinkEndpointCapabilities {
+	return stack.CapabilityRXChecksumOffload
+}
+
+func (ep *wireEndpoint) Attach(dispatcher stack.NetworkDispatcher) {
+	ep.dispatcher = dispatcher
+}
+
+func (ep *wireEndpoint) IsAttached() bool {
+	return ep.dispatcher != nil
+}
+
+func (ep *wireEndpoint) Wait() {
+}
+
+func (ep *wireEndpoint) ARPHardwareType() header.ARPHardwareType {
+	return header.ARPHardwareNone
+}
+
+func (ep *wireEndpoint) AddHeader(buffer *stack.PacketBuffer) {
+}
+
+func (ep *wireEndpoint) ParseHeader(ptr *stack.PacketBuffer) bool {
+	return true
+}
+
+func (ep *wireEndpoint) WritePackets(list stack.PacketBufferList) (int, tcpip.Error) {
+	for _, packetBuffer := range list.AsSlice() {
+		packetBuffer.IncRef()
+		select {
+		case <-ep.done:
+			return 0, &tcpip.ErrClosedForSend{}
+		case ep.outbound <- packetBuffer:
+		}
+	}
+	return list.Len(), nil
+}
+
+func (ep *wireEndpoint) Close() {
+}
+
+func (ep *wireEndpoint) SetOnCloseAction(f func()) {
+}

--- a/transport/amnezia/device_stack_gonet.go
+++ b/transport/amnezia/device_stack_gonet.go
@@ -1,0 +1,79 @@
+//go:build with_gvisor
+
+package amnezia
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"time"
+
+	"github.com/sagernet/gvisor/pkg/tcpip"
+	"github.com/sagernet/gvisor/pkg/tcpip/adapters/gonet"
+	"github.com/sagernet/gvisor/pkg/tcpip/stack"
+	"github.com/sagernet/gvisor/pkg/tcpip/transport/tcp"
+	"github.com/sagernet/gvisor/pkg/waiter"
+	"github.com/sagernet/sing-tun"
+	M "github.com/sagernet/sing/common/metadata"
+)
+
+func DialTCPWithBind(ctx context.Context, s *stack.Stack, localAddr, remoteAddr tcpip.FullAddress, network tcpip.NetworkProtocolNumber) (*gonet.TCPConn, error) {
+	// Create TCP endpoint, then connect.
+	var wq waiter.Queue
+	ep, err := s.NewEndpoint(tcp.ProtocolNumber, network, &wq)
+	if err != nil {
+		return nil, errors.New(err.String())
+	}
+
+	// Create wait queue entry that notifies a channel.
+	//
+	// We do this unconditionally as Connect will always return an error.
+	waitEntry, notifyCh := waiter.NewChannelEntry(waiter.WritableEvents)
+	wq.EventRegister(&waitEntry)
+	defer wq.EventUnregister(&waitEntry)
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
+	// Bind before connect if requested.
+	if localAddr != (tcpip.FullAddress{}) {
+		if err = ep.Bind(localAddr); err != nil {
+			return nil, fmt.Errorf("ep.Bind(%+v) = %s", localAddr, err)
+		}
+	}
+
+	err = ep.Connect(remoteAddr)
+	if _, ok := err.(*tcpip.ErrConnectStarted); ok {
+		select {
+		case <-ctx.Done():
+			ep.Close()
+			return nil, ctx.Err()
+		case <-notifyCh:
+		}
+
+		err = ep.LastError()
+	}
+	if err != nil {
+		ep.Close()
+		return nil, &net.OpError{
+			Op:   "connect",
+			Net:  "tcp",
+			Addr: M.SocksaddrFromNetIP(netip.AddrPortFrom(tun.AddrFromAddress(remoteAddr.Addr), remoteAddr.Port)).TCPAddr(),
+			Err:  errors.New(err.String()),
+		}
+	}
+
+	// sing-box added: set keepalive
+	ep.SocketOptions().SetKeepAlive(true)
+	keepAliveIdle := tcpip.KeepaliveIdleOption(15 * time.Second)
+	ep.SetSockOpt(&keepAliveIdle)
+	keepAliveInterval := tcpip.KeepaliveIntervalOption(15 * time.Second)
+	ep.SetSockOpt(&keepAliveInterval)
+
+	return gonet.NewTCPConn(&wq, ep), nil
+}

--- a/transport/amnezia/device_stack_stub.go
+++ b/transport/amnezia/device_stack_stub.go
@@ -1,0 +1,13 @@
+//go:build !with_gvisor
+
+package amnezia
+
+import "github.com/sagernet/sing-tun"
+
+func newStackDevice(options DeviceOptions) (Device, error) {
+	return nil, tun.ErrGVisorNotIncluded
+}
+
+func newSystemStackDevice(options DeviceOptions) (Device, error) {
+	return nil, tun.ErrGVisorNotIncluded
+}

--- a/transport/amnezia/device_system.go
+++ b/transport/amnezia/device_system.go
@@ -1,0 +1,161 @@
+package amnezia
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"os"
+	"runtime"
+	"sync"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-tun"
+	"github.com/sagernet/sing/common"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+	"github.com/sagernet/sing/service"
+	"github.com/sagernet/wireguard-go/device"
+	wgTun "github.com/sagernet/wireguard-go/tun"
+)
+
+var _ Device = (*systemDevice)(nil)
+
+type systemDevice struct {
+	options     DeviceOptions
+	dialer      N.Dialer
+	device      tun.Tun
+	batchDevice tun.LinuxTUN
+	events      chan wgTun.Event
+	closeOnce   sync.Once
+}
+
+func newSystemDevice(options DeviceOptions) (*systemDevice, error) {
+	if options.Name == "" {
+		options.Name = tun.CalculateInterfaceName("wg")
+	}
+	return &systemDevice{
+		options: options,
+		dialer:  options.CreateDialer(options.Name),
+		events:  make(chan wgTun.Event, 1),
+	}, nil
+}
+
+func (w *systemDevice) DialContext(ctx context.Context, network string, destination M.Socksaddr) (net.Conn, error) {
+	return w.dialer.DialContext(ctx, network, destination)
+}
+
+func (w *systemDevice) ListenPacket(ctx context.Context, destination M.Socksaddr) (net.PacketConn, error) {
+	return w.dialer.ListenPacket(ctx, destination)
+}
+
+func (w *systemDevice) SetDevice(device *device.Device) {
+}
+
+func (w *systemDevice) Start() error {
+	networkManager := service.FromContext[adapter.NetworkManager](w.options.Context)
+	tunOptions := tun.Options{
+		Name: w.options.Name,
+		Inet4Address: common.Filter(w.options.Address, func(it netip.Prefix) bool {
+			return it.Addr().Is4()
+		}),
+		Inet6Address: common.Filter(w.options.Address, func(it netip.Prefix) bool {
+			return it.Addr().Is6()
+		}),
+		MTU:            w.options.MTU,
+		GSO:            true,
+		InterfaceScope: true,
+		Inet4RouteAddress: common.Filter(w.options.AllowedAddress, func(it netip.Prefix) bool {
+			return it.Addr().Is4()
+		}),
+		Inet6RouteAddress: common.Filter(w.options.AllowedAddress, func(it netip.Prefix) bool { return it.Addr().Is6() }),
+		InterfaceMonitor:  networkManager.InterfaceMonitor(),
+		InterfaceFinder:   networkManager.InterfaceFinder(),
+		Logger:            w.options.Logger,
+	}
+	// works with Linux, macOS with IFSCOPE routes, not tested on Windows
+	if runtime.GOOS == "darwin" {
+		tunOptions.AutoRoute = true
+	}
+	tunInterface, err := tun.New(tunOptions)
+	if err != nil {
+		return err
+	}
+	err = tunInterface.Start()
+	if err != nil {
+		return err
+	}
+	w.options.Logger.Info("started at ", w.options.Name)
+	w.device = tunInterface
+	batchTUN, isBatchTUN := tunInterface.(tun.LinuxTUN)
+	if isBatchTUN {
+		w.batchDevice = batchTUN
+	}
+	w.events <- wgTun.EventUp
+	return nil
+}
+
+func (w *systemDevice) File() *os.File {
+	return nil
+}
+
+func (w *systemDevice) Read(bufs [][]byte, sizes []int, offset int) (count int, err error) {
+	if w.batchDevice != nil {
+		count, err = w.batchDevice.BatchRead(bufs, offset-tun.PacketOffset, sizes)
+	} else {
+		sizes[0], err = w.device.Read(bufs[0][offset-tun.PacketOffset:])
+		if err == nil {
+			count = 1
+		} else if errors.Is(err, tun.ErrTooManySegments) {
+			err = wgTun.ErrTooManySegments
+		}
+	}
+	return
+}
+
+func (w *systemDevice) Write(bufs [][]byte, offset int) (count int, err error) {
+	if w.batchDevice != nil {
+		return w.batchDevice.BatchWrite(bufs, offset)
+	} else {
+		for _, packet := range bufs {
+			if tun.PacketOffset > 0 {
+				common.ClearArray(packet[offset-tun.PacketOffset : offset])
+				tun.PacketFillHeader(packet[offset-tun.PacketOffset:], tun.PacketIPVersion(packet[offset:]))
+			}
+			_, err = w.device.Write(packet[offset-tun.PacketOffset:])
+			if err != nil {
+				return
+			}
+		}
+	}
+	// WireGuard will not read count
+	return
+}
+
+func (w *systemDevice) Flush() error {
+	return nil
+}
+
+func (w *systemDevice) MTU() (int, error) {
+	return int(w.options.MTU), nil
+}
+
+func (w *systemDevice) Name() (string, error) {
+	return w.options.Name, nil
+}
+
+func (w *systemDevice) Events() <-chan wgTun.Event {
+	return w.events
+}
+
+func (w *systemDevice) Close() error {
+	close(w.events)
+	return w.device.Close()
+}
+
+func (w *systemDevice) BatchSize() int {
+	if w.batchDevice != nil {
+		return w.batchDevice.BatchSize()
+	}
+	return 1
+}

--- a/transport/amnezia/device_system_stack.go
+++ b/transport/amnezia/device_system_stack.go
@@ -1,0 +1,182 @@
+//go:build with_gvisor
+
+package amnezia
+
+import (
+	"net/netip"
+
+	"github.com/sagernet/gvisor/pkg/buffer"
+	"github.com/sagernet/gvisor/pkg/tcpip"
+	"github.com/sagernet/gvisor/pkg/tcpip/header"
+	"github.com/sagernet/gvisor/pkg/tcpip/stack"
+	"github.com/sagernet/gvisor/pkg/tcpip/transport/tcp"
+	"github.com/sagernet/gvisor/pkg/tcpip/transport/udp"
+	"github.com/sagernet/sing-tun"
+	"github.com/sagernet/sing/common"
+	"github.com/sagernet/wireguard-go/device"
+)
+
+var _ Device = (*systemStackDevice)(nil)
+
+type systemStackDevice struct {
+	*systemDevice
+	stack     *stack.Stack
+	endpoint  *deviceEndpoint
+	writeBufs [][]byte
+}
+
+func newSystemStackDevice(options DeviceOptions) (*systemStackDevice, error) {
+	system, err := newSystemDevice(options)
+	if err != nil {
+		return nil, err
+	}
+	endpoint := &deviceEndpoint{
+		mtu:  options.MTU,
+		done: make(chan struct{}),
+	}
+	ipStack, err := tun.NewGVisorStack(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	ipStack.SetTransportProtocolHandler(tcp.ProtocolNumber, tun.NewTCPForwarder(options.Context, ipStack, options.Handler).HandlePacket)
+	ipStack.SetTransportProtocolHandler(udp.ProtocolNumber, tun.NewUDPForwarder(options.Context, ipStack, options.Handler, options.UDPTimeout).HandlePacket)
+	return &systemStackDevice{
+		systemDevice: system,
+		stack:        ipStack,
+		endpoint:     endpoint,
+	}, nil
+}
+
+func (w *systemStackDevice) SetDevice(device *device.Device) {
+	w.endpoint.device = device
+}
+
+func (w *systemStackDevice) Write(bufs [][]byte, offset int) (count int, err error) {
+	if w.batchDevice != nil {
+		w.writeBufs = w.writeBufs[:0]
+		for _, packet := range bufs {
+			if !w.writeStack(packet[offset:]) {
+				w.writeBufs = append(w.writeBufs, packet)
+			}
+		}
+		if len(w.writeBufs) > 0 {
+			return w.batchDevice.BatchWrite(bufs, offset)
+		}
+	} else {
+		for _, packet := range bufs {
+			if !w.writeStack(packet[offset:]) {
+				if tun.PacketOffset > 0 {
+					common.ClearArray(packet[offset-tun.PacketOffset : offset])
+					tun.PacketFillHeader(packet[offset-tun.PacketOffset:], tun.PacketIPVersion(packet[offset:]))
+				}
+				_, err = w.device.Write(packet[offset-tun.PacketOffset:])
+			}
+			if err != nil {
+				return
+			}
+		}
+	}
+	// WireGuard will not read count
+	return
+}
+
+func (w *systemStackDevice) Close() error {
+	close(w.endpoint.done)
+	w.stack.Close()
+	for _, endpoint := range w.stack.CleanupEndpoints() {
+		endpoint.Abort()
+	}
+	w.stack.Wait()
+	return w.systemDevice.Close()
+}
+
+func (w *systemStackDevice) writeStack(packet []byte) bool {
+	var (
+		networkProtocol tcpip.NetworkProtocolNumber
+		destination     netip.Addr
+	)
+	switch header.IPVersion(packet) {
+	case header.IPv4Version:
+		networkProtocol = header.IPv4ProtocolNumber
+		destination = netip.AddrFrom4(header.IPv4(packet).DestinationAddress().As4())
+	case header.IPv6Version:
+		networkProtocol = header.IPv6ProtocolNumber
+		destination = netip.AddrFrom16(header.IPv6(packet).DestinationAddress().As16())
+	}
+	for _, prefix := range w.options.Address {
+		if prefix.Contains(destination) {
+			return false
+		}
+	}
+	packetBuffer := stack.NewPacketBuffer(stack.PacketBufferOptions{
+		Payload: buffer.MakeWithData(packet),
+	})
+	w.endpoint.dispatcher.DeliverNetworkPacket(networkProtocol, packetBuffer)
+	packetBuffer.DecRef()
+	return true
+}
+
+type deviceEndpoint struct {
+	mtu        uint32
+	done       chan struct{}
+	device     *device.Device
+	dispatcher stack.NetworkDispatcher
+}
+
+func (ep *deviceEndpoint) MTU() uint32 {
+	return ep.mtu
+}
+
+func (ep *deviceEndpoint) SetMTU(mtu uint32) {
+}
+
+func (ep *deviceEndpoint) MaxHeaderLength() uint16 {
+	return 0
+}
+
+func (ep *deviceEndpoint) LinkAddress() tcpip.LinkAddress {
+	return ""
+}
+
+func (ep *deviceEndpoint) SetLinkAddress(addr tcpip.LinkAddress) {
+}
+
+func (ep *deviceEndpoint) Capabilities() stack.LinkEndpointCapabilities {
+	return stack.CapabilityRXChecksumOffload
+}
+
+func (ep *deviceEndpoint) Attach(dispatcher stack.NetworkDispatcher) {
+	ep.dispatcher = dispatcher
+}
+
+func (ep *deviceEndpoint) IsAttached() bool {
+	return ep.dispatcher != nil
+}
+
+func (ep *deviceEndpoint) Wait() {
+}
+
+func (ep *deviceEndpoint) ARPHardwareType() header.ARPHardwareType {
+	return header.ARPHardwareNone
+}
+
+func (ep *deviceEndpoint) AddHeader(buffer *stack.PacketBuffer) {
+}
+
+func (ep *deviceEndpoint) ParseHeader(ptr *stack.PacketBuffer) bool {
+	return true
+}
+
+func (ep *deviceEndpoint) WritePackets(list stack.PacketBufferList) (int, tcpip.Error) {
+	for _, packetBuffer := range list.AsSlice() {
+		destination := packetBuffer.Network().DestinationAddress()
+		ep.device.InputPacket(destination.AsSlice(), packetBuffer.AsSlices())
+	}
+	return list.Len(), nil
+}
+
+func (ep *deviceEndpoint) Close() {
+}
+
+func (ep *deviceEndpoint) SetOnCloseAction(f func()) {
+}

--- a/transport/amnezia/endpoint.go
+++ b/transport/amnezia/endpoint.go
@@ -1,0 +1,286 @@
+package amnezia
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"net/netip"
+	"os"
+	"strings"
+
+	"github.com/sagernet/sing/common"
+	E "github.com/sagernet/sing/common/exceptions"
+	F "github.com/sagernet/sing/common/format"
+	M "github.com/sagernet/sing/common/metadata"
+	"github.com/sagernet/sing/common/x/list"
+	"github.com/sagernet/sing/service"
+	"github.com/sagernet/sing/service/pause"
+	"github.com/sagernet/wireguard-go/conn"
+	"github.com/sagernet/wireguard-go/device"
+
+	"go4.org/netipx"
+)
+
+type Endpoint struct {
+	options        EndpointOptions
+	peers          []peerConfig
+	ipcConf        string
+	allowedAddress []netip.Prefix
+	tunDevice      Device
+	device         *device.Device
+	pauseManager   pause.Manager
+	pauseCallback  *list.Element[pause.Callback]
+}
+
+func NewEndpoint(options EndpointOptions) (*Endpoint, error) {
+	if options.PrivateKey == "" {
+		return nil, E.New("missing private key")
+	}
+	privateKeyBytes, err := base64.StdEncoding.DecodeString(options.PrivateKey)
+	if err != nil {
+		return nil, E.Cause(err, "decode private key")
+	}
+	privateKey := hex.EncodeToString(privateKeyBytes)
+	ipcConf := "private_key=" + privateKey
+	if options.ListenPort != 0 {
+		ipcConf += "\nlisten_port=" + F.ToString(options.ListenPort)
+	}
+	if options.JunkPacketCount > 0 {
+		ipcConf += "\njc=" + F.ToString(options.JunkPacketCount)
+	}
+	if options.JunkPacketMinSize > 0 {
+		ipcConf += "\njmin=" + F.ToString(options.JunkPacketMinSize)
+	}
+	if options.JunkPacketMaxSize > 0 {
+		ipcConf += "\njmax=" + F.ToString(options.JunkPacketMaxSize)
+	}
+	if options.InitPacketJunkSize > 0 {
+		ipcConf += "\ns1=" + F.ToString(options.InitPacketJunkSize)
+	}
+	if options.ResponsePacketJunkSize > 0 {
+		ipcConf += "\ns2=" + F.ToString(options.ResponsePacketJunkSize)
+	}
+	if options.InitPacketMagicHeader > 0 {
+		ipcConf += "\nh1=" + F.ToString(options.InitPacketMagicHeader)
+	}
+	if options.ResponsePacketMagicHeader > 0 {
+		ipcConf += "\nh2=" + F.ToString(options.ResponsePacketMagicHeader)
+	}
+	if options.UnderloadPacketMagicHeader > 0 {
+		ipcConf += "\nh3=" + F.ToString(options.UnderloadPacketMagicHeader)
+	}
+	if options.TransportPacketMagicHeader > 0 {
+		ipcConf += "\nh4=" + F.ToString(options.TransportPacketMagicHeader)
+	}
+	var peers []peerConfig
+	for peerIndex, rawPeer := range options.Peers {
+		peer := peerConfig{
+			allowedIPs: rawPeer.AllowedIPs,
+			keepalive:  rawPeer.PersistentKeepaliveInterval,
+		}
+		if rawPeer.Endpoint.Addr.IsValid() {
+			peer.endpoint = rawPeer.Endpoint.AddrPort()
+		} else if rawPeer.Endpoint.IsFqdn() {
+			peer.destination = rawPeer.Endpoint
+		}
+		publicKeyBytes, err := base64.StdEncoding.DecodeString(rawPeer.PublicKey)
+		if err != nil {
+			return nil, E.Cause(err, "decode public key for peer ", peerIndex)
+		}
+		peer.publicKeyHex = hex.EncodeToString(publicKeyBytes)
+		if rawPeer.PreSharedKey != "" {
+			preSharedKeyBytes, err := base64.StdEncoding.DecodeString(rawPeer.PreSharedKey)
+			if err != nil {
+				return nil, E.Cause(err, "decode pre shared key for peer ", peerIndex)
+			}
+			peer.preSharedKeyHex = hex.EncodeToString(preSharedKeyBytes)
+		}
+		if len(rawPeer.AllowedIPs) == 0 {
+			return nil, E.New("missing allowed ips for peer ", peerIndex)
+		}
+		if len(rawPeer.Reserved) > 0 {
+			if len(rawPeer.Reserved) != 3 {
+				return nil, E.New("invalid reserved value for peer ", peerIndex, ", required 3 bytes, got ", len(peer.reserved))
+			}
+			copy(peer.reserved[:], rawPeer.Reserved[:])
+		}
+		peers = append(peers, peer)
+	}
+	var allowedPrefixBuilder netipx.IPSetBuilder
+	for _, peer := range options.Peers {
+		for _, prefix := range peer.AllowedIPs {
+			allowedPrefixBuilder.AddPrefix(prefix)
+		}
+	}
+	allowedIPSet, err := allowedPrefixBuilder.IPSet()
+	if err != nil {
+		return nil, err
+	}
+	allowedAddresses := allowedIPSet.Prefixes()
+	if options.MTU == 0 {
+		options.MTU = 1408
+	}
+	deviceOptions := DeviceOptions{
+		Context:        options.Context,
+		Logger:         options.Logger,
+		System:         options.System,
+		Handler:        options.Handler,
+		UDPTimeout:     options.UDPTimeout,
+		CreateDialer:   options.CreateDialer,
+		Name:           options.Name,
+		MTU:            options.MTU,
+		Address:        options.Address,
+		AllowedAddress: allowedAddresses,
+	}
+	tunDevice, err := NewDevice(deviceOptions)
+	if err != nil {
+		return nil, E.Cause(err, "create WireGuard device")
+	}
+	return &Endpoint{
+		options:        options,
+		peers:          peers,
+		ipcConf:        ipcConf,
+		allowedAddress: allowedAddresses,
+		tunDevice:      tunDevice,
+	}, nil
+}
+
+func (e *Endpoint) Start(resolve bool) error {
+	if common.Any(e.peers, func(peer peerConfig) bool {
+		return !peer.endpoint.IsValid() && peer.destination.IsFqdn()
+	}) {
+		if !resolve {
+			return nil
+		}
+		for peerIndex, peer := range e.peers {
+			if peer.endpoint.IsValid() || !peer.destination.IsFqdn() {
+				continue
+			}
+			destinationAddress, err := e.options.ResolvePeer(peer.destination.Fqdn)
+			if err != nil {
+				return E.Cause(err, "resolve endpoint domain for peer[", peerIndex, "]: ", peer.destination)
+			}
+			e.peers[peerIndex].endpoint = netip.AddrPortFrom(destinationAddress, peer.destination.Port)
+		}
+	} else if resolve {
+		return nil
+	}
+	var bind conn.Bind
+	wgListener, isWgListener := e.options.Dialer.(conn.Listener)
+	if isWgListener {
+		bind = conn.NewStdNetBind(wgListener)
+	} else {
+		var (
+			isConnect   bool
+			connectAddr netip.AddrPort
+			reserved    [3]uint8
+		)
+		if len(e.peers) == 1 {
+			isConnect = true
+			connectAddr = e.peers[0].endpoint
+			reserved = e.peers[0].reserved
+		}
+		bind = NewClientBind(e.options.Context, e.options.Logger, e.options.Dialer, isConnect, connectAddr, reserved)
+	}
+	if isWgListener || len(e.peers) > 1 {
+		for _, peer := range e.peers {
+			if peer.reserved != [3]uint8{} {
+				bind.SetReservedForEndpoint(peer.endpoint, peer.reserved)
+			}
+		}
+	}
+	err := e.tunDevice.Start()
+	if err != nil {
+		return err
+	}
+	logger := &device.Logger{
+		Verbosef: func(format string, args ...interface{}) {
+			e.options.Logger.Debug(fmt.Sprintf(strings.ToLower(format), args...))
+		},
+		Errorf: func(format string, args ...interface{}) {
+			e.options.Logger.Error(fmt.Sprintf(strings.ToLower(format), args...))
+		},
+	}
+	wgDevice := device.NewDevice(e.options.Context, e.tunDevice, bind, logger, e.options.Workers)
+	e.tunDevice.SetDevice(wgDevice)
+	ipcConf := e.ipcConf
+	for _, peer := range e.peers {
+		ipcConf += peer.GenerateIpcLines()
+	}
+	err = wgDevice.IpcSet(ipcConf)
+	if err != nil {
+		return E.Cause(err, "setup wireguard: \n", ipcConf)
+	}
+	e.device = wgDevice
+	e.pauseManager = service.FromContext[pause.Manager](e.options.Context)
+	if e.pauseManager != nil {
+		e.pauseCallback = e.pauseManager.RegisterCallback(e.onPauseUpdated)
+	}
+	return nil
+}
+
+func (e *Endpoint) DialContext(ctx context.Context, network string, destination M.Socksaddr) (net.Conn, error) {
+	if !destination.Addr.IsValid() {
+		return nil, E.Cause(os.ErrInvalid, "invalid non-IP destination")
+	}
+	return e.tunDevice.DialContext(ctx, network, destination)
+}
+
+func (e *Endpoint) ListenPacket(ctx context.Context, destination M.Socksaddr) (net.PacketConn, error) {
+	if !destination.Addr.IsValid() {
+		return nil, E.Cause(os.ErrInvalid, "invalid non-IP destination")
+	}
+	return e.tunDevice.ListenPacket(ctx, destination)
+}
+
+func (e *Endpoint) BindUpdate() error {
+	return e.device.BindUpdate()
+}
+
+func (e *Endpoint) Close() error {
+	if e.device != nil {
+		e.device.Close()
+	}
+	if e.pauseCallback != nil {
+		e.pauseManager.UnregisterCallback(e.pauseCallback)
+	}
+	return nil
+}
+
+func (e *Endpoint) onPauseUpdated(event int) {
+	switch event {
+	case pause.EventDevicePaused:
+		e.device.Down()
+	case pause.EventDeviceWake:
+		e.device.Up()
+	}
+}
+
+type peerConfig struct {
+	destination     M.Socksaddr
+	endpoint        netip.AddrPort
+	publicKeyHex    string
+	preSharedKeyHex string
+	allowedIPs      []netip.Prefix
+	keepalive       uint16
+	reserved        [3]uint8
+}
+
+func (c peerConfig) GenerateIpcLines() string {
+	ipcLines := "\npublic_key=" + c.publicKeyHex
+	if c.endpoint.IsValid() {
+		ipcLines += "\nendpoint=" + c.endpoint.String()
+	}
+	if c.preSharedKeyHex != "" {
+		ipcLines += "\npreshared_key=" + c.preSharedKeyHex
+	}
+	for _, allowedIP := range c.allowedIPs {
+		ipcLines += "\nallowed_ip=" + allowedIP.String()
+	}
+	if c.keepalive > 0 {
+		ipcLines += "\npersistent_keepalive_interval=" + F.ToString(c.keepalive)
+	}
+	return ipcLines
+}

--- a/transport/amnezia/endpoint.go
+++ b/transport/amnezia/endpoint.go
@@ -47,6 +47,8 @@ func NewEndpoint(options EndpointOptions) (*Endpoint, error) {
 	if options.ListenPort != 0 {
 		ipcConf += "\nlisten_port=" + F.ToString(options.ListenPort)
 	}
+
+	/*************  ADDED FOR AMNEZIA  *************/
 	if options.JunkPacketCount > 0 {
 		ipcConf += "\njc=" + F.ToString(options.JunkPacketCount)
 	}
@@ -74,6 +76,7 @@ func NewEndpoint(options EndpointOptions) (*Endpoint, error) {
 	if options.TransportPacketMagicHeader > 0 {
 		ipcConf += "\nh4=" + F.ToString(options.TransportPacketMagicHeader)
 	}
+	/********************  END  ********************/
 	var peers []peerConfig
 	for peerIndex, rawPeer := range options.Peers {
 		peer := peerConfig{

--- a/transport/amnezia/endpoint_options.go
+++ b/transport/amnezia/endpoint_options.go
@@ -1,0 +1,41 @@
+package amnezia
+
+import (
+	"context"
+	"github.com/getlantern/radiance/option"
+	"net/netip"
+	"time"
+
+	"github.com/sagernet/sing-tun"
+	"github.com/sagernet/sing/common/logger"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+)
+
+type EndpointOptions struct {
+	Context      context.Context
+	Logger       logger.ContextLogger
+	System       bool
+	Handler      tun.Handler
+	UDPTimeout   time.Duration
+	Dialer       N.Dialer
+	CreateDialer func(interfaceName string) N.Dialer
+	Name         string
+	MTU          uint32
+	Address      []netip.Prefix
+	PrivateKey   string
+	ListenPort   uint16
+	ResolvePeer  func(domain string) (netip.Addr, error)
+	Peers        []PeerOptions
+	Workers      int
+	option.WireGuardAdvancedSecurityOptions
+}
+
+type PeerOptions struct {
+	Endpoint                    M.Socksaddr
+	PublicKey                   string
+	PreSharedKey                string
+	AllowedIPs                  []netip.Prefix
+	PersistentKeepaliveInterval uint16
+	Reserved                    []uint8
+}

--- a/transport/amnezia/endpoint_options.go
+++ b/transport/amnezia/endpoint_options.go
@@ -28,7 +28,7 @@ type EndpointOptions struct {
 	ResolvePeer  func(domain string) (netip.Addr, error)
 	Peers        []PeerOptions
 	Workers      int
-	option.WireGuardAdvancedSecurityOptions
+	option.WireGuardAdvancedSecurityOptions  /**  ADDED FOR AMNEZIA  **/
 }
 
 type PeerOptions struct {


### PR DESCRIPTION
closes https://github.com/getlantern/engineering/issues/2005
This PR brings AmneziaWG support by:
1. pointing to our version of wireguard-go (this doesn't change behavior of existing wireguard protocol)
2. creating a new 'amnezia' outbound protocol that supports the amnezia-specific config params

99.9% of the code is lifted from wireguard protocol implementation, except for the custom param passing