### PR TITLE
fix unmarshal bug. unmarshal as configresponse instead of config.Config

### DIFF
--- a/client/service/service.go
+++ b/client/service/service.go
@@ -20,6 +20,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	C "github.com/getlantern/common"
+
 	box "github.com/sagernet/sing-box"
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/experimental/libbox"
@@ -234,12 +236,13 @@ func (bs *BoxService) OnNewConfig(_, newConfig *config.Config) error {
 	return updateOutboundsEndpoints(bs.ctx, opts.Outbounds, opts.Endpoints)
 }
 
-func ParseConfig(configRaw []byte) (*config.Config, error) {
-	config, err := json.UnmarshalExtendedContext[*config.Config](BaseContext(), configRaw)
+func UnmarshalConfig(configRaw []byte) (*C.ConfigResponse, error) {
+	config, err := json.UnmarshalExtendedContext[C.ConfigResponse](BaseContext(), configRaw)
 	if err != nil {
-		return nil, fmt.Errorf("parse config: %w", err)
+		return nil, fmt.Errorf("unmarshal options: %w", err)
 	}
-	return config, nil
+
+	return &config, nil
 }
 
 var (

--- a/config/config.go
+++ b/config/config.go
@@ -276,7 +276,7 @@ func (ch *ConfigHandler) setConfigAndNotify(cfg *Config) {
 		}
 		cfg.ConfigResponse = merged
 
-		if cfg.PreferredLocation != (C.ServerLocation{}) {
+		if cfg.PreferredLocation == (C.ServerLocation{}) {
 			cfg.PreferredLocation = ch.preferredLocation.Load().(C.ServerLocation)
 		}
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	O "github.com/sagernet/sing-box/option"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -227,6 +228,313 @@ func TestHandlerFetchConfig(t *testing.T) {
 		err := ch.fetchConfig()
 		require.Error(t, err, "Should return an error when config parsing fails")
 		assert.Contains(t, err.Error(), "parsing config", "Error message should indicate parsing error")
+	})
+}
+
+func TestMergeResp(t *testing.T) {
+	t.Run("SuccessfulMerge", func(t *testing.T) {
+		oldConfig := &C.ConfigResponse{
+			UserInfo: C.UserInfo{
+				IP:       "1.1.1.1",
+				ProToken: "test-pro-token",
+			},
+			Servers: []C.ServerLocation{
+				{Country: "US", City: "New York"},
+			},
+			Options: O.Options{},
+		}
+		newConfig := &C.ConfigResponse{
+			UserInfo: C.UserInfo{
+				IP: "2.2.2.2",
+			},
+			Servers: []C.ServerLocation{
+				{Country: "UK", City: "London"},
+			},
+			Options: O.Options{
+				Outbounds: []O.Outbound{
+					{
+						Tag: "outbound1",
+						Options: map[string]interface{}{
+							"key": "value",
+						},
+					},
+				},
+			},
+		}
+
+		mergedConfig, err := mergeResp(oldConfig, newConfig)
+		require.NoError(t, err, "Should not return an error when merging configs")
+		assert.Equal(t, newConfig.Servers, mergedConfig.Servers, "Merged servers should match newConfig servers")
+		assert.Equal(t, newConfig.Options, mergedConfig.Options, "Merged options should match newConfig options")
+		assert.Equal(t, newConfig.UserInfo.IP, mergedConfig.UserInfo.IP, "Merged IP should match newConfig IP")
+		assert.Equal(t, oldConfig.UserInfo.ProToken, mergedConfig.UserInfo.ProToken, "Merged ProToken should match oldConfig ProToken")
+	})
+
+	t.Run("NoNewServerLocations", func(t *testing.T) {
+		oldConfig := &C.ConfigResponse{
+			UserInfo: C.UserInfo{
+				IP:       "1.1.1.1",
+				ProToken: "test-pro-token",
+			},
+			Servers: []C.ServerLocation{
+				{Country: "US", City: "New York"},
+			},
+			Options: O.Options{},
+		}
+		newConfig := &C.ConfigResponse{
+			UserInfo: C.UserInfo{
+				IP: "2.2.2.2",
+			},
+			Servers: []C.ServerLocation{},
+			Options: O.Options{
+				Outbounds: []O.Outbound{
+					{
+						Tag: "outbound1",
+						Options: map[string]interface{}{
+							"key": "value",
+						},
+					},
+				},
+			},
+		}
+
+		mergedConfig, err := mergeResp(oldConfig, newConfig)
+		require.NoError(t, err, "Should not return an error when merging configs")
+		assert.Equal(t, oldConfig.Servers, mergedConfig.Servers, "Merged servers should match oldConfig servers")
+		assert.Equal(t, newConfig.Options, mergedConfig.Options, "Merged options should match newConfig options")
+		assert.Equal(t, newConfig.UserInfo.IP, mergedConfig.UserInfo.IP, "Merged IP should match newConfig IP")
+		assert.Equal(t, oldConfig.UserInfo.ProToken, mergedConfig.UserInfo.ProToken, "Merged ProToken should match oldConfig ProToken")
+	})
+	t.Run("OverwriteOutbounds", func(t *testing.T) {
+		oldConfig := &C.ConfigResponse{
+			UserInfo: C.UserInfo{
+				IP:       "1.1.1.1",
+				ProToken: "test-pro-token",
+			},
+			Servers: []C.ServerLocation{
+				{Country: "US", City: "New York"},
+			},
+			Options: O.Options{
+				Outbounds: []O.Outbound{
+					{
+						Tag: "outbound3",
+						Options: map[string]interface{}{
+							"key": "value",
+						},
+					},
+				},
+			},
+		}
+		newConfig := &C.ConfigResponse{
+			UserInfo: C.UserInfo{
+				IP: "2.2.2.2",
+			},
+			Servers: []C.ServerLocation{},
+			Options: O.Options{
+				Outbounds: []O.Outbound{
+					{
+						Tag: "outbound1",
+						Options: map[string]interface{}{
+							"key": "value",
+						},
+					},
+				},
+			},
+		}
+
+		mergedConfig, err := mergeResp(oldConfig, newConfig)
+		require.NoError(t, err, "Should not return an error when merging configs")
+		assert.Equal(t, oldConfig.Servers, mergedConfig.Servers, "Merged servers should match oldConfig servers")
+		assert.Equal(t, newConfig.Options.Outbounds, mergedConfig.Options.Outbounds, "Merged options should match newConfig options")
+		assert.Equal(t, newConfig.UserInfo.IP, mergedConfig.UserInfo.IP, "Merged IP should match newConfig IP")
+		assert.Equal(t, oldConfig.UserInfo.ProToken, mergedConfig.UserInfo.ProToken, "Merged ProToken should match oldConfig ProToken")
+	})
+	t.Run("KeepDNSOptions", func(t *testing.T) {
+		oldConfig := &C.ConfigResponse{
+			UserInfo: C.UserInfo{
+				IP:       "1.1.1.1",
+				ProToken: "test-pro-token",
+			},
+			Servers: []C.ServerLocation{
+				{Country: "US", City: "New York"},
+			},
+			Options: O.Options{
+				DNS: &O.DNSOptions{
+					ReverseMapping: true,
+					Servers: []O.DNSServerOptions{
+						{
+							Tag:     "dns1",
+							Address: "8.8.8.8",
+						},
+					},
+				},
+			},
+		}
+		newConfig := &C.ConfigResponse{
+			UserInfo: C.UserInfo{
+				IP: "2.2.2.2",
+			},
+			Servers: []C.ServerLocation{},
+			Options: O.Options{
+				Outbounds: []O.Outbound{
+					{
+						Tag: "outbound1",
+						Options: map[string]interface{}{
+							"key": "value",
+						},
+					},
+				},
+			},
+		}
+
+		mergedConfig, err := mergeResp(oldConfig, newConfig)
+		require.NoError(t, err, "Should not return an error when merging configs")
+		assert.Equal(t, oldConfig.Servers, mergedConfig.Servers, "Merged servers should match oldConfig servers")
+		assert.Equal(t, newConfig.Options.Outbounds, mergedConfig.Options.Outbounds, "Merged Outbounds should match newConfig Outbounds")
+		assert.Equal(t, newConfig.UserInfo.IP, mergedConfig.UserInfo.IP, "Merged IP should match newConfig IP")
+		assert.Equal(t, oldConfig.UserInfo.ProToken, mergedConfig.UserInfo.ProToken, "Merged ProToken should match oldConfig ProToken")
+		assert.Equal(t, oldConfig.Options.DNS, mergedConfig.Options.DNS, "Merged DNS options should match oldConfig DNS options")
+	})
+	t.Run("SuccessfulRemovedUnassignedOutbounds", func(t *testing.T) {
+		oldConfig := &C.ConfigResponse{
+			UserInfo: C.UserInfo{
+				IP:       "1.1.1.1",
+				ProToken: "test-pro-token",
+			},
+			Servers: []C.ServerLocation{
+				{Country: "US", City: "New York"},
+			},
+			Options: O.Options{
+				Outbounds: []O.Outbound{
+					{
+						Tag: "outbound1",
+						Options: map[string]interface{}{
+							"key": "value",
+						},
+					},
+					{
+						Tag: "outbound4",
+						Options: map[string]interface{}{
+							"key": "value",
+						},
+					},
+				},
+			},
+		}
+		newConfig := &C.ConfigResponse{
+			UserInfo: C.UserInfo{
+				IP: "2.2.2.2",
+			},
+			Servers: []C.ServerLocation{
+				{Country: "UK", City: "London"},
+			},
+			Options: O.Options{
+				Outbounds: []O.Outbound{
+					{
+						Tag: "outbound2",
+						Options: map[string]interface{}{
+							"key": "value",
+						},
+					},
+				},
+			},
+		}
+		want := &C.ConfigResponse{
+			UserInfo: C.UserInfo{
+				IP:       "2.2.2.2",
+				ProToken: "test-pro-token",
+			},
+			Servers: []C.ServerLocation{
+				{Country: "UK", City: "London"},
+			},
+			Options: O.Options{
+				Outbounds: []O.Outbound{
+					{
+						Tag: "outbound2",
+						Options: map[string]interface{}{
+							"key": "value",
+						},
+					},
+				},
+			},
+		}
+		mergedConfig, err := mergeResp(oldConfig, newConfig)
+		require.NoError(t, err, "Should not return an error when merging configs")
+		assert.Equal(t, mergedConfig, want)
+	})
+
+	t.Run("DoNotOverwriteAllOptions", func(t *testing.T) {
+		oldConfig := &C.ConfigResponse{
+			Options: O.Options{
+				DNS: &O.DNSOptions{
+					ReverseMapping: true,
+					Servers: []O.DNSServerOptions{
+						{
+							Tag:     "dns1",
+							Address: "8.8.8.8",
+						},
+					},
+				},
+				Outbounds: []O.Outbound{
+					{
+						Tag: "outbound1",
+						Options: map[string]interface{}{
+							"key": "value",
+						},
+					},
+					{
+						Tag: "outbound4",
+						Options: map[string]interface{}{
+							"key": "value",
+						},
+					},
+				},
+			},
+		}
+		newConfig := &C.ConfigResponse{
+			Options: O.Options{
+				DNS: &O.DNSOptions{
+					Servers: []O.DNSServerOptions{
+						{
+							Tag:     "dns1",
+							Address: "1.1.1.1",
+						},
+					},
+				},
+				Outbounds: []O.Outbound{
+					{
+						Tag: "outbound2",
+						Options: map[string]interface{}{
+							"key": "value",
+						},
+					},
+				},
+			},
+		}
+		want := &C.ConfigResponse{
+			Options: O.Options{
+				DNS: &O.DNSOptions{
+					ReverseMapping: true,
+					Servers: []O.DNSServerOptions{
+						{
+							Tag:     "dns1",
+							Address: "1.1.1.1",
+						},
+					},
+				},
+				Outbounds: []O.Outbound{
+					{
+						Tag: "outbound2",
+						Options: map[string]interface{}{
+							"key": "value",
+						},
+					},
+				},
+			},
+		}
+		mergedConfig, err := mergeResp(oldConfig, newConfig)
+		require.NoError(t, err, "Should not return an error when merging configs")
+		assert.Equal(t, mergedConfig, want)
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,6 @@ require (
 )
 
 require (
-	dario.cat/mergo v1.0.1
 	github.com/Xuanwo/go-locale v1.1.3
 	github.com/ajg/form v1.5.1 // indirect
 	github.com/andybalholm/brotli v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ replace github.com/sagernet/wireguard-go => github.com/getlantern/wireguard-go v
 //replace github.com/getlantern/common => ../common
 
 require (
+	dario.cat/mergo v1.0.1
 	github.com/1Password/srp v0.2.0
 	github.com/getlantern/appdir v0.0.0-20250324200952-507a0625eb01
 	github.com/getlantern/common v1.2.1-0.20250428204107-678e5e36cbbf
@@ -118,6 +119,7 @@ require (
 	github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/qdm12/reprint v0.0.0-20200326205758-722754a53494
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/quic-go/qtls-go1-20 v0.4.1 // indirect
 	github.com/sagernet/bbolt v0.0.0-20231014093535-ea5cb2fe9f0a // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
+dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/1Password/srp v0.2.0 h1:PZKAafEyExnwevliL6d2+FDhJXZ0phxqiG2OeIaj9Xk=
 github.com/1Password/srp v0.2.0/go.mod h1:LIGqQ7eEA0UJT98j7sXk60QWVpHJ3g00BX6LOm9kYTc=
 github.com/Jigsaw-Code/outline-sdk v0.0.19 h1:/OpMz+3B/9ypjq/UyEvwZSflzJ4jXFginUOZeN0UssM=
@@ -243,6 +245,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/qdm12/reprint v0.0.0-20200326205758-722754a53494 h1:wSmWgpuccqS2IOfmYrbRiUgv+g37W5suLLLxwwniTSc=
+github.com/qdm12/reprint v0.0.0-20200326205758-722754a53494/go.mod h1:yipyliwI08eQ6XwDm1fEwKPdF/xdbkiHtrU+1Hg+vc4=
 github.com/quic-go/qpack v0.5.1 h1:giqksBPnT/HDtZ6VhtFKgoLOWmlyo9Ei6u9PqzIMbhI=
 github.com/quic-go/qpack v0.5.1/go.mod h1:+PC4XFrEskIVkcLzpEkbLqq1uCoxPhQuvK5rH1ZgaEg=
 github.com/quic-go/qtls-go1-20 v0.4.1 h1:D33340mCNDAIKBqXuAvexTNMUByrYmFYVfKfDN5nfFs=
@@ -304,6 +308,7 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
-dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/1Password/srp v0.2.0 h1:PZKAafEyExnwevliL6d2+FDhJXZ0phxqiG2OeIaj9Xk=
 github.com/1Password/srp v0.2.0/go.mod h1:LIGqQ7eEA0UJT98j7sXk60QWVpHJ3g00BX6LOm9kYTc=
 github.com/Jigsaw-Code/outline-sdk v0.0.19 h1:/OpMz+3B/9ypjq/UyEvwZSflzJ4jXFginUOZeN0UssM=

--- a/radiance.go
+++ b/radiance.go
@@ -130,13 +130,15 @@ func NewRadiance(opts client.Options) (*Radiance, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create issue reporter: %w", err)
 	}
-	confHandler := config.NewConfigHandler(
-		configPollInterval,
-		k.NewHTTPClient(),
-		u, opts.DataDir,
-		boxservice.ParseConfig,
-		opts.Locale,
-	)
+	cOpts := config.Options{
+		PollInterval:     configPollInterval,
+		HTTPClient:       k.NewHTTPClient(),
+		User:             u,
+		DataDir:          opts.DataDir,
+		ConfigRespParser: boxservice.UnmarshalConfig,
+		Locale:           opts.Locale,
+	}
+	confHandler := config.NewConfigHandler(cOpts)
 	confHandler.AddConfigListener(vpnC.OnNewConfig)
 
 	return &Radiance{
@@ -174,6 +176,7 @@ func (r *Radiance) Close() {
 			}
 		}
 	})
+	<-r.stopChan
 }
 
 // Server represents a remote VPN server.


### PR DESCRIPTION
Copilot couldn't actually describe what this PR does.

This PR changes the config parser/unmarshaller to parse as a `ConfigResponse` object, instead of a `Config` object. This fixes a bug where the box options were being overwritten with an empty one on every fetch.

### Configuration Handling Refactor:
* Added new `Options` struct in `ConfigHandler`, encapsulating all configuration options passed to `NewConfigHandler`. (`config/config.go`, [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L50-R61) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L74-R103)
* Added a `mergeResp` function to handle deep merging of old and new configuration responses, ensuring proper updates while preserving specific fields. (`config/config.go`, [config/config.goR290-R306](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R290-R306))

### Test Case Updates:
* Updated test cases to use the new `confRespParser` field and `unmarshalConfig` method in `ConfigHandler`. (`config/config_test.go`, [[1]](diffhunk://#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82R16-R22) [[2]](diffhunk://#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82L34-R35) [[3]](diffhunk://#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82L73-R74)
* Adjusted mock implementations and test data to align with the new configuration response structure. (`config/config_test.go`, [[1]](diffhunk://#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82L157-R158) [[2]](diffhunk://#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82L167-L172)

### Client Integration:
* Refactored `Radiance` to use the new `Options` struct when initializing `ConfigHandler`, improving consistency and reducing boilerplate. (`radiance.go`, [radiance.goL133-R141](diffhunk://#diff-60179a9bacb28016fc7cda79abcad6f09a5c467689999b56f2c6e0cb3d94140cL133-R141))
* Added a synchronization mechanism to the `Close` method in `Radiance` to ensure proper shutdown. (`radiance.go`, [radiance.goR179](diffhunk://#diff-60179a9bacb28016fc7cda79abcad6f09a5c467689999b56f2c6e0cb3d94140cR179))

These changes collectively enhance the robustness and maintainability of the configuration management system while simplifying integration points across the codebase.