### PR TITLE
Temp wg patch

### DIFF
--- a/client/boxoptions/options.go
+++ b/client/boxoptions/options.go
@@ -73,7 +73,7 @@ var (
 					},
 					AutoRoute:              true,
 					StrictRoute:            true,
-					EndpointIndependentNat: true,
+					EndpointIndependentNat: false,
 					Stack:                  "system",
 				},
 			},

--- a/client/boxoptions/options.go
+++ b/client/boxoptions/options.go
@@ -71,10 +71,8 @@ var (
 					Address: badoption.Listable[netip.Prefix]{
 						netip.MustParsePrefix("10.10.1.1/30"),
 					},
-					AutoRoute:              true,
-					StrictRoute:            true,
-					EndpointIndependentNat: false,
-					Stack:                  "system",
+					AutoRoute:   true,
+					StrictRoute: true,
 				},
 			},
 		},

--- a/client/client.go
+++ b/client/client.go
@@ -134,6 +134,7 @@ func (c *vpnClient) StartVPN() error {
 	}
 	err := c.boxService.Start()
 	if err != nil {
+		slog.Error("Failed to start boxService", "error", err)
 		return err
 	}
 

--- a/client/service/service.go
+++ b/client/service/service.go
@@ -34,8 +34,6 @@ import (
 	"github.com/getlantern/sing-box-extensions/protocol"
 	"github.com/getlantern/sing-box-extensions/ruleset"
 
-	exO "github.com/getlantern/sing-box-extensions/option"
-
 	"github.com/getlantern/radiance/client/boxoptions"
 	"github.com/getlantern/radiance/config"
 )
@@ -155,9 +153,9 @@ func newLibboxService(opts option.Options, platIfce libbox.PlatformInterface) (*
 	// that the sing-box instance adds to it
 	ctx := newBaseContext()
 
-	// TEMP: only use first wg endpoint and clear tun name
+	// TEMP: only use first wg endpoint
+	// TODO: remove this when the config API is updated to only return one endpoint
 	opts.Endpoints = opts.Endpoints[:0]
-	patchWGName(opts.Endpoints)
 
 	optsStr, _ := json.MarshalContext(ctx, opts)
 	slog.Info("Creating libbox service", slog.String("opts", string(optsStr)))
@@ -171,18 +169,6 @@ func newLibboxService(opts option.Options, platIfce libbox.PlatformInterface) (*
 	}
 
 	return lb, ctx, nil
-}
-
-func patchWGName(endpoints []option.Endpoint) {
-	for _, endpoint := range endpoints {
-		switch opts := endpoint.Options.(type) {
-		case *option.WireGuardEndpointOptions:
-			opts.Name = ""
-		case *exO.AmneziaWGEndpointOptions:
-			opts.Name = ""
-		default:
-		}
-	}
 }
 
 // Close stops the libbox service and clears the pause timer

