### PR TITLE
add ability to update outbounds and endpoints during sing-box runtime

### DIFF
--- a/client/service/service.go
+++ b/client/service/service.go
@@ -14,11 +14,15 @@ import (
 	"fmt"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sync"
 	"time"
 
 	box "github.com/sagernet/sing-box"
+	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/experimental/libbox"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing-box/option"
 	"github.com/sagernet/sing/service"
 	"github.com/sagernet/sing/service/pause"
 
@@ -173,4 +177,176 @@ func (bs *BoxService) Wake() {
 
 func (bs *BoxService) Ctx() context.Context {
 	return bs.ctx
+}
+
+var (
+	permanentOutbounds = []string{
+		"direct",
+		"dns",
+		"block",
+	}
+	permanentEndpoints = []string{}
+)
+
+// updateOutboundsEndpoints updates the outbounds and endpoints in the router, skipping any present in
+// [permanentOutbounds] and [permanentEndpoints]. updateOutboundsEndpoints will continue processing
+// the remaining outbounds and endpoints even if an error occurs, returning a single error of all
+// errors encountered.
+func updateOutboundsEndpoints(ctx context.Context, outbounds []option.Outbound, endpoints []option.Endpoint) error {
+	router := service.FromContext[adapter.Router](ctx)
+	if router == nil {
+		return errors.New("router missing from context")
+	}
+	// TODO: reaallyy need to be able to get that logFactory.. -_-
+	//			we need to create our own and add it to the context
+	logFactory := service.FromContext[log.Factory](ctx)
+	var errs error
+	if len(outbounds) > 0 {
+		outboundMgr := service.FromContext[adapter.OutboundManager](ctx)
+		if outboundMgr == nil {
+			errs = errors.Join(errs, errors.New("outbound manager missing from context"))
+		} else {
+			err := updateOutbounds(ctx, outboundMgr, router, logFactory, outbounds, permanentOutbounds)
+			if err != nil {
+				errs = fmt.Errorf("update outbounds: %w", err)
+			}
+		}
+	}
+	if len(endpoints) > 0 {
+		endpointMgr := service.FromContext[adapter.EndpointManager](ctx)
+		if endpointMgr == nil {
+			errs = errors.Join(errs, errors.New("endpoint manager missing from context"))
+		} else {
+			err := updateEndpoints(ctx, endpointMgr, router, logFactory, endpoints, permanentEndpoints)
+			if err != nil {
+				errs = errors.Join(errs, fmt.Errorf("update endpoints: %w", err))
+			}
+		}
+	}
+	return errs
+}
+
+// updateOutbounds syncs the [adapter.OutboundManager] with the provided outbounds. It skips excluded
+// or untagged entries, removes outdated ones, and creates or updates the rest. If any error occurs,
+// updateOutbounds will continue processing the remaining outbounds and return a single error of
+// all errors encountered.
+func updateOutbounds(
+	ctx context.Context,
+	outboundMgr adapter.OutboundManager,
+	router adapter.Router,
+	logFactory log.Factory,
+	outbounds []option.Outbound,
+	excludeTags []string,
+) error {
+	newItems, errs := filterItems(outbounds, excludeTags, func(it option.Outbound) string {
+		return it.Tag
+	})
+
+	if nToRemove := len(outboundMgr.Outbounds()) - len(newItems); nToRemove > 0 {
+		errs = errors.Join(errs, removeItems(
+			outboundMgr.Outbounds(),
+			newItems,
+			excludeTags,
+			outboundMgr.Remove,
+			func(it adapter.Outbound) string {
+				return it.Tag()
+			},
+		))
+	}
+
+	for tag, outbound := range newItems {
+		logger := logFactory.NewLogger(fmt.Sprintf("outbound/%s[%s]", outbound.Type, tag))
+		err := outboundMgr.Create(ctx, router, logger, tag, outbound.Type, outbound.Options)
+		if err != nil {
+			errs = errors.Join(errs, fmt.Errorf("initialize [%v]: %w", tag, err))
+		}
+	}
+
+	return errs
+}
+
+// updateEndpoints syncs the [adapter.EndpointManager] with the provided [option.Endpoint]s. It skips
+// excluded or untagged entries, removes outdated ones, and creates or updates the rest. If any error
+// occurs, updateEndpoints will continue processing the remaining endpoints and return a single error
+// of all errors encountered.
+func updateEndpoints(
+	ctx context.Context,
+	endpointMgr adapter.EndpointManager,
+	router adapter.Router,
+	logFactory log.Factory,
+	endpoints []option.Endpoint,
+	excludeTags []string,
+) error {
+	// filter endpoints that are missing a tag or are excluded
+	newItems, errs := filterItems(endpoints, excludeTags, func(it option.Endpoint) string {
+		return it.Tag
+	})
+
+	if nToRemove := len(endpointMgr.Endpoints()) - len(endpoints); nToRemove > 0 {
+		errs = errors.Join(errs, removeItems(
+			endpointMgr.Endpoints(),
+			newItems,
+			excludeTags,
+			endpointMgr.Remove,
+			func(it adapter.Endpoint) string {
+				return it.Tag()
+			},
+		))
+	}
+
+	for tag, endpoint := range newItems {
+		logger := logFactory.NewLogger(fmt.Sprintf("endpoint/%s[%s]", endpoint.Type, tag))
+		err := endpointMgr.Create(ctx, router, logger, tag, endpoint.Type, endpoint.Options)
+		if err != nil {
+			errs = errors.Join(errs, fmt.Errorf("initialize [%v]: %w", tag, err))
+		}
+	}
+
+	return errs
+}
+
+// filterItems returns a map of items with tags as keys. It filters out items that are missing a tag
+// or are present in excludeTags. An error is returned listing all items that are missing a tag.
+func filterItems[T any](items []T, excludeTags []string, getTag func(T) string) (map[string]T, error) {
+	var errs error
+	filtered := make(map[string]T)
+	for idx, it := range items {
+		switch tag := getTag(it); {
+		case tag == "":
+			errs = errors.Join(errs, fmt.Errorf("missing tag for %T[%d]", it, idx))
+		case slices.Contains(excludeTags, tag):
+		default:
+			filtered[tag] = it
+		}
+	}
+	return filtered, errs
+}
+
+// removeItems removes items not present in newItems or excludeTags using the provided remove function.
+// If an error occurs, it continues processing the remaining items and returns a single error of all
+// errors encountered.
+func removeItems[T any, O any](
+	items []T,
+	newItems map[string]O,
+	excludeTags []string,
+	remove func(string) error,
+	getTag func(T) string,
+) error {
+	var errs error
+	nToRemove := len(items) - len(newItems)
+	for _, it := range items {
+		tag := getTag(it)
+		if _, ok := newItems[tag]; ok || slices.Contains(excludeTags, tag) {
+			continue
+		}
+		if err := remove(tag); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("remove [%v]: %w", tag, err))
+		}
+		// still decrease nToRemove even if we get an error and move on
+		nToRemove--
+		if nToRemove == 0 {
+			break
+		}
+	}
+	return errs
 }

