### PR TITLE
Set started false

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/sagernet/sing-box/constant"
@@ -55,7 +56,7 @@ type vpnClient struct {
 	boxService          *boxservice.BoxService
 	splitTunnelHandler  *SplitTunnel
 	customServerManager *boxservice.CustomServerManager
-	started             bool
+	running             atomic.Bool
 	connected           bool
 }
 
@@ -124,7 +125,7 @@ func NewVPNClient(opts Options) (VPNClient, error) {
 func (c *vpnClient) StartVPN() error {
 	clientMu.Lock()
 	defer clientMu.Unlock()
-	if c.started {
+	if c.running.Load() {
 		return errors.New("VPN client is already running")
 	}
 
@@ -140,7 +141,7 @@ func (c *vpnClient) StartVPN() error {
 
 	c.customServerManager.SetContext(c.boxService.Ctx())
 
-	c.started = true
+	c.running.Store(true)
 	c.setConnectionStatus(true)
 	return nil
 }
@@ -149,7 +150,7 @@ func (c *vpnClient) StartVPN() error {
 func (c *vpnClient) StopVPN() error {
 	clientMu.Lock()
 	defer clientMu.Unlock()
-	if !c.started {
+	if !c.running.Load() {
 		return errors.New("VPN client is not running")
 	}
 
@@ -159,6 +160,7 @@ func (c *vpnClient) StopVPN() error {
 	go func() {
 		err = c.boxService.Close()
 		cancel()
+		c.running.Store(false)
 	}()
 	<-ctx.Done()
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
@@ -172,7 +174,7 @@ func (c *vpnClient) StopVPN() error {
 func (c *vpnClient) ConnectionStatus() bool {
 	clientMu.Lock()
 	defer clientMu.Unlock()
-	return c.started && c.connected
+	return c.running.Load() && c.connected
 }
 
 func (c *vpnClient) setConnectionStatus(connected bool) {

--- a/client/client.go
+++ b/client/client.go
@@ -123,11 +123,12 @@ func NewVPNClient(opts Options) (VPNClient, error) {
 
 // Start starts the VPN client
 func (c *vpnClient) StartVPN() error {
-	clientMu.Lock()
-	defer clientMu.Unlock()
 	if c.running.Load() {
 		return errors.New("VPN client is already running")
 	}
+
+	clientMu.Lock()
+	defer clientMu.Unlock()
 
 	slog.Debug("Starting VPN client")
 	if c.boxService == nil {
@@ -148,11 +149,12 @@ func (c *vpnClient) StartVPN() error {
 
 // Stop stops the VPN client and closes the TUN device
 func (c *vpnClient) StopVPN() error {
-	clientMu.Lock()
-	defer clientMu.Unlock()
 	if !c.running.Load() {
 		return errors.New("VPN client is not running")
 	}
+
+	clientMu.Lock()
+	defer clientMu.Unlock()
 
 	slog.Debug("Stopping VPN client")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)


### PR DESCRIPTION
This pull request refactors the `vpnClient` implementation in `client/client.go` to improve thread safety and replace the `started` boolean with an atomic `running` flag. The main changes include the introduction of `sync/atomic` for concurrency-safe state management and updates to methods to utilize the new `atomic.Bool`.

### Thread safety improvements:

* Added `sync/atomic` to imports to enable the use of atomic operations for managing the `running` state.
* Replaced the `started` boolean field with an `atomic.Bool` named `running` in the `vpnClient` struct for thread-safe state management.