--- a/client/service/service.go
+++ b/client/service/service.go
@@ -158,7 +158,7 @@ func newLibboxService(opts option.Options, platIfce libbox.PlatformInterface) (*
 	opts.Endpoints = opts.Endpoints[:0]
 
 	optsStr, _ := json.MarshalContext(ctx, opts)
-	slog.Info("Creating libbox service", slog.String("opts", string(optsStr)))
+	slog.Debug("Creating libbox service", slog.String("opts", string(optsStr)))
 	conf, err := json.MarshalContext(ctx, opts)
 	if err != nil {
 		return nil, nil, fmt.Errorf("marshal options: %w", err)

--- a/client/service/service.go
+++ b/client/service/service.go
@@ -156,12 +156,11 @@ func newLibboxService(opts option.Options, platIfce libbox.PlatformInterface) (*
 	// TODO: remove this when the config API is updated to only return one endpoint
 	opts.Endpoints = opts.Endpoints[:1]
 
-	optsStr, _ := json.MarshalContext(ctx, opts)
-	slog.Debug("Creating libbox service", slog.String("opts", string(optsStr)))
 	conf, err := json.MarshalContext(ctx, opts)
 	if err != nil {
 		return nil, nil, fmt.Errorf("marshal options: %w", err)
 	}
+	slog.Debug("Creating libbox service", slog.String("options", string(conf)))
 	lb, err := libbox.NewServiceWithContext(ctx, string(conf), platIfce)
 	if err != nil {
 		return nil, nil, fmt.Errorf("create libbox service: %w", err)

--- a/client/service/service.go
+++ b/client/service/service.go
@@ -69,7 +69,6 @@ func New(config, baseDir string, platIfce libbox.PlatformInterface, rulesetManag
 		mutRuleSetManager: rulesetManager,
 	}
 
-	slog.Info("Creating libbox service with config", slog.String("config", config))
 	opts, err := json.UnmarshalExtendedContext[option.Options](BaseContext(), []byte(config))
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal options: %w", err)

--- a/client/service/service.go
+++ b/client/service/service.go
@@ -155,7 +155,7 @@ func newLibboxService(opts option.Options, platIfce libbox.PlatformInterface) (*
 
 	// TEMP: only use first wg endpoint
 	// TODO: remove this when the config API is updated to only return one endpoint
-	opts.Endpoints = opts.Endpoints[:0]
+	opts.Endpoints = opts.Endpoints[:1]
 
 	optsStr, _ := json.MarshalContext(ctx, opts)
 	slog.Debug("Creating libbox service", slog.String("opts", string(optsStr)))

--- a/config/config.go
+++ b/config/config.go
@@ -99,6 +99,9 @@ func NewConfigHandler(options Options) *ConfigHandler {
 		wgKeyPath:       filepath.Join(options.DataDir, "wg.key"),
 	}
 
+	// Set the preferred location to an empty struct to define the underlying type.
+	ch.preferredLocation.Store(C.ServerLocation{})
+
 	if err := ch.loadConfig(); err != nil {
 		slog.Error("failed to load config", "error", err)
 	}
@@ -280,10 +283,7 @@ func (ch *ConfigHandler) setConfigAndNotify(cfg *Config) {
 		cfg.ConfigResponse = *merged
 
 		if cfg.PreferredLocation == (C.ServerLocation{}) {
-			location := ch.preferredLocation.Load()
-			if location != nil {
-				cfg.PreferredLocation = location.(C.ServerLocation)
-			}
+			cfg.PreferredLocation = ch.preferredLocation.Load().(C.ServerLocation)
 		}
 	}
 


### PR DESCRIPTION
This pull request introduces logging enhancements, temporary configuration adjustments, and minor refactoring to improve code maintainability and debugging capabilities. 

### Logging Enhancements:
* Added error logging in `StartVPN` to capture failures when starting the `boxService` (`client/client.go`).
* Introduced debug logs in `updateOutbounds` and `updateEndpoints` to provide more visibility into the creation of outbounds and endpoints (`client/service/service.go`) [[1]](diffhunk://#diff-3e93cc11b22eab442b7c9435196e3101e2ac6f286ee1b63c98f0de4099bc5ab9R359) [[2]](diffhunk://#diff-3e93cc11b22eab442b7c9435196e3101e2ac6f286ee1b63c98f0de4099bc5ab9R397).
* Added debug logging for `libbox` service creation, including serialized options for better traceability (`client/service/service.go`).

### Temporary Configuration Adjustments:
* Limited the `Endpoints` slice to zero elements as a temporary measure until the configuration API is updated to return only one endpoint (`client/service/service.go`).

### Refactoring:
* Simplified the handling of `PreferredLocation` in `ConfigHandler` by initializing it explicitly and removing redundant null checks (`config/config.go`) [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R102-R104) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L283-R286).

### Code Cleanup:
* Removed unused fields (`EndpointIndependentNat` and `Stack`) from the `options.go` file to streamline the configuration structure (`client/boxoptions/options.go`).