### PR TITLE
Pass locale in config requests

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -34,6 +34,10 @@ type Options struct {
 	PlatIfce libbox.PlatformInterface
 	// EnableSplitTunneling is the initial state of split tunneling when the service starts
 	EnableSplitTunneling bool
+
+	// Frontend frameworks typically have the most reliable access to the user's locale,
+	// so we use that to determine the user's locale.
+	Locale string
 }
 
 type VPNClient interface {

--- a/config/config.go
+++ b/config/config.go
@@ -66,7 +66,7 @@ type ConfigHandler struct {
 
 // NewConfigHandler creates a new ConfigHandler that fetches the proxy configuration every pollInterval.
 func NewConfigHandler(pollInterval time.Duration, httpClient *http.Client, user user.BaseUser, dataDir string,
-	configParser Unmarshaller) *ConfigHandler {
+	configParser Unmarshaller, locale string) *ConfigHandler {
 	configPath := filepath.Join(dataDir, configFileName)
 	ch := &ConfigHandler{
 		config:          atomic.Value{},
@@ -82,7 +82,7 @@ func NewConfigHandler(pollInterval time.Duration, httpClient *http.Client, user 
 		slog.Error("failed to load config", "error", err)
 	}
 
-	ch.ftr = newFetcher(httpClient, user)
+	ch.ftr = newFetcher(httpClient, user, locale)
 	go ch.fetchLoop(pollInterval)
 	return ch
 }
@@ -300,7 +300,7 @@ func (ch *ConfigHandler) saveConfig(cfg *Config) {
 func (ch *ConfigHandler) GetConfig() (*Config, error) {
 	cfgRes := ch.config.Load()
 	if cfgRes == nil {
-		return nil, fmt.Errorf("no config")
+		return nil, fmt.Errorf("no config yet -- first run?")
 	}
 	cfg, ok := cfgRes.(*Config)
 	if !ok || cfg == nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -111,7 +111,7 @@ func TestSetPreferredServerLocation(t *testing.T) {
 		configPath:   configPath,
 		configParser: mockConfigParser,
 		config:       atomic.Value{},
-		ftr:          newFetcher(http.DefaultClient, &UserStub{}),
+		ftr:          newFetcher(http.DefaultClient, &UserStub{}, "en-US"),
 	}
 
 	ch.config.Store(&Config{

--- a/config/fetcher.go
+++ b/config/fetcher.go
@@ -38,14 +38,16 @@ type fetcher struct {
 	httpClient   *http.Client
 	user         user.BaseUser
 	lastModified time.Time
+	locale       string
 }
 
 // newFetcher creates a new fetcher with the given http client.
-func newFetcher(client *http.Client, user user.BaseUser) Fetcher {
+func newFetcher(client *http.Client, user user.BaseUser, locale string) Fetcher {
 	return &fetcher{
 		httpClient:   client,
 		user:         user,
 		lastModified: time.Time{},
+		locale:       locale,
 	}
 }
 
@@ -59,6 +61,7 @@ func (f *fetcher) fetchConfig(preferred C.ServerLocation) ([]byte, error) {
 		DeviceID:          f.user.DeviceID(),
 		PreferredLocation: &preferred,
 		Backend:           common.SINGBOX,
+		Locale:            f.locale,
 	}
 	buf, err := json.Marshal(&confReq)
 	if err != nil {

--- a/config/fetcher_test.go
+++ b/config/fetcher_test.go
@@ -95,7 +95,7 @@ func TestFetchConfig(t *testing.T) {
 			}
 			fetcher := newFetcher(&http.Client{
 				Transport: mockRT,
-			}, mockUser)
+			}, mockUser, "en-US")
 
 			gotConfig, err := fetcher.fetchConfig(*tt.preferredServerLoc)
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ replace github.com/sagernet/wireguard-go => github.com/getlantern/wireguard-go v
 require (
 	github.com/1Password/srp v0.2.0
 	github.com/getlantern/appdir v0.0.0-20250324200952-507a0625eb01
-	github.com/getlantern/common v1.2.1-0.20250425211416-ce0caf588106
+	github.com/getlantern/common v1.2.1-0.20250428204107-678e5e36cbbf
 	github.com/getlantern/fronted v0.0.0-20250330001402-75899df1c2cd
 	github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65
 	github.com/getlantern/jibber_jabber v0.0.0-20210901195950-68955124cc42
@@ -69,6 +69,7 @@ require (
 
 require (
 	dario.cat/mergo v1.0.1
+	github.com/Xuanwo/go-locale v1.1.3
 	github.com/ajg/form v1.5.1 // indirect
 	github.com/andybalholm/brotli v1.1.0 // indirect
 	github.com/caddyserver/certmagic v0.21.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/Jigsaw-Code/outline-sdk v0.0.19 h1:/OpMz+3B/9ypjq/UyEvwZSflzJ4jXFginU
 github.com/Jigsaw-Code/outline-sdk v0.0.19/go.mod h1:CFDKyGZA4zatKE4vMLe8TyQpZCyINOeRFbMAmYHxodw=
 github.com/Jigsaw-Code/outline-sdk/x v0.0.2 h1:NUJwSzL2XdvmcVtoY9xwU6LwptI9kZOaVWI9kTMvVng=
 github.com/Jigsaw-Code/outline-sdk/x v0.0.2/go.mod h1:8vMQ+QKz62lVkUcPDc276yvopDreniYZQPvhqOn27b0=
+github.com/Xuanwo/go-locale v1.1.3 h1:EWZZJJt5rqPHHbqPRH1zFCn5D7xHjjebODctA4aUO3A=
+github.com/Xuanwo/go-locale v1.1.3/go.mod h1:REn+F/c+AtGSWYACBSYZgl23AP+0lfQC+SEFPN+hj30=
 github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/alitto/pond/v2 v2.1.5 h1:2pp/KAPcb02NSpHsjjnxnrTDzogMLsq+vFf/L0DB84A=
@@ -42,8 +44,8 @@ github.com/getlantern/appdir v0.0.0-20250324200952-507a0625eb01/go.mod h1:3vR6+j
 github.com/getlantern/byteexec v0.0.0-20170405023437-4cfb26ec74f4/go.mod h1:4WCQkaCIwta0KlF9bQZA1jYqp8bzIS2PeCqjnef8nZ8=
 github.com/getlantern/byteexec v0.0.0-20220903142956-e6ed20032cfd h1:0xt9OTbV50a/+ZarMcr86ybWiN1v+bbwzdnVuXHzR/o=
 github.com/getlantern/byteexec v0.0.0-20220903142956-e6ed20032cfd/go.mod h1:oD9q9NB1LNBLHk3WAwza4tivxV7tm7jKFlCNCAv3+M8=
-github.com/getlantern/common v1.2.1-0.20250425211416-ce0caf588106 h1:C5uVnt2aocxC7E3xUxn0M3olo+spc+f8uyEvyw5PQ0Y=
-github.com/getlantern/common v1.2.1-0.20250425211416-ce0caf588106/go.mod h1:ucQSLeHpC4ns6VvlWBinK7BI8LrUWlhZUHArs6VRvXI=
+github.com/getlantern/common v1.2.1-0.20250428204107-678e5e36cbbf h1:80UKl8jRxwJ6Tts6mOqxMIoAM0ioMAe4+Ax0aKdG/iY=
+github.com/getlantern/common v1.2.1-0.20250428204107-678e5e36cbbf/go.mod h1:ucQSLeHpC4ns6VvlWBinK7BI8LrUWlhZUHArs6VRvXI=
 github.com/getlantern/context v0.0.0-20190109183933-c447772a6520/go.mod h1:L+mq6/vvYHKjCX2oez0CgEAJmbq1fbb/oNJIWQkBybY=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=

--- a/radiance.go
+++ b/radiance.go
@@ -81,6 +81,9 @@ func NewRadiance(opts client.Options) (*Radiance, error) {
 		opts.LogDir = appdir.Logs(app.Name)
 	}
 	if opts.Locale == "" {
+		// It is preferable to use the locale from the frontend, as locale is a requirement for lots
+		// of frontend code and therefore is more reliably supported there.
+		// However, if the frontend locale is not available, we can use the system locale as a fallback.
 		if tag, err := locale.Detect(); err != nil {
 			log.Info("Failed to detect locale", "error", err)
 			opts.Locale = "en-US"

--- a/radiance.go
+++ b/radiance.go
@@ -21,6 +21,7 @@ import (
 	"github.com/getlantern/fronted"
 	"github.com/getlantern/kindling"
 
+	"github.com/Xuanwo/go-locale"
 	"github.com/getlantern/radiance/app"
 	"github.com/getlantern/radiance/client"
 	"github.com/getlantern/radiance/common/reporting"
@@ -79,6 +80,14 @@ func NewRadiance(opts client.Options) (*Radiance, error) {
 	if opts.LogDir == "" {
 		opts.LogDir = appdir.Logs(app.Name)
 	}
+	if opts.Locale == "" {
+		if tag, err := locale.Detect(); err != nil {
+			log.Info("Failed to detect locale", "error", err)
+			opts.Locale = "en-US"
+		} else {
+			opts.Locale = tag.String()
+		}
+	}
 	mkdirs(&opts)
 
 	var logWriter io.Writer
@@ -119,7 +128,7 @@ func NewRadiance(opts client.Options) (*Radiance, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create issue reporter: %w", err)
 	}
-	confHandler := config.NewConfigHandler(configPollInterval, k.NewHTTPClient(), u, opts.DataDir, vpnC.ParseConfig)
+	confHandler := config.NewConfigHandler(configPollInterval, k.NewHTTPClient(), u, opts.DataDir, vpnC.ParseConfig, opts.Locale)
 	confHandler.AddConfigListener(vpnC.OnNewConfig)
 
 	return &Radiance{

--- a/user/user.go
+++ b/user/user.go
@@ -85,7 +85,6 @@ func (u *User) LegacyToken() string {
 
 func writeUserData(data *LoginResponse) error {
 	return os.WriteFile(userDataLocation, []byte(data.String()), 0600)
-
 }
 
 func readUserData() (*LoginResponse, error) {


### PR DESCRIPTION
The locale is used in user creation on first run, so we need to pass it.

This pull request introduces support for locale detection and propagation throughout the application, along with minor updates to dependencies and error messaging. The most significant changes involve adding locale support to configuration handling and ensuring the locale is detected and passed through various components.

### Locale Support Enhancements:
* Added a `Locale` field to the `Options` struct in `client/client.go` to store the user's locale.
* Updated `NewConfigHandler` in `config/config.go` to accept a `locale` parameter and propagate it to the `fetcher` for configuration fetching. [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L69-R69) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L85-R85)
* Modified the `fetcher` struct in `config/fetcher.go` to include a `locale` field, and updated the `fetchConfig` method to include the locale in configuration requests. [[1]](diffhunk://#diff-7a29ad907addd7ddb75133a0c5098cc474b34f725c8fb7baff6c2f6708fe494fR41-R50) [[2]](diffhunk://#diff-7a29ad907addd7ddb75133a0c5098cc474b34f725c8fb7baff6c2f6708fe494fR64)
* Integrated locale detection in `radiance.go` using the `go-locale` library. If no locale is provided in `client.Options`, it defaults to detecting the system locale or falling back to `en-US`.

### Dependency Updates:
* Added `github.com/Xuanwo/go-locale` as a new dependency in `go.mod` for locale detection. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R72) [[2]](diffhunk://#diff-60179a9bacb28016fc7cda79abcad6f09a5c467689999b56f2c6e0cb3d94140cR24)
* Updated the version of `github.com/getlantern/common` in `go.mod`.

### Minor Improvements:
* Enhanced error messaging in `GetConfig` to clarify the absence of configuration during the first run.
* Removed an unnecessary blank line in `user/user.go`.