--- a/client/service/service_test.go
+++ b/client/service/service_test.go
@@ -1,0 +1,217 @@
+package boxservice
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing-box/option"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdateOutbounds(t *testing.T) {
+	tests := []struct {
+		name      string
+		outbounds []adapter.Outbound
+		updates   []option.Outbound
+		exclude   []string
+		want      []adapter.Outbound
+		error     bool
+	}{
+		{
+			name: "upsert outbounds",
+			outbounds: []adapter.Outbound{
+				&mockEndpoint{tag: "tag1", typ: "type1"},
+				&mockEndpoint{tag: "tag2", typ: "type2"},
+				&mockEndpoint{tag: "tag3", typ: "type3"},
+			},
+			updates: []option.Outbound{
+				{Tag: "tag1", Type: "NewType"},
+				{Tag: "tag4", Type: "NewType"},
+			},
+			want: []adapter.Outbound{
+				&mockEndpoint{tag: "tag1", typ: "NewType"},
+				&mockEndpoint{tag: "tag4", typ: "NewType"},
+			},
+		},
+		{
+			name: "exclude outbounds",
+			outbounds: []adapter.Outbound{
+				&mockEndpoint{tag: "direct", typ: "type1"},
+				&mockEndpoint{tag: "dns", typ: "type1"},
+				&mockEndpoint{tag: "tag2", typ: "type2"},
+			},
+			updates: []option.Outbound{
+				{Tag: "direct", Type: "NewType"},
+				{Tag: "tag4", Type: "NewType"},
+			},
+			exclude: []string{"direct", "dns"},
+			want: []adapter.Outbound{
+				&mockEndpoint{tag: "direct", typ: "type1"},
+				&mockEndpoint{tag: "dns", typ: "type1"},
+				&mockEndpoint{tag: "tag4", typ: "NewType"},
+			},
+		},
+		{
+			name: "update valid and return error for missing tag",
+			outbounds: []adapter.Outbound{
+				&mockEndpoint{tag: "tag2", typ: "type2"},
+			},
+			updates: []option.Outbound{
+				{Tag: "tag2", Type: "NewType"},
+				{Tag: "", Type: "NewType"},
+			},
+			want: []adapter.Outbound{
+				&mockEndpoint{tag: "tag2", typ: "NewType"},
+			},
+			error: true,
+		},
+	}
+	for _, tt := range tests[1:] {
+		ctx := context.Background()
+		logger := log.NewNOPFactory()
+		t.Run(tt.name, func(t *testing.T) {
+			mgr := mockOutboundManager{outbounds: tt.outbounds}
+			err := updateOutbounds(ctx, &mgr, nil, logger, tt.updates, tt.exclude)
+			if tt.error {
+				assert.Error(t, err)
+			}
+			got := mgr.Outbounds()
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}
+
+func TestUpdateEndpoints(t *testing.T) {
+	tests := []struct {
+		name      string
+		endpoints []adapter.Endpoint
+		updates   []option.Endpoint
+		exclude   []string
+		want      []adapter.Endpoint
+		error     bool
+	}{
+		{
+			name: "upsert endpoints",
+			endpoints: []adapter.Endpoint{
+				&mockEndpoint{tag: "tag1", typ: "type1"},
+				&mockEndpoint{tag: "tag2", typ: "type2"},
+				&mockEndpoint{tag: "tag3", typ: "type3"},
+			},
+			updates: []option.Endpoint{
+				{Tag: "tag1", Type: "NewType"},
+				{Tag: "tag4", Type: "NewType"},
+			},
+			want: []adapter.Endpoint{
+				&mockEndpoint{tag: "tag1", typ: "NewType"},
+				&mockEndpoint{tag: "tag4", typ: "NewType"},
+			},
+		},
+		{
+			name: "exclude endpoints",
+			endpoints: []adapter.Endpoint{
+				&mockEndpoint{tag: "direct", typ: "type1"},
+				&mockEndpoint{tag: "dns", typ: "type1"},
+				&mockEndpoint{tag: "tag2", typ: "type2"},
+			},
+			updates: []option.Endpoint{
+				{Tag: "direct", Type: "NewType"},
+				{Tag: "tag4", Type: "NewType"},
+			},
+			exclude: []string{"direct", "dns"},
+			want: []adapter.Endpoint{
+				&mockEndpoint{tag: "direct", typ: "type1"},
+				&mockEndpoint{tag: "dns", typ: "type1"},
+				&mockEndpoint{tag: "tag4", typ: "NewType"},
+			},
+		},
+		{
+			name: "update valid and return error for missing tag",
+			endpoints: []adapter.Endpoint{
+				&mockEndpoint{tag: "tag2", typ: "type2"},
+			},
+			updates: []option.Endpoint{
+				{Tag: "tag2", Type: "NewType"},
+				{Tag: "", Type: "NewType"},
+			},
+			want: []adapter.Endpoint{
+				&mockEndpoint{tag: "tag2", typ: "NewType"},
+			},
+			error: true,
+		},
+	}
+	for _, tt := range tests[1:] {
+		ctx := context.Background()
+		logger := log.NewNOPFactory()
+		t.Run(tt.name, func(t *testing.T) {
+			mgr := mockEndpointManager{endpoints: tt.endpoints}
+			err := updateEndpoints(ctx, &mgr, nil, logger, tt.updates, tt.exclude)
+			if tt.error {
+				assert.Error(t, err)
+			}
+			got := mgr.Endpoints()
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}
+
+type mockOutboundManager struct {
+	adapter.OutboundManager
+	outbounds []adapter.Outbound
+}
+
+func (m *mockOutboundManager) Outbounds() []adapter.Outbound {
+	return m.outbounds
+}
+
+func (m *mockOutboundManager) Remove(tag string) error {
+	m.outbounds = testRemove(m.outbounds, tag)
+	return nil
+}
+
+func (m *mockOutboundManager) Create(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag, outboundType string, options any) error {
+	m.Remove(tag)
+	m.outbounds = append(m.outbounds, &mockEndpoint{typ: outboundType, tag: tag})
+	return nil
+}
+
+type mockEndpointManager struct {
+	adapter.EndpointManager
+	endpoints []adapter.Endpoint
+}
+
+func (m *mockEndpointManager) Endpoints() []adapter.Endpoint {
+	return m.endpoints
+}
+
+func (m *mockEndpointManager) Remove(tag string) error {
+	m.endpoints = testRemove(m.endpoints, tag)
+	return nil
+}
+
+func (m *mockEndpointManager) Create(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, typ string, options interface{}) error {
+	m.Remove(tag)
+	m.endpoints = append(m.endpoints, &mockEndpoint{typ: typ, tag: tag})
+	return nil
+}
+
+func testRemove[T adapter.Outbound](list []T, tag string) []T {
+	idx := slices.IndexFunc(list, func(e T) bool {
+		return e.Tag() == tag
+	})
+	if idx == -1 {
+		return list
+	}
+	return slices.Delete(list, idx, idx+1)
+}
+
+type mockEndpoint struct {
+	adapter.Endpoint
+	typ string
+	tag string
+}
+
+func (m *mockEndpoint) Type() string { return m.typ }
+func (m *mockEndpoint) Tag() string  { return m.tag }


### PR DESCRIPTION
This pull request introduces significant updates to the `client/service/service.go` and adds new tests in `client/service/service_test.go`. The primary focus is on enhancing the management of outbounds and endpoints with new functions and tests.

### Enhancements to Outbounds and Endpoints Management:

* Introduced `updateOutboundsEndpoints` function to update outbounds and endpoints in the router, skipping any permanent ones and collecting errors encountered during the process.
* Added `updateOutbounds` and `updateEndpoints` functions to synchronize the respective managers with the provided configurations, handling exclusions, removals, and updates.
* Implemented helper functions `filterItems` and `removeItems` to facilitate the filtering and removal of items based on tags.

### Testing Enhancements:

* Added new test cases in `client/service/service_test.go` to verify the functionality of `updateOutbounds` and `updateEndpoints` functions, including scenarios for upserting, excluding, and handling errors for missing tags.