### PR TITLE
update box options on new config

### DIFF
--- a/client/boxoptions/options.go
+++ b/client/boxoptions/options.go
@@ -12,71 +12,196 @@ import (
 	"github.com/getlantern/radiance/option"
 )
 
-var BoxOptions = O.Options{
-	Log: &O.LogOptions{
-		Disabled:     false,
-		Level:        "trace",
-		Output:       "lantern.log",
-		Timestamp:    true,
-		DisableColor: true,
-	},
-	DNS: &O.DNSOptions{
-		Servers: []O.DNSServerOptions{
-			{
-				Tag:     "dns-google-dot",
-				Address: "tls://8.8.4.4",
-			},
-			{
-				Tag:     "dns-cloudflare-dot",
-				Address: "tls://1.1.1.1",
-			},
-			{
-				Tag:     "dns-sb-dot",
-				Address: "tls://185.222.222.222",
-			},
-			{
-				Tag:             "dns-google-doh",
-				Address:         "https://dns.google/dns-query",
-				AddressResolver: "dns-google-dot",
-			},
-			{
-				Tag:             "dns-cloudflare-doh",
-				Address:         "https://cloudflare-dns.com/dns-query",
-				AddressResolver: "dns-cloudflare-dot",
-			},
-			{
-				Tag:             "dns-sb-doh",
-				Address:         "https://doh.dns.sb/dns-query",
-				AddressResolver: "dns-sb-dot",
-			},
-			{
-				Tag:     "local",
-				Address: "223.5.5.5",
-				Detour:  "direct",
-			},
+var (
+	BoxOptions = O.Options{
+		Log: &O.LogOptions{
+			Disabled:     false,
+			Level:        "trace",
+			Output:       "lantern.log",
+			Timestamp:    true,
+			DisableColor: true,
 		},
-		DNSClientOptions: O.DNSClientOptions{
-			Strategy: O.DomainStrategy(dns.DomainStrategyUseIPv4),
-		},
-	},
-	Inbounds: []O.Inbound{
-		{
-			Type: "tun",
-			Tag:  "tun-in",
-			Options: &O.TunInboundOptions{
-				InterfaceName: "utun225",
-				MTU:           1500,
-				Address: badoption.Listable[netip.Prefix]{
-					netip.MustParsePrefix("10.10.1.1/30"),
+		DNS: &O.DNSOptions{
+			Servers: []O.DNSServerOptions{
+				{
+					Tag:     "dns-google-dot",
+					Address: "tls://8.8.4.4",
 				},
-				AutoRoute:              true,
-				StrictRoute:            true,
-				EndpointIndependentNat: true,
-				Stack:                  "system",
+				{
+					Tag:     "dns-cloudflare-dot",
+					Address: "tls://1.1.1.1",
+				},
+				{
+					Tag:     "dns-sb-dot",
+					Address: "tls://185.222.222.222",
+				},
+				{
+					Tag:             "dns-google-doh",
+					Address:         "https://dns.google/dns-query",
+					AddressResolver: "dns-google-dot",
+				},
+				{
+					Tag:             "dns-cloudflare-doh",
+					Address:         "https://cloudflare-dns.com/dns-query",
+					AddressResolver: "dns-cloudflare-dot",
+				},
+				{
+					Tag:             "dns-sb-doh",
+					Address:         "https://doh.dns.sb/dns-query",
+					AddressResolver: "dns-sb-dot",
+				},
+				{
+					Tag:     "local",
+					Address: "223.5.5.5",
+					Detour:  "direct",
+				},
+			},
+			DNSClientOptions: O.DNSClientOptions{
+				Strategy: O.DomainStrategy(dns.DomainStrategyUseIPv4),
 			},
 		},
-	},
-	Outbounds: []O.Outbound{
+		Inbounds: []O.Inbound{
+			{
+				Type: "tun",
+				Tag:  "tun-in",
+				Options: &O.TunInboundOptions{
+					InterfaceName: "utun225",
+					MTU:           1500,
+					Address: badoption.Listable[netip.Prefix]{
+						netip.MustParsePrefix("10.10.1.1/30"),
+					},
+					AutoRoute:              true,
+					StrictRoute:            true,
+					EndpointIndependentNat: true,
+					Stack:                  "system",
+				},
+			},
+		},
+		Outbounds: []O.Outbound{
+			{
+				Type:    "direct",
+				Tag:     "direct",
+				Options: &O.DirectOutboundOptions{},
+			},
+			{
+				Type:    "dns",
+				Tag:     "dns-out",
+				Options: &O.DNSOptions{},
+			},
+			{
+				Type: constant.TypeOutline,
+				Tag:  "outline-out",
+				Options: &option.OutboundOutlineOptions{
+					DNSResolvers: []option.DNSEntryConfig{
+						{
+							TLS: &option.TLSEntryConfig{
+								Name:    "dns.google",
+								Address: "8.8.8.8:853",
+							},
+						},
+						{
+							HTTPS: &option.HTTPSEntryConfig{
+								Name: "dns.google",
+							},
+						},
+						{
+							HTTPS: &option.HTTPSEntryConfig{
+								Name:    "cloudflare-dns.com.",
+								Address: "cloudflare.net.",
+							},
+						},
+						{
+							HTTPS: &option.HTTPSEntryConfig{
+								Name:    "doh.dns.sb",
+								Address: "https://doh.dns.sb/dns-query",
+							},
+						},
+						{
+							System: &struct{}{},
+						},
+					},
+					TLS:         []string{"", "split:1", "split:2,20*5", "split:200|disorder:1", "tlsfrag:1"},
+					Domains:     []string{"api.iantem.io", "google.com"},
+					TestTimeout: "10s",
+				},
+			},
+		},
+		Route: &O.RouteOptions{
+			AutoDetectInterface: true,
+			Rules: []O.Rule{
+				{
+					Type: C.RuleTypeDefault,
+					DefaultOptions: O.DefaultRule{
+						RawDefaultRule: O.RawDefaultRule{
+							Inbound: badoption.Listable[string]{"tun-in"},
+						},
+						RuleAction: O.RuleAction{
+							Action: C.RuleActionTypeSniff,
+						},
+					},
+				},
+				{
+					Type: C.RuleTypeDefault,
+					DefaultOptions: O.DefaultRule{
+						RawDefaultRule: O.RawDefaultRule{
+							Protocol: badoption.Listable[string]{"dns"},
+						},
+						RuleAction: O.RuleAction{
+							Action: C.RuleActionTypeRoute,
+							RouteOptions: O.RouteActionOptions{
+								Outbound: "dns-out",
+							},
+						},
+					},
+				},
+				{
+					Type: C.RuleTypeDefault,
+					DefaultOptions: O.DefaultRule{
+						RawDefaultRule: O.RawDefaultRule{
+							Inbound: badoption.Listable[string]{"tun-in"},
+							Domain:  badoption.Listable[string]{"api.iantem.io", "google.com"},
+						},
+						RuleAction: O.RuleAction{
+							Action: C.RuleActionTypeRoute,
+							RouteOptions: O.RouteActionOptions{
+								Outbound: "outline-out",
+							},
+						},
+					},
+				},
+				{
+					Type: C.RuleTypeDefault,
+					DefaultOptions: O.DefaultRule{
+						RawDefaultRule: O.RawDefaultRule{
+							Protocol: badoption.Listable[string]{"ssh"},
+						},
+						RuleAction: O.RuleAction{
+							Action: C.RuleActionTypeRoute,
+							RouteOptions: O.RouteActionOptions{
+								Outbound: "direct",
+							},
+						},
+					},
+				},
+				{
+					Type: C.RuleTypeDefault,
+					DefaultOptions: O.DefaultRule{
+						RawDefaultRule: O.RawDefaultRule{
+							Inbound: badoption.Listable[string]{"tun-in"},
+						},
+						RuleAction: O.RuleAction{
+							Action: C.RuleActionTypeRoute,
+							RouteOptions: O.RouteActionOptions{
+								Outbound: "direct",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	BaseOutbounds = []O.Outbound{
 		{
 			Type:    "direct",
 			Tag:     "direct",
@@ -88,114 +213,11 @@ var BoxOptions = O.Options{
 			Options: &O.DNSOptions{},
 		},
 		{
-			Type: constant.TypeOutline,
-			Tag:  "outline-out",
-			Options: &option.OutboundOutlineOptions{
-				DNSResolvers: []option.DNSEntryConfig{
-					{
-						TLS: &option.TLSEntryConfig{
-							Name:    "dns.google",
-							Address: "8.8.8.8:853",
-						},
-					},
-					{
-						HTTPS: &option.HTTPSEntryConfig{
-							Name: "dns.google",
-						},
-					},
-					{
-						HTTPS: &option.HTTPSEntryConfig{
-							Name:    "cloudflare-dns.com.",
-							Address: "cloudflare.net.",
-						},
-					},
-					{
-						HTTPS: &option.HTTPSEntryConfig{
-							Name:    "doh.dns.sb",
-							Address: "https://doh.dns.sb/dns-query",
-						},
-					},
-					{
-						System: &struct{}{},
-					},
-				},
-				TLS:         []string{"", "split:1", "split:2,20*5", "split:200|disorder:1", "tlsfrag:1"},
-				Domains:     []string{"api.iantem.io", "google.com"},
-				TestTimeout: "10s",
-			},
+			Type:    "block",
+			Tag:     "block",
+			Options: &O.StubOptions{},
 		},
-	},
-	Route: &O.RouteOptions{
-		AutoDetectInterface: true,
-		Rules: []O.Rule{
-			{
-				Type: C.RuleTypeDefault,
-				DefaultOptions: O.DefaultRule{
-					RawDefaultRule: O.RawDefaultRule{
-						Inbound: badoption.Listable[string]{"tun-in"},
-					},
-					RuleAction: O.RuleAction{
-						Action: C.RuleActionTypeSniff,
-					},
-				},
-			},
-			{
-				Type: C.RuleTypeDefault,
-				DefaultOptions: O.DefaultRule{
-					RawDefaultRule: O.RawDefaultRule{
-						Protocol: badoption.Listable[string]{"dns"},
-					},
-					RuleAction: O.RuleAction{
-						Action: C.RuleActionTypeRoute,
-						RouteOptions: O.RouteActionOptions{
-							Outbound: "dns-out",
-						},
-					},
-				},
-			},
-			{
-				Type: C.RuleTypeDefault,
-				DefaultOptions: O.DefaultRule{
-					RawDefaultRule: O.RawDefaultRule{
-						Inbound: badoption.Listable[string]{"tun-in"},
-						Domain:  badoption.Listable[string]{"api.iantem.io", "google.com"},
-					},
-					RuleAction: O.RuleAction{
-						Action: C.RuleActionTypeRoute,
-						RouteOptions: O.RouteActionOptions{
-							Outbound: "outline-out",
-						},
-					},
-				},
-			},
-			{
-				Type: C.RuleTypeDefault,
-				DefaultOptions: O.DefaultRule{
-					RawDefaultRule: O.RawDefaultRule{
-						Protocol: badoption.Listable[string]{"ssh"},
-					},
-					RuleAction: O.RuleAction{
-						Action: C.RuleActionTypeRoute,
-						RouteOptions: O.RouteActionOptions{
-							Outbound: "direct",
-						},
-					},
-				},
-			},
-			{
-				Type: C.RuleTypeDefault,
-				DefaultOptions: O.DefaultRule{
-					RawDefaultRule: O.RawDefaultRule{
-						Inbound: badoption.Listable[string]{"tun-in"},
-					},
-					RuleAction: O.RuleAction{
-						Action: C.RuleActionTypeRoute,
-						RouteOptions: O.RouteActionOptions{
-							Outbound: "direct",
-						},
-					},
-				},
-			},
-		},
-	},
-}
+	}
+
+	BaseEndpoints = []O.Endpoint{}
+)

--- a/client/service/custom_server_manager.go
+++ b/client/service/custom_server_manager.go
@@ -24,12 +24,13 @@ type CustomServerManager struct {
 }
 
 func NewCustomServerManager(ctx context.Context, dataDir string) *CustomServerManager {
-	return &CustomServerManager{
-		ctx:                   ctx,
+	csm := &CustomServerManager{
 		customServers:         make(map[string]CustomServerInfo),
 		customServersMutex:    new(sync.RWMutex),
 		customServersFilePath: filepath.Join(dataDir, "data", "custom_servers.json"),
 	}
+	csm.SetContext(ctx)
+	return csm
 }
 
 type customServers struct {
@@ -38,7 +39,7 @@ type customServers struct {
 
 // CustomServerInfo represents a custom server configuration.
 // Outbound and Endpoint options are mutually exclusive and there can only be
-// one of those fields nil.
+// one of those fields non-nil.
 type CustomServerInfo struct {
 	Tag      string           `json:"tag"`
 	Outbound *option.Outbound `json:"outbound,omitempty"`
@@ -50,6 +51,10 @@ type ServerConnectConfig []byte
 
 // SetContext update the context with the latest changes.
 func (m *CustomServerManager) SetContext(ctx context.Context) {
+	csm := service.PtrFromContext[CustomServerManager](ctx)
+	if csm == nil {
+		ctx = service.ContextWith(ctx, m)
+	}
 	m.ctx = ctx
 }
 

--- a/client/service/service.go
+++ b/client/service/service.go
@@ -61,6 +61,7 @@ const CustomSelectorTag = "custom_selector"
 // to interact with the underlying platform
 func New(config, baseDir string, platIfce libbox.PlatformInterface, rulesetManager *ruleset.Manager) (*BoxService, error) {
 	bs := &BoxService{
+		ctx:               newBaseContext(),
 		config:            atomic.Value{},
 		platIfce:          platIfce,
 		mutRuleSetManager: rulesetManager,

--- a/client/service/service.go
+++ b/client/service/service.go
@@ -32,6 +32,7 @@ import (
 	"github.com/getlantern/sing-box-extensions/protocol"
 	"github.com/getlantern/sing-box-extensions/ruleset"
 
+	"github.com/getlantern/radiance/client/boxoptions"
 	"github.com/getlantern/radiance/config"
 )
 
@@ -58,19 +59,24 @@ const CustomSelectorTag = "custom_selector"
 
 // New creates a new BoxService that wraps a [libbox.BoxService]. platformInterface is used
 // to interact with the underlying platform
-func New(config, dataDir string, platIfce libbox.PlatformInterface, rulesetManager *ruleset.Manager) (*BoxService, error) {
+func New(config, baseDir string, platIfce libbox.PlatformInterface, rulesetManager *ruleset.Manager) (*BoxService, error) {
 	bs := &BoxService{
 		config:            atomic.Value{},
 		platIfce:          platIfce,
 		mutRuleSetManager: rulesetManager,
 	}
 
-	bs.config.Store(config)
+	slog.Info("Creating libbox service with config", slog.String("config", config))
+	opts, err := json.UnmarshalExtendedContext[option.Options](BaseContext(), []byte(config))
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal options: %w", err)
+	}
 
+	bs.config.Store(opts)
 	setupOpts := &libbox.SetupOptions{
-		BasePath:    dataDir,
-		WorkingPath: filepath.Join(dataDir, "data"),
-		TempPath:    filepath.Join(dataDir, "temp"),
+		BasePath:    baseDir,
+		WorkingPath: filepath.Join(baseDir, "data"),
+		TempPath:    filepath.Join(baseDir, "temp"),
 	}
 	if runtime.GOOS == "android" {
 		setupOpts.FixAndroidStack = true
@@ -92,7 +98,7 @@ func (bs *BoxService) Start() error {
 	}
 
 	// (re)-initialize the libbox service
-	conf := bs.config.Load().(string)
+	conf := bs.config.Load().(option.Options)
 	lb, ctx, err := newLibboxService(conf, bs.platIfce)
 	if err != nil {
 		return fmt.Errorf("create libbox service: %w", err)
@@ -138,12 +144,16 @@ func newBaseContext() context.Context {
 }
 
 // newLibboxService creates a new libbox service with the given config and platform interface
-func newLibboxService(config string, platIfce libbox.PlatformInterface) (*libbox.BoxService, context.Context, error) {
+func newLibboxService(opts option.Options, platIfce libbox.PlatformInterface) (*libbox.BoxService, context.Context, error) {
 	// initialize the libbox service
 	// we need to create a new context each time so we have a fresh context, free of all the values
 	// that the sing-box instance adds to it
 	ctx := newBaseContext()
-	lb, err := libbox.NewServiceWithContext(ctx, config, platIfce)
+	conf, err := json.MarshalContext(ctx, opts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal options: %w", err)
+	}
+	lb, err := libbox.NewServiceWithContext(ctx, string(conf), platIfce)
 	if err != nil {
 		return nil, nil, fmt.Errorf("create libbox service: %w", err)
 	}
@@ -217,12 +227,13 @@ func (bs *BoxService) Ctx() context.Context {
 func (bs *BoxService) OnNewConfig(_, newConfig *config.Config) error {
 	slog.Debug("Received new config")
 
-	opts := newConfig.ConfigResponse.Options
-	conf, err := json.MarshalContext(bs.ctx, opts)
-	if err != nil {
-		return fmt.Errorf("marshal options: %w", err)
-	}
-	bs.config.Store(string(conf))
+	newOpts := newConfig.ConfigResponse.Options
+	currOpts := bs.config.Load().(option.Options)
+
+	currOpts.Outbounds = append(boxoptions.BaseOutbounds, newOpts.Outbounds...)
+	currOpts.Endpoints = append(boxoptions.BaseEndpoints, newOpts.Endpoints...)
+
+	bs.config.Store(currOpts)
 
 	bs.mu.Lock()
 	if !bs.isRunning {
@@ -231,7 +242,11 @@ func (bs *BoxService) OnNewConfig(_, newConfig *config.Config) error {
 	}
 	bs.mu.Unlock()
 
-	return updateOutboundsEndpoints(bs.ctx, opts.Outbounds, opts.Endpoints)
+	err := updateOutboundsEndpoints(bs.ctx, newOpts.Outbounds, newOpts.Endpoints)
+	if err != nil {
+		return fmt.Errorf("update outbounds/endpoints: %w", err)
+	}
+	return nil
 }
 
 func ParseConfig(configRaw []byte) (*config.Config, error) {
@@ -239,6 +254,7 @@ func ParseConfig(configRaw []byte) (*config.Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
+
 	return config, nil
 }
 

--- a/client/service/service_test.go
+++ b/client/service/service_test.go
@@ -42,8 +42,9 @@ func TestOnNewConfig(t *testing.T) {
 			mu:        sync.Mutex{},
 		}
 
+		bs.config.Store(option.Options{})
 		err := bs.OnNewConfig(nil, mockConfig)
-		if err != nil && strings.HasPrefix(err.Error(), "router missing") {
+		if err != nil && strings.Contains(err.Error(), "router missing") {
 			err = nil
 		}
 		require.NoError(t, err)
@@ -62,6 +63,7 @@ func TestOnNewConfig(t *testing.T) {
 			isRunning: false,
 		}
 
+		bs.config.Store(option.Options{})
 		err := bs.OnNewConfig(nil, mockConfig)
 		require.NoError(t, err)
 	})


### PR DESCRIPTION
This pull request refactors the configuration handling in the `BoxService` to use structured `option.Options` instead of raw strings, introduces default base outbounds and endpoints, and updates the options with the new outbounds and endpoints from recent config.

### Configuration Refactor:

* Updated `BoxService` to use `option.Options` for configuration instead of raw strings. This includes changes to the `New`, `Start`, and `OnNewConfig` methods, as well as the `newLibboxService` function. (`client/service/service.go`: [[1]](diffhunk://#diff-3e93cc11b22eab442b7c9435196e3101e2ac6f286ee1b63c98f0de4099bc5ab9L61-R79) [[2]](diffhunk://#diff-3e93cc11b22eab442b7c9435196e3101e2ac6f286ee1b63c98f0de4099bc5ab9L95-R101) [[3]](diffhunk://#diff-3e93cc11b22eab442b7c9435196e3101e2ac6f286ee1b63c98f0de4099bc5ab9L141-R156) [[4]](diffhunk://#diff-3e93cc11b22eab442b7c9435196e3101e2ac6f286ee1b63c98f0de4099bc5ab9L220-R236)

* Added logic to merge new configuration options with default base outbounds and endpoints (`BaseOutbounds` and `BaseEndpoints`) when applying updates. (`client/service/service.go`: [client/service/service.goL220-R236](diffhunk://#diff-3e93cc11b22eab442b7c9435196e3101e2ac6f286ee1b63c98f0de4099bc5ab9L220-R236))

### New Default Configuration Components:

* Introduced `BaseOutbounds` and `BaseEndpoints` in `boxoptions/options.go` to define default outbounds and endpoints for the service. (`client/boxoptions/options.go`: [client/boxoptions/options.goR203-R223](diffhunk://#diff-376a60d662a43ac127f3219f7d86b8fcd9d1d1371dbcd9fe37d91a99195f857bR203-R223))

### Test Updates:

* Updated test cases in `service_test.go` to initialize the `BoxService` configuration with `option.Options` to match the new structure. (`client/service/service_test.go`: [[1]](diffhunk://#diff-06f4a7dbfa0bfec2a5a1503607b4b3735ac58c6d5c12bfc7e056def9f638589eR45-R47) [[2]](diffhunk://#diff-06f4a7dbfa0bfec2a5a1503607b4b3735ac58c6d5c12bfc7e056def9f638589eR66)