### PR TITLE
Add missing logger for Windows build

### DIFF
--- a/user/deviceid/deviceid.go
+++ b/user/deviceid/deviceid.go
@@ -3,7 +3,12 @@ package deviceid
 import (
 	"encoding/base64"
 
+	"github.com/getlantern/golog"
 	"github.com/google/uuid"
+)
+
+var (
+	log = golog.LoggerFor("deviceid")
 )
 
 // OldStyleDeviceID returns the old style of device ID, which is derived from the MAC address.


### PR DESCRIPTION
This fixes a build error caused by the deviceid package not importing a logger on Windows:

```
Error: C:\Users\runneradmin\go\pkg\mod\github.com\getlantern\radiance@v0.0.0-20250404013922-fcb930ca277f\user\deviceid\deviceid_windows.go:21:3: undefined: log
Error: C:\Users\runneradmin\go\pkg\mod\github.com\getlantern\radiance@v0.0.0-20250404013922-fcb930ca277f\user\deviceid\deviceid_windows.go:28:4: undefined: log
Error: C:\Users\runneradmin\go\pkg\mod\github.com\getlantern\radiance@v0.0.0-20250404013922-fcb930ca277f\user\deviceid\deviceid_windows.go:31:3: undefined: log
Error: C:\Users\runneradmin\go\pkg\mod\github.com\getlantern\radiance@v0.0.0-20250404013922-fcb930ca277f\user\deviceid\deviceid_windows.go:34:4: undefined: log
Error: C:\Users\runneradmin\go\pkg\mod\github.com\getlantern\radiance@v0.0.0-20250404013922-fcb930ca277f\user\deviceid\deviceid_windows.go:40:4: undefined: log
```

