### PR TITLE
Updated config merge to preserve elements we want to from old config while using new elements we want

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 
 	C "github.com/getlantern/common"
+	"github.com/qdm12/reprint"
 	"github.com/sagernet/sing-box/constant"
 	"github.com/sagernet/sing-box/option"
 	singjson "github.com/sagernet/sing/common/json"
@@ -289,11 +290,12 @@ func (ch *ConfigHandler) setConfigAndNotify(cfg *Config) {
 // mergeResp merges the old and new configuration responses. The merged response is returned
 // along with any error that occurred during the merge.
 func mergeResp(oldConfig, newConfig *C.ConfigResponse) (*C.ConfigResponse, error) {
-	if err := mergo.Merge(oldConfig, newConfig, mergo.WithOverride); err != nil {
+	oldConfigCopy := reprint.This(*oldConfig).(C.ConfigResponse)
+	if err := mergo.Merge(&oldConfigCopy, newConfig, mergo.WithOverride); err != nil {
 		slog.Error("merging config", "error", err)
 		return newConfig, err
 	}
-	return oldConfig, nil
+	return &oldConfigCopy, nil
 }
 
 // fetchLoop fetches the configuration every pollInterval.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -462,6 +462,80 @@ func TestMergeResp(t *testing.T) {
 		require.NoError(t, err, "Should not return an error when merging configs")
 		assert.Equal(t, mergedConfig, want)
 	})
+
+	t.Run("DoNotOverwriteAllOptions", func(t *testing.T) {
+		oldConfig := &C.ConfigResponse{
+			Options: O.Options{
+				DNS: &O.DNSOptions{
+					ReverseMapping: true,
+					Servers: []O.DNSServerOptions{
+						{
+							Tag:     "dns1",
+							Address: "8.8.8.8",
+						},
+					},
+				},
+				Outbounds: []O.Outbound{
+					{
+						Tag: "outbound1",
+						Options: map[string]interface{}{
+							"key": "value",
+						},
+					},
+					{
+						Tag: "outbound4",
+						Options: map[string]interface{}{
+							"key": "value",
+						},
+					},
+				},
+			},
+		}
+		newConfig := &C.ConfigResponse{
+			Options: O.Options{
+				DNS: &O.DNSOptions{
+					Servers: []O.DNSServerOptions{
+						{
+							Tag:     "dns1",
+							Address: "1.1.1.1",
+						},
+					},
+				},
+				Outbounds: []O.Outbound{
+					{
+						Tag: "outbound2",
+						Options: map[string]interface{}{
+							"key": "value",
+						},
+					},
+				},
+			},
+		}
+		want := &C.ConfigResponse{
+			Options: O.Options{
+				DNS: &O.DNSOptions{
+					ReverseMapping: true,
+					Servers: []O.DNSServerOptions{
+						{
+							Tag:     "dns1",
+							Address: "1.1.1.1",
+						},
+					},
+				},
+				Outbounds: []O.Outbound{
+					{
+						Tag: "outbound2",
+						Options: map[string]interface{}{
+							"key": "value",
+						},
+					},
+				},
+			},
+		}
+		mergedConfig, err := mergeResp(oldConfig, newConfig)
+		require.NoError(t, err, "Should not return an error when merging configs")
+		assert.Equal(t, mergedConfig, want)
+	})
 }
 
 // MockFetcher is a mock implementation of the fetcher used for testing

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -262,11 +262,8 @@ func TestMergeResp(t *testing.T) {
 			},
 		}
 
-		t.Logf("New config:    %+v", newConfig)
 		mergedConfig, err := mergeResp(oldConfig, newConfig)
 		require.NoError(t, err, "Should not return an error when merging configs")
-		t.Logf("New config:    %+v", newConfig)
-		t.Logf("Merged config: %+v", mergedConfig)
 		assert.Equal(t, newConfig.Servers, mergedConfig.Servers, "Merged servers should match newConfig servers")
 		assert.Equal(t, newConfig.Options, mergedConfig.Options, "Merged options should match newConfig options")
 		assert.Equal(t, newConfig.UserInfo.IP, mergedConfig.UserInfo.IP, "Merged IP should match newConfig IP")
@@ -301,11 +298,8 @@ func TestMergeResp(t *testing.T) {
 			},
 		}
 
-		t.Logf("New config:    %+v", newConfig)
 		mergedConfig, err := mergeResp(oldConfig, newConfig)
 		require.NoError(t, err, "Should not return an error when merging configs")
