### PR TITLE
Fix active server

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -213,6 +213,7 @@ func (ch *ConfigHandler) fetchConfig() error {
 		}
 	}
 
+	slog.Info("Fetching config")
 	resp, err := ch.ftr.fetchConfig(preferred, privateKey.PublicKey().String())
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrFetchingConfig, err)
@@ -221,6 +222,7 @@ func (ch *ConfigHandler) fetchConfig() error {
 		slog.Info("no new config available")
 		return nil
 	}
+	slog.Info("Config fetched from server")
 
 	// Otherwise, we keep the previous config and store any error that might have occurred.
 	// We still want to keep the previous config if there was an error. This is important

--- a/config/fetcher.go
+++ b/config/fetcher.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/getlantern/radiance/backend"
 	"github.com/getlantern/radiance/common"
+	"github.com/getlantern/radiance/internal"
 )
 
 const configURL = "https://api.iantem.io/v1/config-new"
@@ -71,7 +72,7 @@ func (f *fetcher) fetchConfig(preferred C.ServerLocation, wgPublicKey string) ([
 		return nil, fmt.Errorf("marshal config request: %w", err)
 	}
 
-	slog.Info("fetching config", "request", string(buf))
+	slog.Debug("sending config request", "request", string(buf))
 	buf, err = f.send(bytes.NewReader(buf))
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
@@ -80,7 +81,7 @@ func (f *fetcher) fetchConfig(preferred C.ServerLocation, wgPublicKey string) ([
 	if buf == nil { // no new config available
 		return nil, nil
 	}
-	slog.Info("fetched config", "config", string(buf))
+	slog.Log(nil, internal.LevelTrace, "received config", "config", string(buf))
 
 	f.lastModified = time.Now()
 	return buf, nil

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -220,15 +220,18 @@ func activeServer(group string) (string, error) {
 		groupMap[g.Tag] = g
 	}
 	if group == autoAllTag {
-		g, ok := groupMap[group]
-		if !ok {
-			return "", errors.New("group not found: " + group)
-		}
-		switch g.Selected {
-		case autoLanternTag:
-			group = servers.SGLantern
-		case autoUserTag:
-			group = servers.SGUser
+		if g, ok := groupMap[group]; ok {
+			if g.Selected == autoLanternTag {
+				group = servers.SGLantern
+			} else {
+				group = servers.SGUser
+			}
+		} else {
+			if _, ok = groupMap[autoLanternTag]; ok {
+				group = servers.SGLantern
+			} else {
+				group = servers.SGUser
+			}
 		}
 	}
 	return resolveActive(groupMap, group)

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -156,16 +156,14 @@ func GetStatus() (Status, error) {
 		return s, nil
 	}
 
-	if s.TunnelOpen {
-		switch selected {
-		case autoAllTag, autoLanternTag, autoUserTag:
-			s.ActiveServer, err = activeServer(group)
-			if err != nil {
-				return s, fmt.Errorf("failed to get active server: %w", err)
-			}
-		default:
-			s.ActiveServer = selected
+	switch selected {
+	case autoAllTag, autoLanternTag, autoUserTag:
+		s.ActiveServer, err = activeServer(group)
+		if err != nil {
+			return s, fmt.Errorf("failed to get active server: %w", err)
 		}
+	default:
+		s.ActiveServer = selected
 	}
 	slog.Debug("Tunnel status", "tunnelOpen", s.TunnelOpen, "selectedServer", s.SelectedServer, "activeServer", s.ActiveServer)
 	return s, nil

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -395,17 +395,6 @@ func (c *cmdClientHandler) WriteGroups(message libbox.OutboundGroupIterator) {
 	for groups.HasNext() {
 		c.groups = append(c.groups, groups.Next())
 	}
-
-	type item struct {
-		tag string
-		typ string
-	}
-	for _, g := range c.groups {
-		items := []item{}
-		for _, i := range g.ItemList {
-			items = append(items, item{i.Tag, i.Type})
-		}
-	}
 	c.done <- struct{}{}
 }
 


### PR DESCRIPTION
This pull request refactors and improves the handling of "auto" server selection and status reporting in the VPN tunnel logic. The changes clarify the logic for auto-selection, ensure correct placeholder behavior, and improve status reporting for selected and active servers.

**Auto server selection and outbound management:**

* Refactored the logic for creating and updating the "auto-all" outbound group, ensuring it correctly switches between a placeholder and a real outbound based on the availability of lantern and user servers. Added the `updateAuto` function to encapsulate this logic.
* Changed the handling of tags for auto outbounds in `buildOptions` and `updateServers`, removing legacy code and ensuring that only relevant tags are included in the "auto-all" outbound. [[1]](diffhunk://#diff-b4d9691285344ba933cb3a079a39675d434c132ec7ef278fc9e12827484ef573L264-L270) [[2]](diffhunk://#diff-dbe8a66225db78e0b7d169d4e14f37159a5552657e7031f13170a0aec3afd455L333-L363)
* Updated constants and tag naming for clarity (`autoAllTag` is now `"auto"` instead of `"auto-all"`).

**Status reporting and server selection:**

* Refactored `selectedServer`, `activeServer`, and `getOutboundGroup` functions to correctly resolve the selected and active servers, especially when auto-selection is used. [[1]](diffhunk://#diff-25828e7146300d37842032752af02678c7c569a51995a9d0314e1ec400cdb94eL142-R196) [[2]](diffhunk://#diff-25828e7146300d37842032752af02678c7c569a51995a9d0314e1ec400cdb94eL172-L234)