### PR TITLE
Fix connection status state

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -25,7 +25,7 @@ import (
 var (
 	client   *vpnClient
 	clientMu sync.Mutex
-	serverMu sync.Mutex
+	statusMu sync.Mutex
 )
 
 type Options struct {
@@ -151,8 +151,8 @@ func (c *vpnClient) ConnectionStatus() bool {
 }
 
 func (c *vpnClient) setConnectionStatus(connected bool) {
-	serverMu.Lock()
-	defer serverMu.Unlock()
+	statusMu.Lock()
+	defer statusMu.Unlock()
 	c.connected = connected
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -25,6 +25,7 @@ import (
 var (
 	client   *vpnClient
 	clientMu sync.Mutex
+	serverMu sync.Mutex
 )
 
 type Options struct {
@@ -150,6 +151,8 @@ func (c *vpnClient) ConnectionStatus() bool {
 }
 
 func (c *vpnClient) setConnectionStatus(connected bool) {
+	serverMu.Lock()
+	defer serverMu.Unlock()
 	c.connected = connected
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -115,6 +115,7 @@ func (c *vpnClient) StartVPN() error {
 	}
 
 	c.started = true
+	c.setConnectionStatus(true)
 	return nil
 }
 
@@ -137,6 +138,7 @@ func (c *vpnClient) StopVPN() error {
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		return errors.New("box did not stop in time")
 	}
+	c.setConnectionStatus(false)
 	return err
 }
 
@@ -148,8 +150,6 @@ func (c *vpnClient) ConnectionStatus() bool {
 }
 
 func (c *vpnClient) setConnectionStatus(connected bool) {
-	clientMu.Lock()
-	defer clientMu.Unlock()
 	c.connected = connected
 }
 


### PR DESCRIPTION
This pull request updates the `vpnClient` implementation in `client/client.go` to improve the handling of VPN connection status. The primary changes involve setting the connection status during the start and stop of the VPN and simplifying the `setConnectionStatus` method.

### Connection status management:

* [`client/client.go`](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09R118): Updated `StartVPN` to call `setConnectionStatus(true)` when the VPN starts, ensuring the connection status is accurately reflected.
* [`client/client.go`](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09R141): Updated `StopVPN` to call `setConnectionStatus(false)` when the VPN stops, maintaining consistency in connection status tracking.

### Code simplification:

* [`client/client.go`](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L151-L152): Removed the use of `clientMu` in the `setConnectionStatus` method, simplifying the implementation.