### PR TITLE
create base sing-box ctx

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -48,7 +48,6 @@ type VPNClient interface {
 	ResumeVPN()
 	SplitTunnelHandler() *SplitTunnel
 	OnNewConfig(oldConfig, newConfig *config.Config) error
-	ParseConfig(config []byte) (*config.Config, error)
 }
 
 type vpnClient struct {
@@ -215,10 +214,6 @@ func injectRouteRules(routeOpts *option.RouteOptions, atIdx int, rules []option.
 		routeOpts.RuleSet = append(routeOpts.RuleSet, rulesets...)
 	}
 	return routeOpts
-}
-
-func (c *vpnClient) ParseConfig(configRaw []byte) (*config.Config, error) {
-	return c.boxService.ParseConfig(configRaw)
 }
 
 func (c *vpnClient) OnNewConfig(oldConfig, newConfig *config.Config) error {

--- a/client/service/service.go
+++ b/client/service/service.go
@@ -34,6 +34,11 @@ import (
 	"github.com/getlantern/radiance/config"
 )
 
+var (
+	baseCtx   context.Context
+	ctxAccess sync.Mutex
+)
+
 // BoxService is a wrapper around libbox.BoxService
 type BoxService struct {
 	libbox            *libbox.BoxService
@@ -104,18 +109,30 @@ func (bs *BoxService) Start() error {
 	return nil
 }
 
-// newLibboxService creates a new libbox service with the given config and platform interface
-func newLibboxService(config string, platIfce libbox.PlatformInterface) (*libbox.BoxService, context.Context, error) {
+func BaseContext() context.Context {
+	ctxAccess.Lock()
+	defer ctxAccess.Unlock()
+	if baseCtx == nil {
+		baseCtx = newBaseContext()
+	}
+	return baseCtx
+}
+
+func newBaseContext() context.Context {
 	// Retrieve protocol registries
 	inboundRegistry, outboundRegistry, endpointRegistry := protocol.GetRegistries()
-	ctx := box.Context(
+	return box.Context(
 		context.Background(),
 		inboundRegistry,
 		outboundRegistry,
 		endpointRegistry,
 	)
+}
 
+// newLibboxService creates a new libbox service with the given config and platform interface
+func newLibboxService(config string, platIfce libbox.PlatformInterface) (*libbox.BoxService, context.Context, error) {
 	// initialize the libbox service
+	ctx := newBaseContext()
 	lb, err := libbox.NewServiceWithContext(ctx, config, platIfce)
 	if err != nil {
 		return nil, nil, fmt.Errorf("create libbox service: %w", err)
@@ -193,8 +210,8 @@ func (bs *BoxService) OnNewConfig(_, newConfig *config.Config) error {
 		newConfig.ConfigResponse.Options.Endpoints)
 }
 
-func (bs *BoxService) ParseConfig(configRaw []byte) (*config.Config, error) {
-	config, err := json.UnmarshalExtendedContext[*config.Config](bs.ctx, configRaw)
+func ParseConfig(configRaw []byte) (*config.Config, error) {
+	config, err := json.UnmarshalExtendedContext[*config.Config](BaseContext(), configRaw)
 	if err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}

--- a/client/service/service.go
+++ b/client/service/service.go
@@ -132,6 +132,8 @@ func newBaseContext() context.Context {
 // newLibboxService creates a new libbox service with the given config and platform interface
 func newLibboxService(config string, platIfce libbox.PlatformInterface) (*libbox.BoxService, context.Context, error) {
 	// initialize the libbox service
+	// we need to create a new context each time so we have a fresh context, free of all the values
+	// that the sing-box instance adds to it
 	ctx := newBaseContext()
 	lb, err := libbox.NewServiceWithContext(ctx, config, platIfce)
 	if err != nil {

--- a/radiance.go
+++ b/radiance.go
@@ -22,8 +22,10 @@ import (
 	"github.com/getlantern/kindling"
 
 	"github.com/Xuanwo/go-locale"
+
 	"github.com/getlantern/radiance/app"
 	"github.com/getlantern/radiance/client"
+	boxservice "github.com/getlantern/radiance/client/service"
 	"github.com/getlantern/radiance/common/reporting"
 	"github.com/getlantern/radiance/config"
 	"github.com/getlantern/radiance/issue"
@@ -131,7 +133,13 @@ func NewRadiance(opts client.Options) (*Radiance, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create issue reporter: %w", err)
 	}
-	confHandler := config.NewConfigHandler(configPollInterval, k.NewHTTPClient(), u, opts.DataDir, vpnC.ParseConfig, opts.Locale)
+	confHandler := config.NewConfigHandler(
+		configPollInterval,
+		k.NewHTTPClient(),
+		u, opts.DataDir,
+		boxservice.ParseConfig,
+		opts.Locale,
+	)
 	confHandler.AddConfigListener(vpnC.OnNewConfig)
 
 	return &Radiance{

--- a/radiance_test.go
+++ b/radiance_test.go
@@ -10,13 +10,15 @@ import (
 	"github.com/stretchr/testify/require"
 
 	C "github.com/getlantern/common"
+
 	"github.com/getlantern/radiance/client"
 	"github.com/getlantern/radiance/config"
 )
 
 func TestNewRadiance(t *testing.T) {
 	t.Run("it should create a new Radiance instance successfully", func(t *testing.T) {
-		r, err := NewRadiance(client.Options{DataDir: t.TempDir()})
+		dir := t.TempDir()
+		r, err := NewRadiance(client.Options{DataDir: dir})
 		assert.NotNil(t, r)
 		assert.NoError(t, err)
 		assert.NotNil(t, r.VPNClient)


### PR DESCRIPTION
This pull request refactors configuration parsing and introduces a shared base context for the `BoxService`. The most significant changes include removing the `ParseConfig` method from the `VPNClient` interface and `vpnClient` implementation, creating a global `BaseContext` function for shared context management, and updating the configuration handler to use the new `ParseConfig` function in `BoxService`.

### Refactoring Configuration Parsing:

* Removed the `ParseConfig` method from the `VPNClient` interface and its implementation in `vpnClient`, delegating the responsibility to `BoxService`. (`client/client.go`, [[1]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L51) [[2]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L220-L223)
* Added a new `ParseConfig` function to `BoxService`, which uses the global `BaseContext` for context management during JSON unmarshalling. (`client/service/service.go`, [client/service/service.goL196-R214](diffhunk://#diff-3e93cc11b22eab442b7c9435196e3101e2ac6f286ee1b63c98f0de4099bc5ab9L196-R214))

### Shared Base Context for `BoxService`:

* Introduced a global `BaseContext` function and its supporting `newBaseContext` function to manage a shared context for `BoxService`. This ensures consistent context usage across the application. (`client/service/service.go`, [[1]](diffhunk://#diff-3e93cc11b22eab442b7c9435196e3101e2ac6f286ee1b63c98f0de4099bc5ab9R37-R41) [[2]](diffhunk://#diff-3e93cc11b22eab442b7c9435196e3101e2ac6f286ee1b63c98f0de4099bc5ab9L107-R135)

### Configuration Handler Update:

* Updated the `NewRadiance` function to use the new `ParseConfig` function from `BoxService` instead of the removed `vpnClient.ParseConfig` method. (`radiance.go`, [radiance.goL134-R142](diffhunk://#diff-60179a9bacb28016fc7cda79abcad6f09a5c467689999b56f2c6e0cb3d94140cL134-R142))

### Miscellaneous:

* Added a new import alias (`boxservice`) in `radiance.go` to reference the `client/service` package for the updated `ParseConfig` function. (`radiance.go`, [radiance.goR25-R28](diffhunk://#diff-60179a9bacb28016fc7cda79abcad6f09a5c467689999b56f2c6e0cb3d94140cR25-R28))