### PR TITLE
Use new config request format

### DIFF
--- a/backend/headers.go
+++ b/backend/headers.go
@@ -6,11 +6,9 @@ import (
 	"io"
 	"math/big"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/getlantern/radiance/app"
-	"github.com/getlantern/radiance/user"
 	"github.com/getlantern/timezone"
 )
 
@@ -28,24 +26,20 @@ const (
 )
 
 // NewRequestWithHeaders creates a new [http.Request] with the required headers.
-func NewRequestWithHeaders(ctx context.Context, method, url string, body io.Reader, user user.BaseUser) (*http.Request, error) {
+func NewRequestWithHeaders(ctx context.Context, method, url string, body io.Reader) (*http.Request, error) {
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("User-Agent", "Lantern/"+app.ClientVersion)
+
 	// add required headers. Currently, all but the auth token are placeholders.
-	req.Header.Set(appVersionHeader, app.ClientVersion)
-	req.Header.Set(versionHeader, app.Version)
-	req.Header.Set(userIDHeader, strconv.FormatInt(user.LegacyID(), 10))
-	req.Header.Set(platformHeader, app.Platform)
-	req.Header.Set(appNameHeader, app.Name)
-	req.Header.Set(deviceIDHeader, user.DeviceID())
 	return req, nil
 }
 
 // NewIssueRequest creates a new HTTP request with the required headers for issue reporting.
-func NewIssueRequest(ctx context.Context, method, url string, body io.Reader, user user.BaseUser) (*http.Request, error) {
-	req, err := NewRequestWithHeaders(ctx, method, url, body, user)
+func NewIssueRequest(ctx context.Context, method, url string, body io.Reader) (*http.Request, error) {
+	req, err := NewRequestWithHeaders(ctx, method, url, body)
 	if err != nil {
 		return nil, err
 	}

--- a/config/fetcher.go
+++ b/config/fetcher.go
@@ -51,13 +51,12 @@ func newFetcher(client *http.Client, user user.BaseUser) Fetcher {
 // fetchConfig fetches the configuration from the server. Nil is returned if no new config is available.
 func (f *fetcher) fetchConfig(preferred C.ServerLocation) ([]byte, error) {
 	confReq := C.ConfigRequest{
-		ClientVersion:     app.ClientVersion,
 		SingboxVersion:    singVersion(),
 		UserID:            strconv.FormatInt(f.user.LegacyID(), 10),
 		OS:                app.Platform,
 		AppName:           app.Name,
 		DeviceID:          f.user.DeviceID(),
-		PreferredLocation: preferred,
+		PreferredLocation: &preferred,
 	}
 	buf, err := json.Marshal(&confReq)
 	if err != nil {
@@ -80,7 +79,7 @@ func (f *fetcher) fetchConfig(preferred C.ServerLocation) ([]byte, error) {
 
 // send sends a request to the server with the given body and returns the response.
 func (f *fetcher) send(body io.Reader) ([]byte, error) {
-	req, err := backend.NewRequestWithHeaders(context.Background(), http.MethodPost, configURL, body, f.user)
+	req, err := backend.NewRequestWithHeaders(context.Background(), http.MethodPost, configURL, body)
 	if err != nil {
 		return nil, fmt.Errorf("could not create request: %w", err)
 	}

--- a/config/fetcher.go
+++ b/config/fetcher.go
@@ -15,6 +15,7 @@ import (
 
 	"slices"
 
+	"github.com/getlantern/common"
 	C "github.com/getlantern/common"
 	"github.com/getlantern/radiance/app"
 	"github.com/getlantern/radiance/backend"
@@ -57,6 +58,7 @@ func (f *fetcher) fetchConfig(preferred C.ServerLocation) ([]byte, error) {
 		AppName:           app.Name,
 		DeviceID:          f.user.DeviceID(),
 		PreferredLocation: &preferred,
+		Backend:           common.SINGBOX,
 	}
 	buf, err := json.Marshal(&confReq)
 	if err != nil {

--- a/config/fetcher_test.go
+++ b/config/fetcher_test.go
@@ -119,7 +119,6 @@ func TestFetchConfig(t *testing.T) {
 				err = json.Unmarshal(body, &confReq)
 				require.NoError(t, err)
 
-				assert.Equal(t, app.ClientVersion, confReq.ClientVersion)
 				assert.Equal(t, strconv.FormatInt(mockUser.LegacyID(), 10), confReq.UserID)
 				assert.Equal(t, app.Platform, confReq.OS)
 				assert.Equal(t, app.Name, confReq.AppName)

--- a/config/fetcher_test.go
+++ b/config/fetcher_test.go
@@ -124,7 +124,7 @@ func TestFetchConfig(t *testing.T) {
 				assert.Equal(t, app.Name, confReq.AppName)
 				assert.Equal(t, mockUser.DeviceID(), confReq.DeviceID)
 				if tt.preferredServerLoc != nil {
-					assert.Equal(t, *tt.preferredServerLoc, confReq.PreferredLocation)
+					assert.Equal(t, tt.preferredServerLoc, confReq.PreferredLocation)
 				}
 			}
 		})

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ replace github.com/sagernet/wireguard-go => github.com/getlantern/wireguard-go v
 require (
 	github.com/1Password/srp v0.2.0
 	github.com/getlantern/appdir v0.0.0-20250324200952-507a0625eb01
-	github.com/getlantern/common v1.2.1-0.20250404213255-37d58e3e0fae
+	github.com/getlantern/common v1.2.1-0.20250425195451-a144eeeb624f
 	github.com/getlantern/fronted v0.0.0-20250330001402-75899df1c2cd
 	github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65
 	github.com/getlantern/jibber_jabber v0.0.0-20210901195950-68955124cc42

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ replace github.com/sagernet/wireguard-go => github.com/getlantern/wireguard-go v
 require (
 	github.com/1Password/srp v0.2.0
 	github.com/getlantern/appdir v0.0.0-20250324200952-507a0625eb01
-	github.com/getlantern/common v1.2.1-0.20250425202034-b7b1907c0c8c
+	github.com/getlantern/common v1.2.1-0.20250425211416-ce0caf588106
 	github.com/getlantern/fronted v0.0.0-20250330001402-75899df1c2cd
 	github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65
 	github.com/getlantern/jibber_jabber v0.0.0-20210901195950-68955124cc42

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ replace github.com/sagernet/wireguard-go => github.com/getlantern/wireguard-go v
 require (
 	github.com/1Password/srp v0.2.0
 	github.com/getlantern/appdir v0.0.0-20250324200952-507a0625eb01
-	github.com/getlantern/common v1.2.1-0.20250425195451-a144eeeb624f
+	github.com/getlantern/common v1.2.1-0.20250425202034-b7b1907c0c8c
 	github.com/getlantern/fronted v0.0.0-20250330001402-75899df1c2cd
 	github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65
 	github.com/getlantern/jibber_jabber v0.0.0-20210901195950-68955124cc42

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/getlantern/appdir v0.0.0-20250324200952-507a0625eb01/go.mod h1:3vR6+j
 github.com/getlantern/byteexec v0.0.0-20170405023437-4cfb26ec74f4/go.mod h1:4WCQkaCIwta0KlF9bQZA1jYqp8bzIS2PeCqjnef8nZ8=
 github.com/getlantern/byteexec v0.0.0-20220903142956-e6ed20032cfd h1:0xt9OTbV50a/+ZarMcr86ybWiN1v+bbwzdnVuXHzR/o=
 github.com/getlantern/byteexec v0.0.0-20220903142956-e6ed20032cfd/go.mod h1:oD9q9NB1LNBLHk3WAwza4tivxV7tm7jKFlCNCAv3+M8=
-github.com/getlantern/common v1.2.1-0.20250425202034-b7b1907c0c8c h1:HR5GJLZHlNNL60OlY4/yUuorAjeheD/8yqu68TVt+uk=
-github.com/getlantern/common v1.2.1-0.20250425202034-b7b1907c0c8c/go.mod h1:ucQSLeHpC4ns6VvlWBinK7BI8LrUWlhZUHArs6VRvXI=
+github.com/getlantern/common v1.2.1-0.20250425211416-ce0caf588106 h1:C5uVnt2aocxC7E3xUxn0M3olo+spc+f8uyEvyw5PQ0Y=
+github.com/getlantern/common v1.2.1-0.20250425211416-ce0caf588106/go.mod h1:ucQSLeHpC4ns6VvlWBinK7BI8LrUWlhZUHArs6VRvXI=
 github.com/getlantern/context v0.0.0-20190109183933-c447772a6520/go.mod h1:L+mq6/vvYHKjCX2oez0CgEAJmbq1fbb/oNJIWQkBybY=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/getlantern/appdir v0.0.0-20250324200952-507a0625eb01/go.mod h1:3vR6+j
 github.com/getlantern/byteexec v0.0.0-20170405023437-4cfb26ec74f4/go.mod h1:4WCQkaCIwta0KlF9bQZA1jYqp8bzIS2PeCqjnef8nZ8=
 github.com/getlantern/byteexec v0.0.0-20220903142956-e6ed20032cfd h1:0xt9OTbV50a/+ZarMcr86ybWiN1v+bbwzdnVuXHzR/o=
 github.com/getlantern/byteexec v0.0.0-20220903142956-e6ed20032cfd/go.mod h1:oD9q9NB1LNBLHk3WAwza4tivxV7tm7jKFlCNCAv3+M8=
-github.com/getlantern/common v1.2.1-0.20250404213255-37d58e3e0fae h1:uRuUGf1TgBRCWelqxKC1aa7gqTsQ6u4dPwMyRGDZ5x4=
-github.com/getlantern/common v1.2.1-0.20250404213255-37d58e3e0fae/go.mod h1:ucQSLeHpC4ns6VvlWBinK7BI8LrUWlhZUHArs6VRvXI=
+github.com/getlantern/common v1.2.1-0.20250425195451-a144eeeb624f h1:goAFvC8aHsNqKEG9MzimLSQ34aSve5og1gryySezmOE=
+github.com/getlantern/common v1.2.1-0.20250425195451-a144eeeb624f/go.mod h1:ucQSLeHpC4ns6VvlWBinK7BI8LrUWlhZUHArs6VRvXI=
 github.com/getlantern/context v0.0.0-20190109183933-c447772a6520/go.mod h1:L+mq6/vvYHKjCX2oez0CgEAJmbq1fbb/oNJIWQkBybY=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/getlantern/appdir v0.0.0-20250324200952-507a0625eb01/go.mod h1:3vR6+j
 github.com/getlantern/byteexec v0.0.0-20170405023437-4cfb26ec74f4/go.mod h1:4WCQkaCIwta0KlF9bQZA1jYqp8bzIS2PeCqjnef8nZ8=
 github.com/getlantern/byteexec v0.0.0-20220903142956-e6ed20032cfd h1:0xt9OTbV50a/+ZarMcr86ybWiN1v+bbwzdnVuXHzR/o=
 github.com/getlantern/byteexec v0.0.0-20220903142956-e6ed20032cfd/go.mod h1:oD9q9NB1LNBLHk3WAwza4tivxV7tm7jKFlCNCAv3+M8=
-github.com/getlantern/common v1.2.1-0.20250425195451-a144eeeb624f h1:goAFvC8aHsNqKEG9MzimLSQ34aSve5og1gryySezmOE=
-github.com/getlantern/common v1.2.1-0.20250425195451-a144eeeb624f/go.mod h1:ucQSLeHpC4ns6VvlWBinK7BI8LrUWlhZUHArs6VRvXI=
+github.com/getlantern/common v1.2.1-0.20250425202034-b7b1907c0c8c h1:HR5GJLZHlNNL60OlY4/yUuorAjeheD/8yqu68TVt+uk=
+github.com/getlantern/common v1.2.1-0.20250425202034-b7b1907c0c8c/go.mod h1:ucQSLeHpC4ns6VvlWBinK7BI8LrUWlhZUHArs6VRvXI=
 github.com/getlantern/context v0.0.0-20190109183933-c447772a6520/go.mod h1:L+mq6/vvYHKjCX2oez0CgEAJmbq1fbb/oNJIWQkBybY=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=

--- a/issue/issue.go
+++ b/issue/issue.go
@@ -145,7 +145,7 @@ func (ir *IssueReporter) Report(
 		return err
 	}
 
-	req, err := backend.NewIssueRequest(context.Background(), http.MethodPost, requestURL, bytes.NewReader(out), ir.user)
+	req, err := backend.NewIssueRequest(context.Background(), http.MethodPost, requestURL, bytes.NewReader(out))
 	if err != nil {
 		return log.Errorf("creating request: %w", err)
 	}


### PR DESCRIPTION
This pull request refactors the handling of user-related headers and configuration data in HTTP requests by removing the dependency on the `user.BaseUser` type across multiple functions. It simplifies the codebase by consolidating header logic and reducing parameter dependencies. Additionally, it updates the `go.mod` file to use a newer version of the `github.com/getlantern/common` library.

### Refactoring HTTP Request Header Handling:
* Removed the `user.BaseUser` parameter from `NewRequestWithHeaders` and `NewIssueRequest` functions in `backend/headers.go`. User-related headers such as `userIDHeader` and `deviceIDHeader` were removed, and a simplified `User-Agent` header was added instead. (`[backend/headers.goL31-R42](diffhunk://#diff-e07fb405996bcf124cc1c767f6851c1f8ff05caee363cdd6de36cfb9ab43c574L31-R42)`)
* Updated the `fetchConfig` method in `config/fetcher.go` to remove the `ClientVersion` field from the configuration request and adjusted the `send` method to align with the updated `NewRequestWithHeaders` function. (`[[1]](diffhunk://#diff-7a29ad907addd7ddb75133a0c5098cc474b34f725c8fb7baff6c2f6708fe494fL54-R59)`, `[[2]](diffhunk://#diff-7a29ad907addd7ddb75133a0c5098cc474b34f725c8fb7baff6c2f6708fe494fL83-R82)`)
* Modified the `Report` method in `issue/issue.go` to stop passing `user.BaseUser` to `NewIssueRequest`. (`[issue/issue.goL148-R148](diffhunk://#diff-78cb896736d386aba49a1e1f0edb2d2b36f0ea8a28051dac625f7bf58d4242c7L148-R148)`)

### Test Updates:
* Adjusted the `TestFetchConfig` test in `config/fetcher_test.go` to remove assertions for the `ClientVersion` field, reflecting its removal from the configuration request. (`[config/fetcher_test.goL122](diffhunk://#diff-7ba16797e42350c53b41e8b4cab7b67d7922c2ff020cf022e2c2b08566fe08daL122)`)

### Dependency Update:
* Updated the `github.com/getlantern/common` dependency in `go.mod` to a newer version (`v1.2.1-0.20250425195451-a144eeeb624f`). (`[go.modL17-R17](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L17-R17)`)