### PR TITLE
add lantern urltest outbound

### DIFF
--- a/client/boxoptions/options.go
+++ b/client/boxoptions/options.go
@@ -76,7 +76,8 @@ var (
 				},
 			},
 		},
-		Outbounds: BaseOutbounds,
+		// use direct as the default outbound for URLTest so sing-box starts
+		Outbounds: append(BaseOutbounds, URLTestOutbound([]string{"direct"})),
 		Route: &O.RouteOptions{
 			AutoDetectInterface: true,
 			Rules: []O.Rule{
@@ -122,7 +123,6 @@ var (
 			},
 		},
 	}
-
 	BaseOutbounds = []O.Outbound{
 		{
 			Type:    "direct",
@@ -139,10 +139,7 @@ var (
 			Tag:     "block",
 			Options: &O.StubOptions{},
 		},
-		// use direct as the default outbound so sing-box starts
-		URLTestOutbound([]string{"direct"}),
 	}
-
 	BaseEndpoints = []O.Endpoint{}
 )
 

--- a/client/boxoptions/options.go
+++ b/client/boxoptions/options.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sagernet/sing/common/json/badoption"
 )
 
-const LanternURLTestTag = "lantern_servers"
+const LanternAutoTag = "lantern-auto"
 
 var (
 	BoxOptions = O.Options{
@@ -114,7 +114,7 @@ var (
 						RuleAction: O.RuleAction{
 							Action: C.RuleActionTypeRoute,
 							RouteOptions: O.RouteActionOptions{
-								Outbound: LanternURLTestTag,
+								Outbound: LanternAutoTag,
 							},
 						},
 					},
@@ -149,7 +149,7 @@ var (
 func URLTestOutbound(tags []string) O.Outbound {
 	return option.Outbound{
 		Type: constant.TypeURLTest,
-		Tag:  LanternURLTestTag,
+		Tag:  LanternAutoTag,
 		Options: &option.URLTestOutboundOptions{
 			Outbounds: tags,
 		},

--- a/client/service/service.go
+++ b/client/service/service.go
@@ -249,7 +249,7 @@ func (bs *BoxService) OnNewConfig(_, newConfig *config.Config) error {
 	// update the lanter URLTest outbound with the new tags
 	newTags := collectTags(newOpts.Outbounds, newOpts.Endpoints)
 	idx := slices.IndexFunc(currOpts.Outbounds, func(it option.Outbound) bool {
-		return it.Tag == boxoptions.LanternURLTestTag
+		return it.Tag == boxoptions.LanternAutoTag
 	})
 	if idx != -1 {
 		opts := currOpts.Outbounds[idx].Options.(*option.URLTestOutboundOptions)
@@ -363,11 +363,11 @@ func collectTags(outbounds []option.Outbound, endpoints []option.Endpoint) []str
 // all tags are present in the existing URLTest outbound. If they are, it does nothing.
 func reinitializeURLTest(ctx context.Context, newTags []string) error {
 	outboundMgr := service.FromContext[adapter.OutboundManager](ctx)
-	outbound, fnd := outboundMgr.Outbound(boxoptions.LanternURLTestTag)
+	outbound, fnd := outboundMgr.Outbound(boxoptions.LanternAutoTag)
 	if fnd {
 		urlTest, ok := outbound.(*group.URLTest)
 		if !ok {
-			return fmt.Errorf("outbound %s is not a URLTest", boxoptions.LanternURLTestTag)
+			return fmt.Errorf("outbound %s is not a URLTest", boxoptions.LanternAutoTag)
 		}
 		tags := urlTest.All()
 		slices.Sort(newTags)
@@ -382,8 +382,8 @@ func reinitializeURLTest(ctx context.Context, newTags []string) error {
 	err := outboundMgr.Create(
 		ctx,
 		router,
-		logFactory.NewLogger(boxoptions.LanternURLTestTag),
-		boxoptions.LanternURLTestTag,
+		logFactory.NewLogger(boxoptions.LanternAutoTag),
+		boxoptions.LanternAutoTag,
 		constant.TypeURLTest,
 		&option.URLTestOutboundOptions{
 			Outbounds: newTags,

--- a/client/service/service.go
+++ b/client/service/service.go
@@ -24,9 +24,11 @@ import (
 
 	box "github.com/sagernet/sing-box"
 	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/constant"
 	"github.com/sagernet/sing-box/experimental/libbox"
 	"github.com/sagernet/sing-box/log"
 	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing-box/protocol/group"
 	"github.com/sagernet/sing/common/json"
 	"github.com/sagernet/sing/service"
 	"github.com/sagernet/sing/service/pause"
@@ -244,6 +246,18 @@ func (bs *BoxService) OnNewConfig(_, newConfig *config.Config) error {
 	currOpts.Outbounds = append(boxoptions.BaseOutbounds, newOpts.Outbounds...)
 	currOpts.Endpoints = append(boxoptions.BaseEndpoints, newOpts.Endpoints...)
 
+	// update the lanter URLTest outbound with the new tags
+	newTags := collectTags(newOpts.Outbounds, newOpts.Endpoints)
+	idx := slices.IndexFunc(currOpts.Outbounds, func(it option.Outbound) bool {
+		return it.Tag == boxoptions.LanternURLTestTag
+	})
+	if idx != -1 {
+		opts := currOpts.Outbounds[idx].Options.(*option.URLTestOutboundOptions)
+		opts.Outbounds = newTags
+	} else { // this should never happen but just in case
+		currOpts.Outbounds = append(currOpts.Outbounds, boxoptions.URLTestOutbound(newTags))
+	}
+
 	// add custom server outbounds/endpoints
 	csm := service.PtrFromContext[CustomServerManager](bs.ctx)
 	if csm != nil {
@@ -270,6 +284,11 @@ func (bs *BoxService) OnNewConfig(_, newConfig *config.Config) error {
 	if err != nil {
 		return fmt.Errorf("update outbounds/endpoints: %w", err)
 	}
+
+	if err = reinitializeURLTest(bs.ctx, newTags); err != nil {
+		return fmt.Errorf("reinitialize urltest: %w", err)
+	}
+
 	return nil
 }
 
@@ -327,6 +346,53 @@ func updateOutboundsEndpoints(ctx context.Context, outbounds []option.Outbound, 
 		}
 	}
 	return errs
+}
+
+func collectTags(outbounds []option.Outbound, endpoints []option.Endpoint) []string {
+	tags := make([]string, 0, len(outbounds)+len(endpoints))
+	for _, outbound := range outbounds {
+		tags = append(tags, outbound.Tag)
+	}
+	for _, endpoint := range endpoints {
+		tags = append(tags, endpoint.Tag)
+	}
+	return tags
+}
+
+// reinitializeURLTest reinitializes the URLTest outbound with the provided tags. It checks if the
+// all tags are present in the existing URLTest outbound. If they are, it does nothing.
+func reinitializeURLTest(ctx context.Context, newTags []string) error {
+	outboundMgr := service.FromContext[adapter.OutboundManager](ctx)
+	outbound, fnd := outboundMgr.Outbound(boxoptions.LanternURLTestTag)
+	if fnd {
+		urlTest, ok := outbound.(*group.URLTest)
+		if !ok {
+			return fmt.Errorf("outbound %s is not a URLTest", boxoptions.LanternURLTestTag)
+		}
+		tags := urlTest.All()
+		slices.Sort(newTags)
+		slices.Sort(tags)
+		if slices.Equal(tags, newTags) {
+			return nil
+		}
+	}
+	slog.Debug("Reinitializing URLTest outbound", "tags:", newTags)
+	router := service.FromContext[adapter.Router](ctx)
+	logFactory := service.FromContext[log.Factory](ctx)
+	err := outboundMgr.Create(
+		ctx,
+		router,
+		logFactory.NewLogger(boxoptions.LanternURLTestTag),
+		boxoptions.LanternURLTestTag,
+		constant.TypeURLTest,
+		&option.URLTestOutboundOptions{
+			Outbounds: newTags,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("create urltest outbound: %w", err)
+	}
+	return nil
 }
 
 // updateOutbounds syncs the [adapter.OutboundManager] with the provided outbounds. It skips excluded


### PR DESCRIPTION
This pull request introduces significant changes to the `boxoptions` and `service` packages, primarily focused on refactoring the outbound configuration to use a new `LanternURLTest` tag and adding functionality to dynamically manage URLTest outbounds. The changes improve modularity and flexibility in handling outbound configurations.

### Refactoring and Modularization of Outbounds:
* Introduced a new constant `LanternURLTestTag` and a helper function `URLTestOutbound` to define URLTest outbounds, improving clarity and reusability in outbound setup (`client/boxoptions/options.go`). [[1]](diffhunk://#diff-376a60d662a43ac127f3219f7d86b8fcd9d1d1371dbcd9fe37d91a99195f857bR6-R15) [[2]](diffhunk://#diff-376a60d662a43ac127f3219f7d86b8fcd9d1d1371dbcd9fe37d91a99195f857bR142-R157)

### Dynamic URLTest Outbound Management:
* Added logic in `OnNewConfig` to dynamically update the `LanternURLTest` outbound with new tags from the configuration. This ensures that the outbound configuration remains up-to-date (`client/service/service.go`).
* Implemented a `reinitializeURLTest` function to reinitialize the URLTest outbound if the tags have changed, providing robust handling of dynamic updates (`client/service/service.go`). [[1]](diffhunk://#diff-3e93cc11b22eab442b7c9435196e3101e2ac6f286ee1b63c98f0de4099bc5ab9R287-R291) [[2]](diffhunk://#diff-3e93cc11b22eab442b7c9435196e3101e2ac6f286ee1b63c98f0de4099bc5ab9R351-R397)

### Other Improvements:
* Updated the default outbound configuration to use the `LanternURLTest` tag, ensuring consistency in routing logic (`client/boxoptions/options.go`).