-		t.Logf("New config:    %+v", newConfig)
-		t.Logf("Merged config: %+v", mergedConfig)
 		assert.Equal(t, oldConfig.Servers, mergedConfig.Servers, "Merged servers should match oldConfig servers")
 		assert.Equal(t, newConfig.Options, mergedConfig.Options, "Merged options should match newConfig options")
 		assert.Equal(t, newConfig.UserInfo.IP, mergedConfig.UserInfo.IP, "Merged IP should match newConfig IP")
@@ -348,11 +342,8 @@ func TestMergeResp(t *testing.T) {
 			},
 		}
 
-		t.Logf("New config:    %+v", newConfig)
 		mergedConfig, err := mergeResp(oldConfig, newConfig)
 		require.NoError(t, err, "Should not return an error when merging configs")
-		t.Logf("New config:    %+v", newConfig)
-		t.Logf("Merged config: %+v", mergedConfig)
 		assert.Equal(t, oldConfig.Servers, mergedConfig.Servers, "Merged servers should match oldConfig servers")
 		assert.Equal(t, newConfig.Options.Outbounds, mergedConfig.Options.Outbounds, "Merged options should match newConfig options")
 		assert.Equal(t, newConfig.UserInfo.IP, mergedConfig.UserInfo.IP, "Merged IP should match newConfig IP")
@@ -396,11 +387,8 @@ func TestMergeResp(t *testing.T) {
 			},
 		}
 
-		t.Logf("New config:    %+v", newConfig)
 		mergedConfig, err := mergeResp(oldConfig, newConfig)
 		require.NoError(t, err, "Should not return an error when merging configs")
-		t.Logf("New config:    %+v", newConfig)
-		t.Logf("Merged config: %+v", mergedConfig)
 		assert.Equal(t, oldConfig.Servers, mergedConfig.Servers, "Merged servers should match oldConfig servers")
 		assert.Equal(t, newConfig.Options.Outbounds, mergedConfig.Options.Outbounds, "Merged Outbounds should match newConfig Outbounds")
 		assert.Equal(t, newConfig.UserInfo.IP, mergedConfig.UserInfo.IP, "Merged IP should match newConfig IP")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -395,6 +395,73 @@ func TestMergeResp(t *testing.T) {
 		assert.Equal(t, oldConfig.UserInfo.ProToken, mergedConfig.UserInfo.ProToken, "Merged ProToken should match oldConfig ProToken")
 		assert.Equal(t, oldConfig.Options.DNS, mergedConfig.Options.DNS, "Merged DNS options should match oldConfig DNS options")
 	})
