### PR TITLE
pass ctx to ruleset manager

### DIFF
--- a/client/service/service.go
+++ b/client/service/service.go
@@ -88,7 +88,7 @@ func (bs *BoxService) Start() error {
 
 	// we need to start the ruleset manager before starting the libbox service but after the libbox
 	// service has been initialized so that the ruleset manager can access the routing rules.
-	if err := bs.mutRuleSetManager.Start(bs.ctx); err != nil {
+	if err := bs.mutRuleSetManager.Start(ctx); err != nil {
 		return fmt.Errorf("start ruleset manager: %w", err)
 	}
 


### PR DESCRIPTION
This pull request includes a minor update to the `client/service/service.go` file. The change modifies the context parameter passed to the `Start` method of `mutRuleSetManager`.

* [`client/service/service.go`](diffhunk://#diff-3e93cc11b22eab442b7c9435196e3101e2ac6f286ee1b63c98f0de4099bc5ab9L91-R91): Updated the context parameter from `bs.ctx` to `ctx` in the `Start` method call for `mutRuleSetManager`.