### PR TITLE
set tun mtu and add ipv6 address

### DIFF
--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -94,9 +94,11 @@ func baseOpts() O.Options {
 					InterfaceName: "utun225",
 					Address: []netip.Prefix{
 						netip.MustParsePrefix("10.10.1.1/30"),
+						netip.MustParsePrefix("fdf0:f3e1:0fdd::1/126"),
 					},
 					AutoRoute:   true,
 					StrictRoute: true,
+					MTU:         1500,
 				},
 			},
 		},


### PR DESCRIPTION
This pull request introduces minor configuration updates to the VPN interface options. The changes add support for an IPv6 address and explicitly set the MTU value.

- **VPN Interface Configuration Updates:**
  * Added an IPv6 address (`fdf0:f3e1:0fdd::1/126`) to the `Address` list in the VPN interface options.
  * Explicitly set the `MTU` to 1500 in the VPN interface options.