### PR TITLE
Handle empty device ID

### DIFF
--- a/metrics/otel.go
+++ b/metrics/otel.go
@@ -59,7 +59,7 @@ func buildResources(serviceName string, a Attributes) []attribute.KeyValue {
 
 // SetupOTelSDK bootstraps the OpenTelemetry pipeline.
 // If it does not return an error, make sure to call shutdown for proper cleanup.
-func SetupOTelSDK(ctx context.Context, attributes Attributes, cfg common.ConfigResponse) (func(context.Context) error, error) {
+func SetupOTelSDK(ctx context.Context, attributes Attributes, cfg *common.ConfigResponse) (func(context.Context) error, error) {
 	if cfg.Features == nil {
 		cfg.Features = make(map[string]bool)
 	}


### PR DESCRIPTION
`lantern-outline` does not currently have code to pass a device ID to `common.Init`, so this code fails. This checks for an empty ID and sets it if it's empty.

This pull request makes several improvements to how the application initializes and manages configuration, particularly with regards to device ID handling and OpenTelemetry (OTEL) setup. The main changes are focused on ensuring that a device ID is always set, refactoring function signatures to use pointers for configuration objects, and making minor code cleanups.

**Device ID management and initialization:**

* The `Init` function in `common/init.go` now ensures that if the `deviceID` parameter is empty, it is automatically set using `deviceid.Get()`, improving robustness in device identification.
* The `deviceid` package is now imported in `common/init.go` to support the above enhancement.

**Configuration and OpenTelemetry (OTEL) setup:**

* The `initOTEL` function and its callers have been refactored to accept a pointer to `ConfigResponse` instead of a value, ensuring more efficient memory usage and consistency across the codebase. [[1]](diffhunk://#diff-4e0ce0c23ba3bc563c296dde07d80886147c80b39982549b9aaa94b6d5174356L246-R251) [[2]](diffhunk://#diff-4e0ce0c23ba3bc563c296dde07d80886147c80b39982549b9aaa94b6d5174356L117-R122)
* The `SetupOTelSDK` function in `metrics/otel.go` has also been updated to accept a pointer to `ConfigResponse`, aligning with the changes in `initOTEL`.

**Code cleanup:**

* The `ReplaceAttr` function in the logger initialization now ignores the `groups` parameter by using `_`, which is a minor code style improvement.