### PR TITLE
IOS cleanup

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -10,6 +10,7 @@ import (
 type APIHandler struct {
 	User      *User
 	ProServer *Pro
+	UserInfo  common.UserInfo
 }
 
 func NewAPIHandlerInternal(httpClient *http.Client, userinfo common.UserInfo) *APIHandler {
@@ -18,5 +19,6 @@ func NewAPIHandlerInternal(httpClient *http.Client, userinfo common.UserInfo) *A
 	return &APIHandler{
 		User:      u,
 		ProServer: pro,
+		UserInfo:  userinfo,
 	}
 }

--- a/api/api.go
+++ b/api/api.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/getlantern/radiance/common"
+)
+
+// APIHandler is a struct that contains the API clients for User and Pro.
+type APIHandler struct {
+	User      *User
+	ProServer *Pro
+}
+
+func NewAPIHandlerInternal(httpClient *http.Client, userinfo common.UserInfo) *APIHandler {
+	u := NewUser(httpClient, userinfo)
+	pro := NewPro(httpClient, userinfo)
+	return &APIHandler{
+		User:      u,
+		ProServer: pro,
+	}
+}

--- a/client/service/service.go
+++ b/client/service/service.go
@@ -28,10 +28,9 @@ import (
 	"github.com/sagernet/sing/service"
 	"github.com/sagernet/sing/service/pause"
 
+	"github.com/getlantern/radiance/config"
 	"github.com/getlantern/sing-box-extensions/protocol"
 	"github.com/getlantern/sing-box-extensions/ruleset"
-
-	"github.com/getlantern/radiance/config"
 )
 
 // BoxService is a wrapper around libbox.BoxService

--- a/init.go
+++ b/init.go
@@ -34,9 +34,11 @@ type sharedConfig struct {
 }
 
 // initCommon initializes the common configuration for the Radiance client and API handler.
