### PR TITLE
set socket path in common.init to break import cycle

### DIFF
--- a/common/init.go
+++ b/common/init.go
@@ -21,10 +21,12 @@ import (
 	"github.com/getlantern/osversion"
 
 	C "github.com/getlantern/common"
+
 	"github.com/getlantern/radiance/common/env"
 	"github.com/getlantern/radiance/common/reporting"
 	"github.com/getlantern/radiance/internal"
 	"github.com/getlantern/radiance/metrics"
+	"github.com/getlantern/radiance/vpn/ipc"
 )
 
 const (
@@ -69,9 +71,16 @@ func Init(dataDir, logDir, logLevel, deviceID string) error {
 		return fmt.Errorf("failed to setup directories: %w", err)
 	}
 
-	err = initLogger(filepath.Join(logPath.Load().(string), LogFileName), logLevel)
+	dataDir = dataPath.Load().(string)
+	logDir = logPath.Load().(string)
+
+	err = initLogger(filepath.Join(logDir, LogFileName), logLevel)
 	if err != nil {
 		return fmt.Errorf("initialize log: %w", err)
+	}
+
+	if runtime.GOOS != "windows" {
+		ipc.SetSocketPath(dataDir)
 	}
 
 	// creating file watcher to monitor changes to config file and initialize whatever depends on it

--- a/vpn/ipc/conn_other.go
+++ b/vpn/ipc/conn_other.go
@@ -11,33 +11,35 @@ import (
 )
 
 const (
-	apiURL = "http://unix"
+	apiURL   = "http://unix"
+	sockFile = "radiance.sock"
 )
 
 var (
-	// might need a locker
-	socksPath = ""
-	sockFile  = "radiance.sock"
-	uid       = os.Getuid()
-	gid       = os.Getgid()
+	sockPath string
+
+	uid = os.Getuid()
+	gid = os.Getgid()
 )
 
+// SetSocketPath sets the path for the Unix domain socket file for client connections.
+func SetSocketPath(path string) {
+	sockPath = filepath.Join(path, sockFile)
+}
+
 func dialContext(_ context.Context, _, _ string) (net.Conn, error) {
-	if socksPath == "" {
-		return nil, fmt.Errorf("socks path not defined")
-	}
 	return net.DialUnix("unix", nil, &net.UnixAddr{
-		Name: socksPath,
+		Name: sockPath,
 		Net:  "unix",
 	})
 }
 
 // listen creates a Unix domain socket listener in the specified directory.
 func listen(path string) (net.Listener, error) {
-	socksPath = filepath.Join(path, sockFile)
-	os.Remove(socksPath)
+	path = filepath.Join(path, sockFile)
+	os.Remove(path)
 	listener, err := net.ListenUnix("unix", &net.UnixAddr{
-		Name: socksPath,
+		Name: path,
 		Net:  "unix",
 	})
 	if err != nil {

--- a/vpn/ipc/conn_windows.go
+++ b/vpn/ipc/conn_windows.go
@@ -25,6 +25,11 @@ const (
 	// sddl = `D:P(A;;GA;;;SY)(A;;GA;;;BA)(A;;GA;;;BU)`
 )
 
+// SetSocketPath not supported on Windows.
+func SetSocketPath(path string) {
+	panic("SetSocketPath is not supported on Windows")
+}
+
 func dialContext(ctx context.Context, _, _ string) (net.Conn, error) {
 	ctx, cancel := context.WithTimeout(ctx, connectTimeout)
 	defer cancel()

--- a/vpn/ipc/http.go
+++ b/vpn/ipc/http.go
@@ -7,16 +7,17 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/getlantern/radiance/traces"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/getlantern/radiance/traces"
 )
+
+const tracerName = "github.com/getlantern/radiance/vpn/ipc"
 
 // empty is a placeholder type for requests that do not expect a response body.
 type empty struct{}
-
-const tracerName = "github.com/getlantern/radiance/vpn/ipc"
 
 // sendRequest sends an HTTP request to the specified endpoint with the given method and data.
 func sendRequest[T any](method, endpoint string, data any) (T, error) {


### PR DESCRIPTION
This pull request updates the initialization and socket handling logic for the VPN IPC (Inter-Process Communication) system, improving clarity and correctness around Unix domain socket paths and cross-platform support. The main changes include refactoring how the socket path is set and used, ensuring platform-specific handling, and cleaning up imports and constants.

**Cross-platform socket path management:**

* Added a new `SetSocketPath` function in `vpn/ipc/conn_other.go` to explicitly set the Unix domain socket file path, replacing the previous approach using a global variable. All socket operations now use this path, improving clarity and reducing potential errors. (`[vpn/ipc/conn_other.goR15-R42](diffhunk://#diff-8c065bf7377ebc8816f244a881ad9482d358c9654577e7415f7f53af221a5f91R15-R42)`)
* On Windows, added a stub `SetSocketPath` function in `vpn/ipc/conn_windows.go` that panics if called, preventing misuse on unsupported platforms. (`[vpn/ipc/conn_windows.goR28-R32](diffhunk://#diff-ce7601db1e6ce8c2793327a70bd3b00011bf2c1f23c202429227e4cb1e74df01R28-R32)`)
* In `common/init.go`, updated the initialization logic to set the socket path using `ipc.SetSocketPath(dataDir)` for non-Windows platforms, ensuring the socket is correctly placed in the data directory. (`[common/init.goL72-R85](diffhunk://#diff-4e0ce0c23ba3bc563c296dde07d80886147c80b39982549b9aaa94b6d5174356L72-R85)`)