### PR TITLE
WireGuard permssion issue

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -292,12 +292,12 @@ func setWireGuardKeyInOptions(endpoints []option.Endpoint, privateKey wgtypes.Ke
 			opts.PrivateKey = privateKey.String()
 			// Requires privilege and cannot conflict with existing system interfaces
 			// System tries to use system env; for mobile we need to tun device
-			opts.System = !(common.IsAndroid() || common.IsIOS())
+			opts.System = !(common.IsAndroid() || common.IsIOS() || common.IsMacOS())
 		case *exO.AmneziaEndpointOptions:
 			opts.PrivateKey = privateKey.String()
 			// Requires privilege and cannot conflict with existing system interfaces
 			// System tries to use system env; for mobile we need to tun device
-			opts.System = !(common.IsAndroid() || common.IsIOS())
+			opts.System = !(common.IsAndroid() || common.IsIOS() || common.IsMacOS())
 		default:
 		}
 	}


### PR DESCRIPTION
This pull request refactors the function responsible for injecting the WireGuard private key into endpoint options and adds logic to ensure the correct system interface is used depending on the platform (desktop vs. mobile). The changes improve code clarity and ensure better platform compatibility.

Refactoring and naming improvements:
* Renamed the function `settingWGPrivateKeyInConfig` to `setWireGuardKeyInOptions` for clarity and consistency. (`config/config.go` [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L240-R240) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L288-R300)

Platform compatibility enhancements:
* Updated the WireGuard endpoint options logic to set the `System` field to `false` on Android and iOS, ensuring that a TUN device is used on mobile platforms instead of the system interface. This logic is applied to both `WireGuardEndpointOptions` and `AmneziaEndpointOptions`. (`config/config.go` [config/config.goL288-R300](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L288-R300))