### PR TITLE
retrieve box instance log factory, update sing-box-minimal

### DIFF
--- a/client/service/service.go
+++ b/client/service/service.go
@@ -84,6 +84,7 @@ func (bs *BoxService) Start() error {
 	if err != nil {
 		return fmt.Errorf("create libbox service: %w", err)
 	}
+	service.MustRegister(ctx, lb.LogFactory())
 
 	// we need to start the ruleset manager before starting the libbox service but after the libbox
 	// service has been initialized so that the ruleset manager can access the routing rules.
@@ -216,8 +217,7 @@ func updateOutboundsEndpoints(ctx context.Context, outbounds []option.Outbound, 
 	if router == nil {
 		return errors.New("router missing from context")
 	}
-	// TODO: reaallyy need to be able to get that logFactory.. -_-
-	//			we need to create our own and add it to the context
+
 	logFactory := service.FromContext[log.Factory](ctx)
 	var errs error
 	if len(outbounds) > 0 {
@@ -364,5 +364,5 @@ func removeItems[I ~[]T, T bA, O any](
 			i++
 		}
 	}
-  return errs
+	return errs
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.6
 
 toolchain go1.24.1
 
-replace github.com/sagernet/sing-box => github.com/getlantern/sing-box-minimal v1.11.6-0.20250319162213-b56a0b17a972
+replace github.com/sagernet/sing-box => github.com/getlantern/sing-box-minimal v1.11.6-0.20250411173055-d82f542dfd3f
 
 replace github.com/sagernet/wireguard-go => github.com/getlantern/wireguard-go v0.0.1-beta.5.0.20250310145906-45220d8aec77
 
@@ -26,7 +26,7 @@ require (
 	github.com/getlantern/timezone v0.0.0-20210901200113-3f9de9d360c9
 	github.com/gobwas/ws v1.4.0
 	github.com/google/uuid v1.6.0
-	github.com/sagernet/sing v0.6.4
+	github.com/sagernet/sing v0.6.5
 	github.com/sagernet/sing-box v1.11.5
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/otel/log v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 h1:JWH5BB2o0e
 github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175/go.mod h1:h3S9LBmmzN/xM+lwYZHE4abzTtCTtidKtG+nxZcCZX0=
 github.com/getlantern/sing-box-extensions v0.0.0-20250402200957-bb61b4768333 h1:uzHP/we+IZUbeL3WPq00tpdmc8hkh+iiyI7faeslM+U=
 github.com/getlantern/sing-box-extensions v0.0.0-20250402200957-bb61b4768333/go.mod h1:Vig0N8h0x4KtG0QZkPk1ZvEeZ7+Kkd12xiJMGrGNiZE=
-github.com/getlantern/sing-box-minimal v1.11.6-0.20250319162213-b56a0b17a972 h1:n1d3qX4G8IqDiOUnZMy404ZJP0cJqYPBYAtgBnZiDvU=
-github.com/getlantern/sing-box-minimal v1.11.6-0.20250319162213-b56a0b17a972/go.mod h1:9n60qJQH2gmrtjKUbnjdNt+Tvg5bq2ZBYNvNOdUz65w=
+github.com/getlantern/sing-box-minimal v1.11.6-0.20250411173055-d82f542dfd3f h1:1EM684uAJTApkeubw0W8BbxdrTaXkaXxbM1hJ+KRTZ8=
+github.com/getlantern/sing-box-minimal v1.11.6-0.20250411173055-d82f542dfd3f/go.mod h1:iKFH3Hqus29C3+CxQBsqk2+54SEjDDk2ljYplxN7Uzs=
 github.com/getlantern/timezone v0.0.0-20210901200113-3f9de9d360c9 h1:VTNjZxSuAHUzu13lYpEVB8gc3xz5hZePGNHG5enHYLY=
 github.com/getlantern/timezone v0.0.0-20210901200113-3f9de9d360c9/go.mod h1:7uvbzuoOr3uYGHZx5QWlI8/C52XEf/aTb/tJFEe41Ak=
 github.com/getlantern/tlsdialer/v3 v3.0.3 h1:OXzzAqO8YojBOu2Kk8wquX2zbFmgJjji41RpaT6knLg=
@@ -273,8 +273,8 @@ github.com/sagernet/quic-go v0.49.0-beta.1/go.mod h1:uesWD1Ihrldq1M3XtjuEvIUqi8W
 github.com/sagernet/reality v0.0.0-20230406110435-ee17307e7691 h1:5Th31OC6yj8byLGkEnIYp6grlXfo1QYUfiYFGjewIdc=
 github.com/sagernet/reality v0.0.0-20230406110435-ee17307e7691/go.mod h1:B8lp4WkQ1PwNnrVMM6KyuFR20pU8jYBD+A4EhJovEXU=
 github.com/sagernet/sing v0.2.18/go.mod h1:OL6k2F0vHmEzXz2KW19qQzu172FDgSbUSODylighuVo=
-github.com/sagernet/sing v0.6.4 h1:UdvcJXcwHjsdftIz1ct7IyhTlztd24DIQZAq2rMaJww=
-github.com/sagernet/sing v0.6.4/go.mod h1:ARkL0gM13/Iv5VCZmci/NuoOlePoIsW0m7BWfln/Hak=
+github.com/sagernet/sing v0.6.5 h1:TBKTK6Ms0/MNTZm+cTC2hhKunE42XrNIdsxcYtWqeUU=
+github.com/sagernet/sing v0.6.5/go.mod h1:ARkL0gM13/Iv5VCZmci/NuoOlePoIsW0m7BWfln/Hak=
 github.com/sagernet/sing-dns v0.4.0 h1:+mNoOuR3nljjouCH+qMg4zHI1+R9T2ReblGFkZPEndc=
 github.com/sagernet/sing-dns v0.4.0/go.mod h1:dweQs54ng2YGzoJfz+F9dGuDNdP5pJ3PLeggnK5VWc8=
 github.com/sagernet/sing-mux v0.3.1 h1:kvCc8HyGAskDHDQ0yQvoTi/7J4cZPB/VJMsAM3MmdQI=


### PR DESCRIPTION
This pull request includes several updates to the `client/service/service.go` and `go.mod` files. The changes primarily focus on registering services, cleaning up context usage, and updating dependencies.

### Service registration and context cleanup:

* [`client/service/service.go`](diffhunk://#diff-3e93cc11b22eab442b7c9435196e3101e2ac6f286ee1b63c98f0de4099bc5ab9R87): Added a call to `service.MustRegister(ctx, lb.LogFactory())` in the `Start` method to ensure the service is registered with the provided log factory.
* [`client/service/service.go`](diffhunk://#diff-3e93cc11b22eab442b7c9435196e3101e2ac6f286ee1b63c98f0de4099bc5ab9L219-R220): Removed outdated comments and ensured the log factory is retrieved from the context in the `updateOutboundsEndpoints` function.

### Dependency updates:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L7-R7): Replaced the `github.com/sagernet/sing-box` dependency with a new version.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L29-R29): Updated the `github.com/sagernet/sing` dependency to version `v0.6.5`.