### PR TITLE
Fix auto select on first connect

### DIFF
--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -139,14 +139,17 @@ func baseOpts() O.Options {
 						},
 					},
 				},
-				{
+				{ // split tunnel rule
 					Type: C.RuleTypeDefault,
 					DefaultOptions: O.DefaultRule{
 						RawDefaultRule: O.RawDefaultRule{
 							RuleSet: []string{splitTunnelTag},
 						},
 						RuleAction: O.RuleAction{
-							Action: C.RuleActionTypeReject,
+							Action: C.RuleActionTypeRoute,
+							RouteOptions: O.RouteActionOptions{
+								Outbound: "direct",
+							},
 						},
 					},
 				},
@@ -167,7 +170,7 @@ func baseOpts() O.Options {
 				groupRule(autoAllTag),
 				groupRule(servers.SGLantern),
 				groupRule(servers.SGUser),
-				{
+				{ // catch-all rule to ensure no fallthrough
 					Type: C.RuleTypeDefault,
 					DefaultOptions: O.DefaultRule{
 						RawDefaultRule: O.RawDefaultRule{},

--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -172,7 +172,7 @@ func baseOpts() O.Options {
 					DefaultOptions: O.DefaultRule{
 						RawDefaultRule: O.RawDefaultRule{},
 						RuleAction: O.RuleAction{
-							Action: C.RuleActionRejectMethodDefault,
+							Action: C.RuleActionTypeReject,
 						},
 					},
 				},

--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -146,6 +146,17 @@ func baseOpts() O.Options {
 							RuleSet: []string{splitTunnelTag},
 						},
 						RuleAction: O.RuleAction{
+							Action: C.RuleActionRejectMethodDefault,
+						},
+					},
+				},
+				{
+					Type: C.RuleTypeDefault,
+					DefaultOptions: O.DefaultRule{
+						RawDefaultRule: O.RawDefaultRule{
+							IPIsPrivate: true,
+						},
+						RuleAction: O.RuleAction{
 							Action: C.RuleActionTypeRoute,
 							RouteOptions: O.RouteActionOptions{
 								Outbound: "direct",
@@ -156,6 +167,15 @@ func baseOpts() O.Options {
 				groupRule(autoAllTag),
 				groupRule(servers.SGLantern),
 				groupRule(servers.SGUser),
+				{
+					Type: C.RuleTypeDefault,
+					DefaultOptions: O.DefaultRule{
+						RawDefaultRule: O.RawDefaultRule{},
+						RuleAction: O.RuleAction{
+							Action: C.RuleActionRejectMethodDefault,
+						},
+					},
+				},
 			},
 			RuleSet: []O.RuleSet{
 				{
@@ -311,13 +331,13 @@ func mergeAndCollectTags(dst, src *O.Options) []string {
 	dst.Outbounds = append(dst.Outbounds, src.Outbounds...)
 	dst.Endpoints = append(dst.Endpoints, src.Endpoints...)
 
-	if src.Route != nil {
-		dst.Route.Rules = append(dst.Route.Rules, src.Route.Rules...)
-		dst.Route.RuleSet = append(dst.Route.RuleSet, src.Route.RuleSet...)
-	}
-	if src.DNS != nil {
-		dst.DNS.Servers = append(dst.DNS.Servers, src.DNS.Servers...)
-	}
+	// if src.Route != nil {
+	// 	dst.Route.Rules = append(dst.Route.Rules, src.Route.Rules...)
+	// 	dst.Route.RuleSet = append(dst.Route.RuleSet, src.Route.RuleSet...)
+	// }
+	// if src.DNS != nil {
+	// 	dst.DNS.Servers = append(dst.DNS.Servers, src.DNS.Servers...)
+	// }
 
 	var tags []string
 	for _, out := range src.Outbounds {
@@ -386,7 +406,6 @@ func groupRule(group string) O.Rule {
 		Type: C.RuleTypeDefault,
 		DefaultOptions: O.DefaultRule{
 			RawDefaultRule: O.RawDefaultRule{
-				Inbound:   []string{"tun-in"},
 				ClashMode: group,
 			},
 			RuleAction: O.RuleAction{

--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -146,7 +146,7 @@ func baseOpts() O.Options {
 							RuleSet: []string{splitTunnelTag},
 						},
 						RuleAction: O.RuleAction{
-							Action: C.RuleActionRejectMethodDefault,
+							Action: C.RuleActionTypeReject,
 						},
 					},
 				},

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -31,7 +31,10 @@ func QuickConnect(group string, platIfce libbox.PlatformInterface) error {
 		return ConnectToServer(servers.SGLantern, autoLanternTag, platIfce)
 	case servers.SGUser:
 		return ConnectToServer(servers.SGUser, autoUserTag, platIfce)
-	case "all", "":
+	case "":
+		group = autoAllTag
+		fallthrough // fall through to handle empty group as "all"
+	case "all":
 		if isOpen() {
 			cc := libbox.NewStandaloneCommandClient()
 			if err := cc.SetClashMode(autoAllTag); err != nil {

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -31,10 +31,7 @@ func QuickConnect(group string, platIfce libbox.PlatformInterface) error {
 		return ConnectToServer(servers.SGLantern, autoLanternTag, platIfce)
 	case servers.SGUser:
 		return ConnectToServer(servers.SGUser, autoUserTag, platIfce)
-	case "":
-		group = autoAllTag
-		fallthrough // fall through to handle empty group as "all"
-	case "all":
+	case autoAllTag, "all", "":
 		if isOpen() {
 			cc := libbox.NewStandaloneCommandClient()
 			if err := cc.SetClashMode(autoAllTag); err != nil {
@@ -42,7 +39,7 @@ func QuickConnect(group string, platIfce libbox.PlatformInterface) error {
 			}
 			return nil
 		}
-		return connect(group, "", platIfce)
+		return connect(autoAllTag, "", platIfce)
 	default:
 		return fmt.Errorf("invalid group: %s", group)
 	}


### PR DESCRIPTION
Use `autoAllTag` consistently when handling the "all" group in `QuickConnect`. Add a "catch-all" reject routing rule to prevent fallthrough.