### PR TITLE
latest sing-box-minimal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 toolchain go1.24.1
 
-replace github.com/sagernet/sing-box => github.com/getlantern/sing-box-minimal v1.11.6-0.20250411173055-d82f542dfd3f
+replace github.com/sagernet/sing-box => github.com/getlantern/sing-box-minimal v1.11.11-lantern
 
 replace github.com/sagernet/wireguard-go => github.com/getlantern/wireguard-go v0.0.1-beta.5.0.20250310145906-45220d8aec77
 
@@ -133,7 +133,7 @@ require (
 	github.com/sagernet/nftables v0.3.0-beta.4 // indirect
 	github.com/sagernet/quic-go v0.49.0-beta.1 // indirect
 	github.com/sagernet/reality v0.0.0-20230406110435-ee17307e7691 // indirect
-	github.com/sagernet/sing-dns v0.4.2
+	github.com/sagernet/sing-dns v0.4.3
 	github.com/sagernet/sing-mux v0.3.2 // indirect
 	github.com/sagernet/sing-quic v0.4.1 // indirect
 	github.com/sagernet/sing-shadowsocks v0.2.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65
 	github.com/getlantern/jibber_jabber v0.0.0-20210901195950-68955124cc42
 	github.com/getlantern/kindling v0.0.0-20250506175908-d622fb5c9990
-	github.com/getlantern/sing-box-extensions v0.0.3-0.20250527121217-391f8261a775
+	github.com/getlantern/sing-box-extensions v0.0.3-0.20250527123041-ac84f0af290f
 	github.com/getlantern/timezone v0.0.0-20210901200113-3f9de9d360c9
 	github.com/go-resty/resty/v2 v2.16.5
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65
 	github.com/getlantern/jibber_jabber v0.0.0-20210901195950-68955124cc42
 	github.com/getlantern/kindling v0.0.0-20250506175908-d622fb5c9990
-	github.com/getlantern/sing-box-extensions v0.0.3-0.20250513165743-4f40385f7529
+	github.com/getlantern/sing-box-extensions v0.0.3-0.20250527121217-391f8261a775
 	github.com/getlantern/timezone v0.0.0-20210901200113-3f9de9d360c9
 	github.com/go-resty/resty/v2 v2.16.5
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 h1:3BwvWj0JZzFEvNNi
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534/go.mod h1:ZsLfOY6gKQOTyEcPYNA9ws5/XHZQFroxqCOhHjGcs9Y=
 github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 h1:JWH5BB2o0eAeGs0tZnFPpQGx+nMIo/WmxKnj2hnGjgE=
 github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175/go.mod h1:h3S9LBmmzN/xM+lwYZHE4abzTtCTtidKtG+nxZcCZX0=
-github.com/getlantern/sing-box-extensions v0.0.3-0.20250513165743-4f40385f7529 h1:TX640i2IhOd90HW3ruPRD9hdIHSlVN8KzFr74gfYKh0=
-github.com/getlantern/sing-box-extensions v0.0.3-0.20250513165743-4f40385f7529/go.mod h1:S6k95+BS/5vCiHlmUAo6iMeq6GvRd2ro3uB9d+RQ3G8=
+github.com/getlantern/sing-box-extensions v0.0.3-0.20250527121217-391f8261a775 h1:YCq1j0rBxgPB+wt3/MVsxleE4bS3YKw/bU+6abECe9Q=
+github.com/getlantern/sing-box-extensions v0.0.3-0.20250527121217-391f8261a775/go.mod h1:NFLIYOX8xslKewQojGUPB3f8ShTM0ZcLoce+wdrVb5U=
 github.com/getlantern/sing-box-minimal v1.11.11-lantern h1:HZx3FukmeHTmtcYB7/E2eQQESDOoYjox/m0LGiQ0U6Y=
 github.com/getlantern/sing-box-minimal v1.11.11-lantern/go.mod h1:wrbdu8l5rj5q0LbxdMtUiT2cJ7kmtJ4pDkdreym41oA=
 github.com/getlantern/timezone v0.0.0-20210901200113-3f9de9d360c9 h1:VTNjZxSuAHUzu13lYpEVB8gc3xz5hZePGNHG5enHYLY=

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 h1:JWH5BB2o0e
 github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175/go.mod h1:h3S9LBmmzN/xM+lwYZHE4abzTtCTtidKtG+nxZcCZX0=
 github.com/getlantern/sing-box-extensions v0.0.3-0.20250513165743-4f40385f7529 h1:TX640i2IhOd90HW3ruPRD9hdIHSlVN8KzFr74gfYKh0=
 github.com/getlantern/sing-box-extensions v0.0.3-0.20250513165743-4f40385f7529/go.mod h1:S6k95+BS/5vCiHlmUAo6iMeq6GvRd2ro3uB9d+RQ3G8=
-github.com/getlantern/sing-box-minimal v1.11.6-0.20250411173055-d82f542dfd3f h1:1EM684uAJTApkeubw0W8BbxdrTaXkaXxbM1hJ+KRTZ8=
-github.com/getlantern/sing-box-minimal v1.11.6-0.20250411173055-d82f542dfd3f/go.mod h1:iKFH3Hqus29C3+CxQBsqk2+54SEjDDk2ljYplxN7Uzs=
+github.com/getlantern/sing-box-minimal v1.11.11-lantern h1:HZx3FukmeHTmtcYB7/E2eQQESDOoYjox/m0LGiQ0U6Y=
+github.com/getlantern/sing-box-minimal v1.11.11-lantern/go.mod h1:wrbdu8l5rj5q0LbxdMtUiT2cJ7kmtJ4pDkdreym41oA=
 github.com/getlantern/timezone v0.0.0-20210901200113-3f9de9d360c9 h1:VTNjZxSuAHUzu13lYpEVB8gc3xz5hZePGNHG5enHYLY=
 github.com/getlantern/timezone v0.0.0-20210901200113-3f9de9d360c9/go.mod h1:7uvbzuoOr3uYGHZx5QWlI8/C52XEf/aTb/tJFEe41Ak=
 github.com/getlantern/tlsdialer/v3 v3.0.3 h1:OXzzAqO8YojBOu2Kk8wquX2zbFmgJjji41RpaT6knLg=
@@ -280,8 +280,8 @@ github.com/sagernet/reality v0.0.0-20230406110435-ee17307e7691 h1:5Th31OC6yj8byL
 github.com/sagernet/reality v0.0.0-20230406110435-ee17307e7691/go.mod h1:B8lp4WkQ1PwNnrVMM6KyuFR20pU8jYBD+A4EhJovEXU=
 github.com/sagernet/sing v0.6.9 h1:y/XJH17oyBd6hxgQtKnIdLXu7TsOHxO5i1JeVfVmjXw=
 github.com/sagernet/sing v0.6.9/go.mod h1:ARkL0gM13/Iv5VCZmci/NuoOlePoIsW0m7BWfln/Hak=
-github.com/sagernet/sing-dns v0.4.2 h1:cWe2XPUBFLep2j9kJV4Epg3bctGhMvrrl/sWi9Wszfg=
-github.com/sagernet/sing-dns v0.4.2/go.mod h1:dweQs54ng2YGzoJfz+F9dGuDNdP5pJ3PLeggnK5VWc8=
+github.com/sagernet/sing-dns v0.4.3 h1:R6X9oWYbdZ0Mm+8PkdqrBkqx3JwiAbnETUZGOpEdY4E=
+github.com/sagernet/sing-dns v0.4.3/go.mod h1:dweQs54ng2YGzoJfz+F9dGuDNdP5pJ3PLeggnK5VWc8=
 github.com/sagernet/sing-mux v0.3.2 h1:meZVFiiStvHThb/trcpAkCrmtJOuItG5Dzl1RRP5/NE=
 github.com/sagernet/sing-mux v0.3.2/go.mod h1:pht8iFY4c9Xltj7rhVd208npkNaeCxzyXCgulDPLUDA=
 github.com/sagernet/sing-quic v0.4.1 h1:pxlMa4efZu/M07RgGagNNDDyl6ZUwpmNUjRTpgHOWK4=

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 h1:3BwvWj0JZzFEvNNi
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534/go.mod h1:ZsLfOY6gKQOTyEcPYNA9ws5/XHZQFroxqCOhHjGcs9Y=
 github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 h1:JWH5BB2o0eAeGs0tZnFPpQGx+nMIo/WmxKnj2hnGjgE=
 github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175/go.mod h1:h3S9LBmmzN/xM+lwYZHE4abzTtCTtidKtG+nxZcCZX0=
-github.com/getlantern/sing-box-extensions v0.0.3-0.20250527121217-391f8261a775 h1:YCq1j0rBxgPB+wt3/MVsxleE4bS3YKw/bU+6abECe9Q=
-github.com/getlantern/sing-box-extensions v0.0.3-0.20250527121217-391f8261a775/go.mod h1:NFLIYOX8xslKewQojGUPB3f8ShTM0ZcLoce+wdrVb5U=
+github.com/getlantern/sing-box-extensions v0.0.3-0.20250527123041-ac84f0af290f h1:k6K+XIkna3A2IHJpT4S5kRTOeKinY32JGNakLoJRIXU=
+github.com/getlantern/sing-box-extensions v0.0.3-0.20250527123041-ac84f0af290f/go.mod h1:NFLIYOX8xslKewQojGUPB3f8ShTM0ZcLoce+wdrVb5U=
 github.com/getlantern/sing-box-minimal v1.11.11-lantern h1:HZx3FukmeHTmtcYB7/E2eQQESDOoYjox/m0LGiQ0U6Y=
 github.com/getlantern/sing-box-minimal v1.11.11-lantern/go.mod h1:wrbdu8l5rj5q0LbxdMtUiT2cJ7kmtJ4pDkdreym41oA=
 github.com/getlantern/timezone v0.0.0-20210901200113-3f9de9d360c9 h1:VTNjZxSuAHUzu13lYpEVB8gc3xz5hZePGNHG5enHYLY=


### PR DESCRIPTION
This includes a fix where we use platforminterface whenever it's not nil. This also fixes a broken build with sing-box-extensions diverging from sing-box.