-func InitCommon(opts client.Options) (*sharedConfig, error) {
+func initialize(opts client.Options) (*sharedConfig, error) {
 	var err error
+
 	sharedInitOnce.Do(func() {
+
 		reporting.Init()
 		if opts.DataDir == "" {
 			opts.DataDir = appdir.General(app.Name)
@@ -62,9 +64,11 @@ func InitCommon(opts client.Options) (*sharedConfig, error) {
 			err = fmt.Errorf("could not create log: %w", err)
 			return
 		}
+			
+		
 		f, ferr := newFronted(logWriter, reporting.PanicListener, filepath.Join(opts.DataDir, "fronted_cache.json"))
 		if ferr != nil {
-			err = fmt.Errorf("failed to create fronted: %w", err)
+			err = fmt.Errorf("failed to create fronted: %w", ferr)
 			return
 		}
 
@@ -79,6 +83,7 @@ func InitCommon(opts client.Options) (*sharedConfig, error) {
 			userConfig: common.NewUserConfig(platformDeviceID, opts.DataDir, opts.Locale),
 			kindling:   k,
 		}
+		log.Debug("Initialized shared config", "dataDir", opts.DataDir, "logDir", opts.LogDir, "locale", opts.Locale)
 	})
 	return sharedInit, err
 

--- a/init.go
+++ b/init.go
@@ -1,0 +1,135 @@
+package radiance
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/getlantern/appdir"
+	"github.com/getlantern/fronted"
+	"github.com/getlantern/kindling"
+	"github.com/getlantern/radiance/app"
+	"github.com/getlantern/radiance/client"
+	"github.com/getlantern/radiance/common"
+	"github.com/getlantern/radiance/common/deviceid"
+	"github.com/getlantern/radiance/common/reporting"
+)
+
+var (
+	sharedInitOnce sync.Once
+	sharedInit     *sharedConfig
+)
+var log *slog.Logger
+
+// sharedConfig is a struct that contains the shared configuration for the Radiance client and API handler.
+type sharedConfig struct {
+	logWriter  io.Writer
+	userConfig common.UserInfo
+	kindling   kindling.Kindling
+}
+
+// initCommon initializes the common configuration for the Radiance client and API handler.
+func InitCommon(opts client.Options) (*sharedConfig, error) {
+	var err error
+	sharedInitOnce.Do(func() {
+		reporting.Init()
+		if opts.DataDir == "" {
+			opts.DataDir = appdir.General(app.Name)
+		}
+		if opts.LogDir == "" {
+			opts.LogDir = appdir.Logs(app.Name)
+		}
+		if opts.Locale == "" {
+			opts.Locale = "en-US"
+		}
+
+		var platformDeviceID string
+		if common.IsAndroid() || common.IsIOS() {
+			platformDeviceID = opts.DeviceID
+		} else {
+			platformDeviceID = deviceid.Get()
+		}
+
+		mkdirs(&opts)
+		var logWriter io.Writer
+		log, logWriter, err = newLog(filepath.Join(opts.LogDir, app.LogFileName))
+		if err != nil {
+			err = fmt.Errorf("could not create log: %w", err)
+			return
+		}
+		f, ferr := newFronted(logWriter, reporting.PanicListener, filepath.Join(opts.DataDir, "fronted_cache.json"))
+		if ferr != nil {
+			err = fmt.Errorf("failed to create fronted: %w", err)
+			return
+		}
+
+		k := kindling.NewKindling(
+			kindling.WithPanicListener(reporting.PanicListener),
+			kindling.WithLogWriter(logWriter),
+			kindling.WithDomainFronting(f),
+			kindling.WithProxyless("api.iantem.io"))
+
+		sharedInit = &sharedConfig{
+			logWriter:  logWriter,
+			userConfig: common.NewUserConfig(platformDeviceID, opts.DataDir, opts.Locale),
+			kindling:   k,
+		}
+	})
+	return sharedInit, err
+
+}
+
+func mkdirs(opts *client.Options) {
+	// Make sure the data and logs dirs exist
+	for _, dir := range []string{opts.DataDir, opts.LogDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			log.Error("Failed to create data directory", "dir", dir, "error", err)
+		}
+	}
+}
+
+// Return an slog logger configured to write to both stdout and the log file.
+func newLog(logPath string) (*slog.Logger, io.Writer, error) {
+	// If the log file does not exist, create it.
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to open log file: %w", err)
+	}
+	// defer f.Close() - file should be closed externally when logger is no longer needed
+	logWriter := io.MultiWriter(os.Stdout, f)
+	logger := slog.New(slog.NewTextHandler(logWriter, nil))
+	slog.SetDefault(logger)
+	return logger, logWriter, nil
+}
+
+func newFronted(logWriter io.Writer, panicListener func(string), cacheFile string) (fronted.Fronted, error) {
+	// Parse the domain from the URL.
+	configURL := "https://raw.githubusercontent.com/getlantern/lantern-binaries/refs/heads/main/fronted.yaml.gz"
+	u, err := url.Parse(configURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse URL: %v", err)
+	}
+	// Extract the domain from the URL.
+	domain := u.Host
+
+	// First, download the file from the specified URL using the smart dialer.
+	// Then, create a new fronted instance with the downloaded file.
+	trans, err := kindling.NewSmartHTTPTransport(logWriter, domain)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create smart HTTP transport: %v", err)
+	}
+	httpClient := &http.Client{
+		Transport: trans,
+	}
+	return fronted.NewFronted(
+		fronted.WithPanicListener(panicListener),
+		fronted.WithCacheFile(cacheFile),
+		fronted.WithHTTPClient(httpClient),
+		fronted.WithConfigURL(configURL),
+	), nil
+}

--- a/init_test.go
+++ b/init_test.go
@@ -1,0 +1,24 @@
+package radiance
+
+import (
+	"testing"
+
+	"github.com/getlantern/radiance/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitialize(t *testing.T) {
+	opts := client.Options{
+		DataDir:  "/tmp/data",
+		LogDir:   "/tmp/logs",
+		Locale:   "en-US",
+		DeviceID: "test-device-id",
+	}
+	_, err := initialize(opts)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, sharedInit)
+	newShared, ierr := initialize(opts)
+	assert.NoError(t, ierr)
+	assert.Equal(t, sharedInit, newShared)
+}

