### PR TITLE
Add options parameter to VPN connect functions

### DIFF
--- a/common/platform.go
+++ b/common/platform.go
@@ -9,3 +9,6 @@ func IsAndroid() bool {
 func IsIOS() bool {
 	return runtime.GOOS == "ios"
 }
+func IsMacOS() bool {
+	return runtime.GOOS == "darwin"
+}

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -84,9 +84,6 @@ func ConnectToServer(group, tag string, platIfce libbox.PlatformInterface, optio
 func connect(group, tag string, platIfce libbox.PlatformInterface) error {
 	path := common.DataPath()
 	_ = newSplitTunnel(path) // ensure split tunnel rule file exists to prevent sing-box from complaining
-
-	log.Printf("Path: %s", path)
-
 	opts, err := buildOptions(group, path)
 	if err != nil {
 		return fmt.Errorf("failed to build options: %w", err)

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"log/slog"
 	"path/filepath"
 	"slices"


### PR DESCRIPTION
This pull request introduces changes to improve the initialization and logging process in the `vpn/vpn.go` file. The most significant updates include adding support for passing configuration options via the `radiance.Options` struct, ensuring proper initialization of shared resources, and enhancing logging for debugging purposes.

### Initialization Improvements:
* Updated the `QuickConnect` and `ConnectToServer` functions to accept a new `radiance.Options` parameter, ensuring that paths and logger configurations are properly initialized using `common.Init`. This prevents potential issues with uninitialized resources. [[1]](diffhunk://#diff-25828e7146300d37842032752af02678c7c569a51995a9d0314e1ec400cdb94eR21-R42) [[2]](diffhunk://#diff-25828e7146300d37842032752af02678c7c569a51995a9d0314e1ec400cdb94eL51-R69)

### Logging Enhancements:
* Added a `log.Printf` statement in the `connect` function to log the data path, aiding in debugging and visibility of runtime behavior.

### Dependency Updates:
* Added `log` and `github.com/getlantern/radiance` to the import statements to support the new logging and options functionality. [[1]](diffhunk://#diff-25828e7146300d37842032752af02678c7c569a51995a9d0314e1ec400cdb94eR10) [[2]](diffhunk://#diff-25828e7146300d37842032752af02678c7c569a51995a9d0314e1ec400cdb94eR21-R42)