+	t.Run("SuccessfulRemovedUnassignedOutbounds", func(t *testing.T) {
+		oldConfig := &C.ConfigResponse{
+			UserInfo: C.UserInfo{
+				IP:       "1.1.1.1",
+				ProToken: "test-pro-token",
+			},
+			Servers: []C.ServerLocation{
+				{Country: "US", City: "New York"},
+			},
+			Options: O.Options{
+				Outbounds: []O.Outbound{
+					{
+						Tag: "outbound1",
+						Options: map[string]interface{}{
+							"key": "value",
+						},
+					},
+					{
+						Tag: "outbound4",
+						Options: map[string]interface{}{
+							"key": "value",
+						},
+					},
+				},
+			},
+		}
+		newConfig := &C.ConfigResponse{
+			UserInfo: C.UserInfo{
+				IP: "2.2.2.2",
+			},
+			Servers: []C.ServerLocation{
+				{Country: "UK", City: "London"},
+			},
+			Options: O.Options{
+				Outbounds: []O.Outbound{
+					{
+						Tag: "outbound2",
+						Options: map[string]interface{}{
+							"key": "value",
+						},
+					},
+				},
+			},
+		}
+		want := &C.ConfigResponse{
+			UserInfo: C.UserInfo{
+				IP:       "2.2.2.2",
+				ProToken: "test-pro-token",
+			},
+			Servers: []C.ServerLocation{
+				{Country: "UK", City: "London"},
+			},
+			Options: O.Options{
+				Outbounds: []O.Outbound{
+					{
+						Tag: "outbound2",
+						Options: map[string]interface{}{
+							"key": "value",
+						},
+					},
+				},
+			},
+		}
+		mergedConfig, err := mergeResp(oldConfig, newConfig)
+		require.NoError(t, err, "Should not return an error when merging configs")
+		assert.Equal(t, mergedConfig, want)
+	})
 }
 
 // MockFetcher is a mock implementation of the fetcher used for testing

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ replace github.com/sagernet/wireguard-go => github.com/getlantern/wireguard-go v
 //replace github.com/getlantern/common => ../common
 
 require (
+	dario.cat/mergo v1.0.1
 	github.com/1Password/srp v0.2.0
 	github.com/getlantern/appdir v0.0.0-20250324200952-507a0625eb01
 	github.com/getlantern/common v1.2.1-0.20250428204107-678e5e36cbbf

--- a/go.mod
+++ b/go.mod
@@ -119,6 +119,7 @@ require (
 	github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/qdm12/reprint v0.0.0-20200326205758-722754a53494
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/quic-go/qtls-go1-20 v0.4.1 // indirect
 	github.com/sagernet/bbolt v0.0.0-20231014093535-ea5cb2fe9f0a // indirect

--- a/go.sum
+++ b/go.sum
@@ -245,6 +245,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/qdm12/reprint v0.0.0-20200326205758-722754a53494 h1:wSmWgpuccqS2IOfmYrbRiUgv+g37W5suLLLxwwniTSc=
+github.com/qdm12/reprint v0.0.0-20200326205758-722754a53494/go.mod h1:yipyliwI08eQ6XwDm1fEwKPdF/xdbkiHtrU+1Hg+vc4=
 github.com/quic-go/qpack v0.5.1 h1:giqksBPnT/HDtZ6VhtFKgoLOWmlyo9Ei6u9PqzIMbhI=
 github.com/quic-go/qpack v0.5.1/go.mod h1:+PC4XFrEskIVkcLzpEkbLqq1uCoxPhQuvK5rH1ZgaEg=
 github.com/quic-go/qtls-go1-20 v0.4.1 h1:D33340mCNDAIKBqXuAvexTNMUByrYmFYVfKfDN5nfFs=
@@ -306,6 +308,7 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
+dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/1Password/srp v0.2.0 h1:PZKAafEyExnwevliL6d2+FDhJXZ0phxqiG2OeIaj9Xk=
 github.com/1Password/srp v0.2.0/go.mod h1:LIGqQ7eEA0UJT98j7sXk60QWVpHJ3g00BX6LOm9kYTc=
 github.com/Jigsaw-Code/outline-sdk v0.0.19 h1:/OpMz+3B/9ypjq/UyEvwZSflzJ4jXFginUOZeN0UssM=


### PR DESCRIPTION
This switches back to using mergo for merging config structs so that we preserve the elements of the old config we want while using elements of the new config we want. This allows the server side to carefully include only the changes we desire vs responding the the entire sing-box options every time.

This pull request refactors the configuration merging logic in `config/config.go` to improve maintainability and correctness. It replaces the custom `mergeResp` function with the `mergo` library for merging configurations and updates the associated test suite to ensure comprehensive coverage of the new behavior.

### Refactoring and dependency updates:

* Replaced the custom `mergeResp` function with an implementation using the `mergo` library to simplify and improve the merging logic for configuration responses. The new implementation uses pointers for `ConfigResponse` and supports overriding fields during the merge. (`config/config.go`, [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L272-R278) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L292-R296)
* Added the `dario.cat/mergo` dependency to the project in `go.mod` to support the new configuration merging functionality.

### Bug fixes in configuration handling:

* Fixed a bug in `setConfigAndNotify` where the `PreferredLocation` field was incorrectly updated. The condition was inverted to ensure that the default value is only set when `PreferredLocation` is empty. (`config/config.go`, [config/config.goL272-R278](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L272-R278))

### Test suite improvements:

* Added a new test function, `TestMergeResp`, to verify the behavior of the updated `mergeResp` function. The tests cover various scenarios, including successful merges, handling of empty server locations, overwriting outbound options, and preserving DNS options. (`config/config_test.go`, [config/config_test.goR234-R411](diffhunk://#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82R234-R411))

### Code cleanup:

* Removed the unused `context` import and the deprecated `badjson` library from `config/config.go`. (`config/config.go`, [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L7) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R18-L25)
* Added a missing alias for the `option` package (`O`) in `config/config_test.go` for consistency. (`config/config_test.go`, [config/config_test.goR12](diffhunk://#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82R12))