--- a/issue/issue.go
+++ b/issue/issue.go
@@ -13,6 +13,7 @@ import (
 	"github.com/getlantern/golog"
 	"github.com/getlantern/jibber_jabber"
 	"github.com/getlantern/osversion"
+
 	"github.com/getlantern/radiance/api"
 	"github.com/getlantern/radiance/app"
 	"github.com/getlantern/radiance/backend"

--- a/radiance.go
+++ b/radiance.go
@@ -114,8 +114,8 @@ func NewAPIHandler(opts client.Options) (*api.APIHandler, error) {
 	return apiHandler, nil
 }
 
-// TODO: the server stuff should probably be moved to the VPNClient as well..
-// eventual this will be moved to the api handler as well
+// TODO: The server-related functionality should probably be moved to the VPNClient as well.
+// Eventually, this functionality will be moved to the API handler for better separation of concerns.
 func (r *Radiance) GetAvailableServers() ([]C.ServerLocation, error) {
 	return r.confHandler.ListAvailableServers()
 }

--- a/radiance.go
+++ b/radiance.go
@@ -25,6 +25,7 @@ import (
 	"github.com/getlantern/radiance/app"
 	"github.com/getlantern/radiance/client"
 	"github.com/getlantern/radiance/common"
+	"github.com/getlantern/radiance/common/deviceid"
 	"github.com/getlantern/radiance/common/reporting"
 	"github.com/getlantern/radiance/config"
 	"github.com/getlantern/radiance/issue"
@@ -159,6 +160,17 @@ func initCommon(opts client.Options) (*sharedConfig, error) {
 		if opts.LogDir == "" {
 			opts.LogDir = appdir.Logs(app.Name)
 		}
+		if opts.Locale == "" {
+			opts.Locale = "en-US"
+		}
+
+		var platformDeviceID string
+		if common.IsAndroid() || common.IsIOS() {
+			platformDeviceID = opts.DeviceID
+		} else {
+			platformDeviceID = deviceid.Get()
+		}
+
 		mkdirs(&opts)
 		var logWriter io.Writer
 		log, logWriter, err = newLog(filepath.Join(opts.LogDir, app.LogFileName))
@@ -172,10 +184,6 @@ func initCommon(opts client.Options) (*sharedConfig, error) {
 			return
 		}
 		// If no local setup from client options, use the default locale
-		if opts.Locale == "" {
-			log.Debug("Locale not set, using default en-US")
-			opts.Locale = "en-US"
-		}
 
 		k := kindling.NewKindling(
 			kindling.WithPanicListener(reporting.PanicListener),
@@ -185,7 +193,7 @@ func initCommon(opts client.Options) (*sharedConfig, error) {
 
 		sharedInit = &sharedConfig{
 			logWriter:  logWriter,
-			userConfig: common.NewUserConfig(opts.DeviceID, opts.DataDir, opts.DataDir),
+			userConfig: common.NewUserConfig(platformDeviceID, opts.DataDir, opts.Locale),
 			kindling:   k,
 		}
 	})

--- a/radiance.go
+++ b/radiance.go
@@ -61,7 +61,7 @@ type Radiance struct {
 // interact with the underlying platform on iOS and Android. On other platforms, it is ignored and
 // can be nil.
 func NewRadiance(opts client.Options) (*Radiance, error) {
-	init, err := InitCommon(opts)
+	init, err := initialize(opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize common: %w", err)
 	}
@@ -101,12 +101,10 @@ func NewRadiance(opts client.Options) (*Radiance, error) {
 }
 
 // NewAPIHandler creates a new APIHandler instance. This is used to interact with the API.
-// The User and Pro fields are API clients used to communicate with the respective endpoints.
-//
-// Note: This separation is necessary because the iOS tunnel runs in a different isolated process.
-// and we need access to the API in the main process.
 func NewAPIHandler(opts client.Options) (*api.APIHandler, error) {
-	init, err := InitCommon(opts)
+	// Note: This separation is necessary because the iOS tunnel runs in a different isolated process.
+	// and we need access to the API in the main process.
+	init, err := initialize(opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize common: %w", err)
 	}

--- a/radiance_test.go
+++ b/radiance_test.go
@@ -23,7 +23,6 @@ func TestNewRadiance(t *testing.T) {
 		assert.NotNil(t, r.confHandler)
 		assert.NotNil(t, r.activeServer)
 		assert.NotNil(t, r.stopChan)
-		assert.NotNil(t, r.user)
 		assert.NotNil(t, r.issueReporter)
 	})
 }

--- a/radiance_test.go
+++ b/radiance_test.go
@@ -30,8 +30,8 @@ func TestNewRadiance(t *testing.T) {
 func TestNewAPIHandler(t *testing.T) {
 	t.Run("it should create a new APIHandler instance successfully", func(t *testing.T) {
 		h, err := NewAPIHandler(client.Options{DataDir: t.TempDir()})
-		assert.NotNil(t, h)
 		assert.NoError(t, err)
+		assert.NotNil(t, h)
 		assert.NotNil(t, h.ProServer)
 		assert.NotNil(t, h.User)
 

--- a/radiance_test.go
+++ b/radiance_test.go
@@ -27,6 +27,17 @@ func TestNewRadiance(t *testing.T) {
 	})
 }
 
+func TestNewAPIHandler(t *testing.T) {
+	t.Run("it should create a new APIHandler instance successfully", func(t *testing.T) {
+		h, err := NewAPIHandler(client.Options{DataDir: t.TempDir()})
+		assert.NotNil(t, h)
+		assert.NoError(t, err)
+		assert.NotNil(t, h.ProServer)
+		assert.NotNil(t, h.User)
+
+	})
+}
+
 type mockVPNClient struct {
 	mock.Mock
 }


### PR DESCRIPTION
**Problem:**

Upon app startup, we need to make several API calls. However, due to the separation of the Radiance processes, these calls cannot be made on iOS, as Radiance runs in a completely isolated process.

**Solution (for now):**

I have exposed a new `NewAPIHandler` that provides access to all the required APIs, which can be invoked without Radiance set up. To minimize duplication, I've tried to reuse as much code as possible, given that on other platforms, we can run in the same process and avoid the isolation issues.

I'm open to suggestions for a better solution.

**Copilot Summary**

This pull request refactors the `Radiance` initialization process to improve code modularity and reusability. It introduces a shared configuration structure (`sharedConfig`) and a new `APIHandler` type, consolidating common initialization logic into a dedicated function (`initCommon`). Additionally, it removes redundant fields and methods from the `Radiance` struct, simplifying its design.

### Refactoring for Code Modularity:
* Introduced a `sharedConfig` struct to centralize shared configuration for the `Radiance` client and the new `APIHandler`, including `logWriter`, `userConfig`, and `kindling`. (`radiance.go`, [radiance.goR58-L67](diffhunk://#diff-60179a9bacb28016fc7cda79abcad6f09a5c467689999b56f2c6e0cb3d94140cR58-L67))
* Added a new `initCommon` function to handle shared initialization logic, such as setting up logging, locale, and `kindling`. This function ensures consistent setup across components. (`radiance.go`, [radiance.goL111-R205](diffhunk://#diff-60179a9bacb28016fc7cda79abcad6f09a5c467689999b56f2c6e0cb3d94140cL111-R205))

### Introduction of `APIHandler`:
* Created a new `APIHandler` type to manage API clients (`User` and `ProServer`) separately from the `Radiance` struct. This separation supports isolated processes, such as those on iOS. (`radiance.go`, [radiance.goL111-R205](diffhunk://#diff-60179a9bacb28016fc7cda79abcad6f09a5c467689999b56f2c6e0cb3d94140cL111-R205))
* Added a `NewAPIHandler` constructor to initialize `APIHandler` instances using the shared configuration. (`radiance.go`, [radiance.goL111-R205](diffhunk://#diff-60179a9bacb28016fc7cda79abcad6f09a5c467689999b56f2c6e0cb3d94140cL111-R205))

### Simplification of `Radiance` Struct:
* Removed `user` and `pro` fields from the `Radiance` struct and their associated getter methods (`User` and `Pro`), as these are now managed by `APIHandler`. (`radiance.go`, [radiance.goL206-L215](diffhunk://#diff-60179a9bacb28016fc7cda79abcad6f09a5c467689999b56f2c6e0cb3d94140cL206-L215))
* Updated `NewRadiance` to use the shared configuration (`sharedConfig`) for initializing components like `confHandler` and `issueReporter`. (`radiance.go`, [radiance.goL81-R98](diffhunk://#diff-60179a9bacb28016fc7cda79abcad6f09a5c467689999b56f2c6e0cb3d94140cL81-R98))

### Testing Enhancements:
* Added a new unit test for the `NewAPIHandler` function to ensure successful creation of `APIHandler` instances. (`radiance_test.go`, [radiance_test.goL26-R40](diffhunk://#diff-4eae5a1a18f88a43177d673d3eefdd1164553dd71501c5c842275b56fc153c84L26-R40))