### PR TITLE
Fix directory handling when radiance is created

### DIFF
--- a/config/fetcher.go
+++ b/config/fetcher.go
@@ -21,7 +21,7 @@ import (
 	"github.com/getlantern/radiance/user"
 )
 
-const configURL = "https://api.iantem.io/v1/config"
+const configURL = "https://api.iantem.io/v1/config-new"
 
 // fetcher is responsible for fetching the configuration from the server.
 type fetcher struct {
@@ -33,8 +33,9 @@ type fetcher struct {
 // newFetcher creates a new fetcher with the given http client.
 func newFetcher(client *http.Client, user user.BaseUser) *fetcher {
 	return &fetcher{
-		httpClient: client,
-		user:       user,
+		httpClient:   client,
+		user:         user,
+		lastModified: time.Time{},
 	}
 }
 

--- a/radiance.go
+++ b/radiance.go
@@ -74,7 +74,7 @@ type Radiance struct {
 func NewRadiance(opts client.Options) (*Radiance, error) {
 	reporting.Init()
 	if opts.DataDir == "" {
-		return nil, fmt.Errorf("dataDir is required")
+		opts.DataDir = appdir.General(app.Name)
 	}
 	if opts.LogDir == "" {
 		opts.LogDir = appdir.Logs(app.Name)

--- a/radiance.go
+++ b/radiance.go
@@ -73,15 +73,17 @@ type Radiance struct {
 // can be nil.
 func NewRadiance(opts client.Options) (*Radiance, error) {
 	reporting.Init()
-
-	dataDirPath, logDir, err := setupDirs(opts.DataDir)
-	if err != nil {
-		return nil, fmt.Errorf("failed to setup directories: %w", err)
+	if opts.DataDir == "" {
+		return nil, fmt.Errorf("dataDir is required")
 	}
+	if opts.LogDir == "" {
+		opts.LogDir = appdir.Logs(app.Name)
+	}
+	mkdirs(&opts)
 
-	logPath := filepath.Join(logDir, app.LogFileName)
 	var logWriter io.Writer
-	log, logWriter, err = newLog(logPath)
+	var err error
+	log, logWriter, err = newLog(filepath.Join(opts.LogDir, app.LogFileName))
 	if err != nil {
 		return nil, fmt.Errorf("could not create log: %w", err)
 	}
@@ -94,8 +96,6 @@ func NewRadiance(opts client.Options) (*Radiance, error) {
 		log.Debug("Setup OpenTelemetry SDK", "shutdown", shutdownMetrics)
 	}
 
-	opts.DataDir = dataDirPath
-	opts.LogDir = logDir
 	vpnC, err := client.NewVPNClient(opts)
 	if err != nil {
 		log.Error("Failed to create VPN client", "error", err)
@@ -103,7 +103,7 @@ func NewRadiance(opts client.Options) (*Radiance, error) {
 	}
 
 	// TODO: Ideally we would know the user locale to set the country on fronted startup.
-	f, err := newFronted(logWriter, reporting.PanicListener, filepath.Join(dataDirPath, "fronted_cache.json"))
+	f, err := newFronted(logWriter, reporting.PanicListener, filepath.Join(opts.DataDir, "fronted_cache.json"))
 	if err != nil {
 		log.Error("Failed to create fronted", "error", err)
 		return nil, fmt.Errorf("failed to create fronted: %w", err)
@@ -119,7 +119,7 @@ func NewRadiance(opts client.Options) (*Radiance, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create issue reporter: %w", err)
 	}
-	confHandler := config.NewConfigHandler(configPollInterval, k.NewHTTPClient(), u, dataDirPath, vpnC.ParseConfig)
+	confHandler := config.NewConfigHandler(configPollInterval, k.NewHTTPClient(), u, opts.DataDir, vpnC.ParseConfig)
 	confHandler.AddConfigListener(vpnC.OnNewConfig)
 
 	return &Radiance{
@@ -129,7 +129,7 @@ func NewRadiance(opts client.Options) (*Radiance, error) {
 		stopChan:      make(chan struct{}),
 		user:          u,
 		issueReporter: issueReporter,
-		logsDir:       logDir,
+		logsDir:       opts.LogDir,
 		shutdownFuncs: shutdownFuncs,
 	}, nil
 }
@@ -247,17 +247,13 @@ func (r *Radiance) ReportIssue(email string, report *IssueReport) error {
 		country)
 }
 
-func setupDirs(baseDir string) (dataDir, logDir string, err error) {
-	// On Windows, Mac, and Linux, we can easily determine the user directories in Go. Typically mobile will have
-	// to pass the base directory to use.
-	if baseDir == "" {
-		return appdir.General(app.Name), appdir.Logs(app.Name), nil
+func mkdirs(opts *client.Options) {
+	// Make sure the data and logs dirs exist
+	for _, dir := range []string{opts.DataDir, opts.LogDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			log.Error("Failed to create data directory", "dir", dir, "error", err)
+		}
 	}
-	logDir = filepath.Join(baseDir, "logs")
-	if err := os.MkdirAll(logDir, 0o755); err != nil {
-		return "", "", fmt.Errorf("failed to setup data directory: %w", err)
-	}
-	return baseDir, logDir, nil
 }
 
 // Return an slog logger configured to write to both stdout and the log file.

--- a/radiance_test.go
+++ b/radiance_test.go
@@ -1,7 +1,6 @@
 package radiance
 
 import (
-	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -105,29 +104,7 @@ func TestReportIssue(t *testing.T) {
 		})
 	}
 }
-func TestSetupDirs(t *testing.T) {
-	t.Run("it should return default directories when baseDir is empty", func(t *testing.T) {
-		dataDir, logDir, err := setupDirs("")
-		assert.NoError(t, err)
-		assert.NotEmpty(t, dataDir)
-		assert.NotEmpty(t, logDir)
-	})
 
-	t.Run("it should create and return directories when baseDir is provided", func(t *testing.T) {
-		baseDir := t.TempDir()
-		dataDir, logDir, err := setupDirs(baseDir)
-		assert.NoError(t, err)
-		assert.Equal(t, baseDir, dataDir)
-		assert.Equal(t, filepath.Join(baseDir, "logs"), logDir)
-		assert.DirExists(t, logDir)
-	})
-
-	t.Run("it should return error when it fails to create directories", func(t *testing.T) {
-		baseDir := "/invalid/path"
-		_, _, err := setupDirs(baseDir)
-		assert.Error(t, err)
-	})
-}
 func TestGetActiveServer(t *testing.T) {
 	t.Run("it should return error when VPN is not connected", func(t *testing.T) {
 		mockClient := &mockVPNClient{}


### PR DESCRIPTION
This honors the log directory passed into options on radiance creation and uses the new config endpoint.