### PR TITLE
OAuth APIS

### DIFF
--- a/api/pro.go
+++ b/api/pro.go
@@ -21,7 +21,7 @@ type Pro struct {
 }
 
 // New returns the object handling anything pro-server related
-func NewPro(httpClient *http.Client, userConfig common.UserInfo) *Pro {
+func NewPro(httpClient *http.Client, userInfo common.UserInfo) *Pro {
 	opts := common.WebClientOptions{
 		HttpClient: httpClient,
 		BaseURL:    common.ProServerUrl,
@@ -30,12 +30,12 @@ func NewPro(httpClient *http.Client, userConfig common.UserInfo) *Pro {
 			req.Header.Set(backend.AppNameHeader, app.Name)
 			req.Header.Set(backend.VersionHeader, app.Version)
 			req.Header.Set(backend.PlatformHeader, app.Platform)
-			req.Header.Set(backend.DeviceIDHeader, userConfig.DeviceID())
-			if userConfig.LegacyToken() != "" {
-				req.Header.Set(backend.ProTokenHeader, userConfig.LegacyToken())
+			req.Header.Set(backend.DeviceIDHeader, userInfo.DeviceID())
+			if userInfo.LegacyToken() != "" {
+				req.Header.Set(backend.ProTokenHeader, userInfo.LegacyToken())
 			}
-			if userConfig.LegacyID() != 0 {
-				req.Header.Set(backend.UserIDHeader, strconv.FormatInt(userConfig.LegacyID(), 10))
+			if userInfo.LegacyID() != 0 {
+				req.Header.Set(backend.UserIDHeader, strconv.FormatInt(userInfo.LegacyID(), 10))
 			}
 			if req.URL != nil && strings.HasSuffix(req.URL.Path, "/subscription-payment-redirect") {
 				req.Header.Set(backend.RefererHeader, "https://lantern.io/")
@@ -46,7 +46,7 @@ func NewPro(httpClient *http.Client, userConfig common.UserInfo) *Pro {
 	return &Pro{
 		proClient: &proClient{
 			WebClient: common.NewWebClient(&opts),
-			UserInfo:  userConfig,
+			UserInfo:  userInfo,
 		},
 	}
 }

--- a/api/pro.go
+++ b/api/pro.go
@@ -54,7 +54,16 @@ func NewPro(httpClient *http.Client, userConfig common.UserInfo) *Pro {
 // Create a new user account
 func (u *Pro) UserCreate(ctx context.Context) (*protos.UserDataResponse, error) {
 	return u.proClient.CreateUser(ctx)
+}
 
+// UserData returns the user data
+func (u *Pro) UserData(ctx context.Context) (*protos.UserDataResponse, error) {
+	resp, err := u.proClient.UserData(ctx)
+	if err != nil {
+		slog.Error("Error in UserData", "error", err)
+		return nil, err
+	}
+	return resp, nil
 }
 
 // SubscriptionPaymentRedirect creates a new subscription with url

--- a/api/pro_api.go
+++ b/api/pro_api.go
@@ -68,18 +68,19 @@ func (c *proClient) CreateUser(ctx context.Context) (*protos.UserDataResponse, e
 	return resp, nil
 }
 
-// UserData is used to get user data
-// this will be also save data to user config
+// UserData will request the user data and return the response.
 func (c *proClient) UserData(ctx context.Context) (*protos.UserDataResponse, error) {
 	var resp *protos.UserDataResponse
 	err := c.Get(ctx, "/user-data", nil, &resp)
 	if err != nil {
-		slog.Error("Error in UserData: %v", "err", err)
+		err = fmt.Errorf("seding user data request: %v", err)
+		slog.Error("", "err", err)
 		return nil, err
 	}
 	if resp.BaseResponse != nil && resp.BaseResponse.Error != "" {
-		slog.Error("Error in UserData: %v", "err", resp.BaseResponse.Error)
-		return nil, fmt.Errorf("error in UserData: %s", resp.BaseResponse.Error)
+		err = fmt.Errorf("recevied bad response: %s", resp.BaseResponse.Error)
+		slog.Error("", "err", err)
+		return nil, err
 	}
 	login := &protos.LoginResponse{
 		LegacyID:       resp.LoginResponse_UserData.UserId,
@@ -89,7 +90,8 @@ func (c *proClient) UserData(ctx context.Context) (*protos.UserDataResponse, err
 	/// Write user data to file
 	err = c.UserInfo.Save(login)
 	if err != nil {
-		slog.Error("Error writing user data: %v", "err", err)
+		err = fmt.Errorf("writing user data: %v", err)
+		slog.Error("", "err", err)
 		return nil, err
 	}
 	return resp, nil

--- a/api/pro_api.go
+++ b/api/pro_api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/getlantern/radiance/api/protos"
@@ -22,6 +23,7 @@ type ProClient interface {
 	Plans(ctx context.Context) (*protos.PlansResponse, error)
 	// User methods
 	CreateUser(ctx context.Context) (*protos.UserDataResponse, error)
+	UserData(ctx context.Context) (*protos.UserDataResponse, error)
 }
 
 // SubscriptionPaymentRedirect is used to get the subscription payment redirect URL with SubscriptionPaymentRedirectRequest
@@ -51,6 +53,33 @@ func (c *proClient) CreateUser(ctx context.Context) (*protos.UserDataResponse, e
 	if err != nil {
 		slog.Error("Error in UserCreate: %v", "err", err)
 		return nil, err
+	}
+	login := &protos.LoginResponse{
+		LegacyID:       resp.LoginResponse_UserData.UserId,
+		LegacyToken:    resp.LoginResponse_UserData.Token,
+		LegacyUserData: resp.LoginResponse_UserData,
+	}
+	/// Write user data to file
+	err = c.UserInfo.Save(login)
+	if err != nil {
+		slog.Error("Error writing user data: %v", "err", err)
+		return nil, err
+	}
+	return resp, nil
+}
+
+// UserData is used to get user data
+// this will be also save data to user config
+func (c *proClient) UserData(ctx context.Context) (*protos.UserDataResponse, error) {
+	var resp *protos.UserDataResponse
+	err := c.Get(ctx, "/user-data", nil, &resp)
+	if err != nil {
+		slog.Error("Error in UserCreate: %v", "err", err)
+		return nil, err
+	}
+	if resp.BaseResponse != nil && resp.BaseResponse.Error != "" {
+		slog.Error("Error in UserData: %v", "err", resp.BaseResponse.Error)
+		return nil, fmt.Errorf("error in UserData: %s", resp.BaseResponse.Error)
 	}
 	login := &protos.LoginResponse{
 		LegacyID:       resp.LoginResponse_UserData.UserId,

--- a/api/pro_api.go
+++ b/api/pro_api.go
@@ -74,7 +74,7 @@ func (c *proClient) UserData(ctx context.Context) (*protos.UserDataResponse, err
 	var resp *protos.UserDataResponse
 	err := c.Get(ctx, "/user-data", nil, &resp)
 	if err != nil {
-		slog.Error("Error in UserCreate: %v", "err", err)
+		slog.Error("Error in UserData: %v", "err", err)
 		return nil, err
 	}
 	if resp.BaseResponse != nil && resp.BaseResponse.Error != "" {

--- a/api/user.go
+++ b/api/user.go
@@ -405,8 +405,7 @@ func (u *User) DeleteAccount(ctx context.Context, password string) error {
 
 // OAuthLogin initiates the OAuth login process for the specified provider.
 func (u *User) OAuthLoginUrl(ctx context.Context, provider string) (*protos.SubscriptionPaymentRedirectResponse, error) {
-	loginUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s", common.APIBaseUrl, "users/oauth2", provider))
-	// https: //df.iantem.io/api/v1/users/oauth2/google'
+	loginUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s", "https://df.iantem.io/api/v1", "users/oauth2", provider))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse URL: %w", err)
 	}

--- a/api/user_api.go
+++ b/api/user_api.go
@@ -28,10 +28,6 @@ type AuthClient interface {
 	DeleteAccount(ctc context.Context, loginData *protos.DeleteUserRequest) error
 	// Logout
 	SignOut(ctx context.Context, logoutData *protos.LogoutRequest) error
-
-	// //OAuth
-	// OAuthProvider(ctx context.Context) (*protos.OAuthProviderNames, error)
-	// OAuthLogin(ctx context.Context, provider string) (*protos.SubscriptionPaymentRedirectResponse, error)
 }
 
 type authClient struct {
@@ -144,21 +140,3 @@ func (c *authClient) SignOut(ctx context.Context, logoutData *protos.LogoutReque
 	var resp protos.EmptyResponse
 	return c.PostPROTOC(ctx, "/users/logout", logoutData, &resp)
 }
-
-// func (c *authClient) OAuthProvider(ctx context.Context) (*protos.OAuthProviderNames, error) {
-// 	var resp *protos.OAuthProviderNames
-// 	err := c.Get(ctx, "/users/oauth2/providers", nil, &resp)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	return resp, nil
-// }
-
-// func (c *authClient) OAuthLogin(ctx context.Context, provider string) (*protos.SubscriptionPaymentRedirectResponse, error) {
-// 	var resp *protos.SubscriptionPaymentRedirectResponse
-// 	err := c.Get(ctx, "/users/oauth2/google", nil, &resp)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	return resp, nil
-// }

--- a/api/user_api.go
+++ b/api/user_api.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/getlantern/radiance/common"
 	"github.com/getlantern/radiance/api/protos"
+	"github.com/getlantern/radiance/common"
 )
 
 type AuthClient interface {
@@ -28,6 +28,10 @@ type AuthClient interface {
 	DeleteAccount(ctc context.Context, loginData *protos.DeleteUserRequest) error
 	// Logout
 	SignOut(ctx context.Context, logoutData *protos.LogoutRequest) error
+
+	// //OAuth
+	// OAuthProvider(ctx context.Context) (*protos.OAuthProviderNames, error)
+	// OAuthLogin(ctx context.Context, provider string) (*protos.SubscriptionPaymentRedirectResponse, error)
 }
 
 type authClient struct {
@@ -140,3 +144,21 @@ func (c *authClient) SignOut(ctx context.Context, logoutData *protos.LogoutReque
 	var resp protos.EmptyResponse
 	return c.PostPROTOC(ctx, "/users/logout", logoutData, &resp)
 }
+
+// func (c *authClient) OAuthProvider(ctx context.Context) (*protos.OAuthProviderNames, error) {
+// 	var resp *protos.OAuthProviderNames
+// 	err := c.Get(ctx, "/users/oauth2/providers", nil, &resp)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	return resp, nil
+// }
+
+// func (c *authClient) OAuthLogin(ctx context.Context, provider string) (*protos.SubscriptionPaymentRedirectResponse, error) {
+// 	var resp *protos.SubscriptionPaymentRedirectResponse
+// 	err := c.Get(ctx, "/users/oauth2/google", nil, &resp)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	return resp, nil
+// }

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -121,6 +121,19 @@ func TestDeleteAccount(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestOAuthLoginUrl(t *testing.T) {
+	u := &User{
+		userData:   &protos.LoginResponse{Id: "test@example.com"},
+		authClient: nil,
+		deviceId:   "deviceId",
+		salt:       nil,
+		userConfig: &mockUserConfig{},
+	}
+	url, err := u.OAuthLoginUrl(context.Background(), "google")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, url)
+}
+
 // Mock implementation of AuthClient for testing purposes
 type mockAuthClient struct {
 	cache    map[string]string

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"math/big"
-	"net/http"
 	"testing"
 
 	"github.com/1Password/srp"
@@ -123,7 +122,9 @@ func TestDeleteAccount(t *testing.T) {
 }
 
 func TestOAuthLoginUrl(t *testing.T) {
-	user := NewUser(&http.Client{}, commonConfig())
+	user := &User{
+		userConfig: commonConfig(),
+	}
 	url, err := user.OAuthLoginUrl(context.Background(), "google")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, url)

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"math/big"
+	"net/http"
 	"testing"
 
 	"github.com/1Password/srp"
@@ -122,14 +123,8 @@ func TestDeleteAccount(t *testing.T) {
 }
 
 func TestOAuthLoginUrl(t *testing.T) {
-	u := &User{
-		userData:   &protos.LoginResponse{Id: "test@example.com"},
-		authClient: nil,
-		deviceId:   "deviceId",
-		salt:       nil,
-		userConfig: &mockUserConfig{},
-	}
-	url, err := u.OAuthLoginUrl(context.Background(), "google")
+	user := NewUser(&http.Client{}, commonConfig())
+	url, err := user.OAuthLoginUrl(context.Background(), "google")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, url)
 }

--- a/init.go
+++ b/init.go
@@ -29,9 +29,9 @@ var (
 
 // sharedConfig is a struct that contains the shared configuration for the Radiance client and API handler.
 type sharedConfig struct {
-	logWriter  io.Writer
-	userConfig common.UserInfo
-	kindling   kindling.Kindling
+	logWriter io.Writer
+	userInfo  common.UserInfo
+	kindling  kindling.Kindling
 }
 
 // initCommon initializes the common configuration for the Radiance client and API handler.
@@ -84,9 +84,9 @@ func initialize(opts client.Options) (*sharedConfig, error) {
 			kindling.WithProxyless("api.iantem.io"))
 
 		sharedInit = &sharedConfig{
-			logWriter:  logWriter,
-			userConfig: common.NewUserConfig(platformDeviceID, opts.DataDir, opts.Locale),
-			kindling:   k,
+			logWriter: logWriter,
+			userInfo:  common.NewUserConfig(platformDeviceID, opts.DataDir, opts.Locale),
+			kindling:  k,
 		}
 		slog.Debug("Initialized shared config", "dataDir", opts.DataDir, "logDir", opts.LogDir, "locale", opts.Locale)
 	})

--- a/radiance.go
+++ b/radiance.go
@@ -52,7 +52,7 @@ type Radiance struct {
 	activeServer *atomic.Value
 	stopChan     chan struct{}
 	//user config is the user config object that contains the device ID and other user data
-	userConfig common.UserInfo
+	userInfo common.UserInfo
 
 	issueReporter *issue.IssueReporter
 	logsDir       string
@@ -83,15 +83,15 @@ func NewRadiance(opts client.Options) (*Radiance, error) {
 		return nil, fmt.Errorf("failed to create VPN client: %w", err)
 	}
 
-	u := api.NewUser(init.kindling.NewHTTPClient(), init.userConfig)
-	issueReporter, err := issue.NewIssueReporter(init.kindling.NewHTTPClient(), u, init.userConfig)
+	u := api.NewUser(init.kindling.NewHTTPClient(), init.userInfo)
+	issueReporter, err := issue.NewIssueReporter(init.kindling.NewHTTPClient(), u, init.userInfo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create issue reporter: %w", err)
 	}
 	cOpts := config.Options{
 		PollInterval:     configPollInterval,
 		HTTPClient:       init.kindling.NewHTTPClient(),
-		User:             init.userConfig,
+		User:             init.userInfo,
 		DataDir:          opts.DataDir,
 		ConfigRespParser: boxservice.UnmarshalConfig,
 		Locale:           opts.Locale,
@@ -104,7 +104,7 @@ func NewRadiance(opts client.Options) (*Radiance, error) {
 		confHandler:   confHandler,
 		activeServer:  new(atomic.Value),
 		stopChan:      make(chan struct{}),
-		userConfig:    init.userConfig,
+		userInfo:    init.userInfo,
 		issueReporter: issueReporter,
 		logsDir:       opts.LogDir,
 		shutdownFuncs: shutdownFuncs,
@@ -119,7 +119,7 @@ func NewAPIHandler(opts client.Options) (*api.APIHandler, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize common: %w", err)
 	}
-	apiHandler := api.NewAPIHandlerInternal(init.kindling.NewHTTPClient(), init.userConfig)
+	apiHandler := api.NewAPIHandlerInternal(init.kindling.NewHTTPClient(), init.userInfo)
 	return apiHandler, nil
 }
 
@@ -174,7 +174,7 @@ func (r *Radiance) GetActiveServer() (*Server, error) {
 // UserInfo returns the user info object for this client
 // This is the user config object that contains the device ID and other user data
 func (r *Radiance) UserInfo() common.UserInfo {
-	return r.userConfig
+	return r.userInfo
 }
 
 // IssueReport represents a user report of a bug or service problem. This report can be submitted


### PR DESCRIPTION
This pull request introduces new functionality for user data retrieval and OAuth login, along with associated tests and minor refactoring. The most important changes include adding a `UserData` method to retrieve user data, implementing an `OAuthLoginUrl` method for initiating OAuth login, and updating tests to cover the new functionality.

### New functionality for user data retrieval:

* Added a `UserData` method to the `Pro` struct and `ProClient` interface to fetch user data from the API, log errors, and save the retrieved data to the user configuration. (`api/pro.go` [[1]](diffhunk://#diff-e4dc6bb43b725d271e3a42224c03ccbbfa8027d8f30a9b71047791bdfaacc58eR57-R66) `api/pro_api.go` [[2]](diffhunk://#diff-117fab96fad71f627d01ee7eb717de3ebce047a86dc8f275c28e3ee62547fedcR26) [[3]](diffhunk://#diff-117fab96fad71f627d01ee7eb717de3ebce047a86dc8f275c28e3ee62547fedcR69-R95)

### New functionality for OAuth login:

* Implemented the `OAuthLoginUrl` method in the `User` struct to generate an OAuth login URL for a specified provider, including query parameters for device ID, user ID, and token. (`api/user.go` [api/user.goR405-R421](diffhunk://#diff-b79b6222953de1b763724ba341a1726bd3a31e17a13ab757355430ed410068fdR405-R421))

### Test coverage:

* Added a unit test for the `OAuthLoginUrl` method to ensure it generates a valid URL without errors. (`api/user_test.go` [api/user_test.goR124-R136](diffhunk://#diff-3185e43859af3f442c0e19cff6b8a7373c9172e180d1aa2fa459451e541be1afR124-R136))

### Minor refactoring:

* Added necessary imports for `fmt`, `url`, and `strconv` in relevant files to support the new functionality. (`api/pro_api.go` [[1]](diffhunk://#diff-117fab96fad71f627d01ee7eb717de3ebce047a86dc8f275c28e3ee62547fedcR5) `api/user.go` [[2]](diffhunk://#diff-b79b6222953de1b763724ba341a1726bd3a31e17a13ab757355430ed410068fdR9-R10)
* Reorganized imports in `api/user_api.go` for consistency. (`api/user_api.go` [api/user_api.goL7-R8](diffhunk://#diff-c20c2426c8512708ad39948eccfa04a32388954f0a3c7ba483382c691520d3cdL7-R8))