### PR TITLE
Fix app crash on macOS when starting/stopping VPN multiple times

### DIFF
--- a/client/service/service.go
+++ b/client/service/service.go
@@ -36,7 +36,7 @@ type BoxService struct {
 	pauseAccess  sync.Mutex
 	pauseTimer   *time.Timer
 	mu           sync.Mutex
-	isRunning    atomic.Bool
+	isRunning    bool
 }
 
 // New creates a new BoxService that wraps a [libbox.BoxService]. platformInterface is used
@@ -65,7 +65,7 @@ func (bs *BoxService) Start() error {
 	bs.mu.Lock()
 	defer bs.mu.Unlock()
 
-	if bs.isRunning.Load() {
+	if bs.isRunning {
 		return errors.New("service is already running")
 	}
 
@@ -80,7 +80,7 @@ func (bs *BoxService) Start() error {
 	bs.pauseManager = service.FromContext[pause.Manager](ctx)
 
 	if err = lb.Start(); err == nil {
-		bs.isRunning.Store(true)
+		bs.isRunning = true
 	}
 	return err
 }
@@ -109,7 +109,7 @@ func (bs *BoxService) Close() error {
 	bs.mu.Lock()
 	defer bs.mu.Unlock()
 
-	if !bs.isRunning.Load() {
+	if !bs.isRunning {
 		return errors.New("service already stopped")
 	}
 
@@ -127,7 +127,7 @@ func (bs *BoxService) Close() error {
 		bs.libbox = nil
 	}
 
-	bs.isRunning.Store(false)
+	bs.isRunning = false
 	return nil
 }
 

--- a/client/service/service.go
+++ b/client/service/service.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	box "github.com/sagernet/sing-box"
@@ -27,24 +28,24 @@ import (
 
 // BoxService is a wrapper around libbox.BoxService
 type BoxService struct {
-	libbox *libbox.BoxService
-	ctx    context.Context
-
+	libbox       *libbox.BoxService
+	ctx          context.Context
+	config       string
+	platIfce     libbox.PlatformInterface
 	pauseManager pause.Manager
 	pauseAccess  sync.Mutex
 	pauseTimer   *time.Timer
+	mu           sync.Mutex
+	isRunning    atomic.Bool
 }
 
 // New creates a new BoxService that wraps a [libbox.BoxService]. platformInterface is used
 // to interact with the underlying platform
 func New(config, dataDir string, platIfce libbox.PlatformInterface) (*BoxService, error) {
-	inboundRegistry, outboundRegistry, endpointRegistry := protocol.GetRegistries()
-	ctx := box.Context(
-		context.Background(),
-		inboundRegistry,
-		outboundRegistry,
-		endpointRegistry,
-	)
+	bs := &BoxService{
+		config:   config,
+		platIfce: platIfce,
+	}
 	setupOpts := &libbox.SetupOptions{
 		BasePath:    dataDir,
 		WorkingPath: filepath.Join(dataDir, "data"),
@@ -56,27 +57,76 @@ func New(config, dataDir string, platIfce libbox.PlatformInterface) (*BoxService
 	if err := libbox.Setup(setupOpts); err != nil {
 		return nil, fmt.Errorf("setup libbox: %w", err)
 	}
-	lb, err := libbox.NewServiceWithContext(ctx, config, platIfce)
-	if err != nil {
-		return nil, fmt.Errorf("create libbox service: %w", err)
-	}
-
-	bs := &BoxService{
-		libbox:       lb,
-		ctx:          ctx,
-		pauseManager: service.FromContext[pause.Manager](ctx),
-		pauseAccess:  sync.Mutex{},
-	}
 
 	return bs, nil
 }
 
 func (bs *BoxService) Start() error {
-	return bs.libbox.Start()
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+	if bs.isRunning.Load() {
+		return errors.New("service is already running")
+	}
+
+	// (re)-initialize the libbox service
+	lb, ctx, err := newLibboxService(bs.config, bs.platIfce)
+	if err != nil {
+		return err
+	}
+
+	bs.libbox = lb
+	bs.ctx = ctx
+	bs.pauseManager = service.FromContext[pause.Manager](ctx)
+
+	if err = bs.libbox.Start(); err == nil {
+		bs.isRunning.Store(true)
+	}
+	return err
+}
+
+// newLibboxService creates a new libbox service with the given config and platform interface
+func newLibboxService(config string, platIfce libbox.PlatformInterface) (*libbox.BoxService, context.Context, error) {
+	// Retrieve protocol registries
+	inboundRegistry, outboundRegistry, endpointRegistry := protocol.GetRegistries()
+	ctx := box.Context(
+		context.Background(),
+		inboundRegistry,
+		outboundRegistry,
+		endpointRegistry,
+	)
+
+	// initialize the libbox service
+	lb, err := libbox.NewServiceWithContext(ctx, config, platIfce)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create libbox service: %v", err)
+	}
+
+	return lb, ctx, nil
 }
 
 func (bs *BoxService) Close() error {
-	return bs.libbox.Close()
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+
+	if !bs.isRunning.Load() {
+		return errors.New("service already closed")
+	}
+
+	// Clear pause timer
+	if bs.pauseTimer != nil {
+		bs.pauseTimer.Stop()
+		bs.pauseTimer = nil
+	}
+
+	if bs.libbox != nil {
+		err := bs.libbox.Close()
+		if err != nil {
+			return fmt.Errorf("failed to close libbox: %v", err)
+		}
+	}
+
+	bs.isRunning.Store(false)
+	return nil
 }
 
 // Pause pauses the network for the specified duration. An error is returned if the network is
@@ -90,7 +140,7 @@ func (bs *BoxService) Pause(dur time.Duration) error {
 	}
 
 	bs.pauseManager.NetworkPause()
-	bs.pauseTimer = time.AfterFunc(dur, bs.pauseManager.NetworkWake)
+	bs.pauseTimer = time.AfterFunc(dur, bs.Wake)
 	return nil
 }
 

--- a/client/service/service.go
+++ b/client/service/service.go
@@ -99,7 +99,7 @@ func newLibboxService(config string, platIfce libbox.PlatformInterface) (*libbox
 	// initialize the libbox service
 	lb, err := libbox.NewServiceWithContext(ctx, config, platIfce)
 	if err != nil {
-		return nil, nil, fmt.Errorf("create libbox service: %v", err)
+		return nil, nil, fmt.Errorf("create libbox service: %w", err)
 	}
 
 	return lb, ctx, nil

--- a/client/service/service.go
+++ b/client/service/service.go
@@ -64,6 +64,7 @@ func New(config, dataDir string, platIfce libbox.PlatformInterface) (*BoxService
 func (bs *BoxService) Start() error {
 	bs.mu.Lock()
 	defer bs.mu.Unlock()
+
 	if bs.isRunning.Load() {
 		return errors.New("service is already running")
 	}
@@ -123,6 +124,7 @@ func (bs *BoxService) Close() error {
 		if err != nil {
 			return fmt.Errorf("failed to close libbox: %v", err)
 		}
+		bs.libbox = nil
 	}
 
 	bs.isRunning.Store(false)

--- a/client/service/service.go
+++ b/client/service/service.go
@@ -15,7 +15,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	box "github.com/sagernet/sing-box"

--- a/client/service/service.go
+++ b/client/service/service.go
@@ -78,7 +78,7 @@ func (bs *BoxService) Start() error {
 	bs.ctx = ctx
 	bs.pauseManager = service.FromContext[pause.Manager](ctx)
 
-	if err = bs.libbox.Start(); err == nil {
+	if err = lb.Start(); err == nil {
 		bs.isRunning.Store(true)
 	}
 	return err
@@ -109,7 +109,7 @@ func (bs *BoxService) Close() error {
 	defer bs.mu.Unlock()
 
 	if !bs.isRunning.Load() {
-		return errors.New("service already closed")
+		return errors.New("service already stopped")
 	}
 
 	// Clear pause timer
@@ -153,6 +153,8 @@ func (bs *BoxService) Wake() {
 		return
 	}
 	bs.pauseManager.NetworkWake()
-	bs.pauseTimer.Stop()
-	bs.pauseTimer = nil
+	if bs.pauseTimer != nil {
+		bs.pauseTimer.Stop()
+		bs.pauseTimer = nil
+	}
 }


### PR DESCRIPTION
This PR resolves an issue where the app would crash or enter an invalid state on macOS if the VPN is started and stopped multiple times in a row: https://github.com/getlantern/engineering/issues/1994

It includes updates to properly reinitialize libbox after stopping and prevents multiple calls to libbox.Close() which caused the "file already closed" errors.
