### PR TITLE
Expose server locations

### DIFF
--- a/fronted.go
+++ b/fronted.go
@@ -1,0 +1,104 @@
+package radiance
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"github.com/getlantern/fronted"
+	"github.com/getlantern/kindling"
+	"github.com/getlantern/radiance/traces"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func newFronted(panicListener func(string), cacheFile string) (fronted.Fronted, error) {
+	// Parse the domain from the URL.
+	configURL := "https://raw.githubusercontent.com/getlantern/lantern-binaries/refs/heads/main/fronted.yaml.gz"
+	u, err := url.Parse(configURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse URL: %v", err)
+	}
+	// Extract the domain from the URL.
+	domain := u.Host
+
+	logWriter := &slogWriter{Logger: slog.Default()}
+
+	// First, download the file from the specified URL using the smart dialer.
+	// Then, create a new fronted instance with the downloaded file.
+	trans, err := kindling.NewSmartHTTPTransport(logWriter, domain)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create smart HTTP transport: %v", err)
+	}
+	lz := &lazyDialingRoundTripper{
+		smartTransportMu: sync.Mutex{},
+		logWriter:        logWriter,
+		domain:           domain,
+	}
+	if trans != nil {
+		lz.smartTransport = trans
+	}
+
+	httpClient := &http.Client{
+		Transport: traces.NewRoundTripper(lz),
+	}
+	fronted.SetLogger(slog.Default())
+	return fronted.NewFronted(
+		fronted.WithPanicListener(panicListener),
+		fronted.WithCacheFile(cacheFile),
+		fronted.WithHTTPClient(httpClient),
+		fronted.WithConfigURL(configURL),
+	), nil
+}
+
+// This is a lazy RoundTripper that allows radiance to start without an error
+// when it's offline.
+type lazyDialingRoundTripper struct {
+	smartTransport   http.RoundTripper
+	smartTransportMu sync.Mutex
+
+	logWriter io.Writer
+	domain    string
+}
+
+// Make sure lazyDialingRoundTripper implements http.RoundTripper
+var _ http.RoundTripper = (*lazyDialingRoundTripper)(nil)
+
+func (lz *lazyDialingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx, span := otel.Tracer(tracerName).Start(req.Context(), "lazy_dialing_round_trip")
+	defer span.End()
+
+	lz.smartTransportMu.Lock()
+
+	if lz.smartTransport == nil {
+		slog.Info("Smart transport is nil")
+		var err error
+		lz.smartTransport, err = kindling.NewSmartHTTPTransport(lz.logWriter, lz.domain)
+		if err != nil {
+			slog.Info("Error creating smart transport", "error", err)
+			lz.smartTransportMu.Unlock()
+			// This typically just means we're offline
+			return nil, traces.RecordError(ctx, fmt.Errorf("could not create smart transport -- offline? %v", err))
+		}
+	}
+
+	lz.smartTransportMu.Unlock()
+	res, err := lz.smartTransport.RoundTrip(req.WithContext(ctx))
+	if err != nil {
+		traces.RecordError(ctx, err, trace.WithStackTrace(true))
+	}
+	return res, err
+}
+
+type slogWriter struct {
+	*slog.Logger
+}
+
+func (w *slogWriter) Write(p []byte) (n int, err error) {
+	// Convert the byte slice to a string and log it
+	w.Info(string(p))
+	return len(p), nil
+}

--- a/radiance.go
+++ b/radiance.go
@@ -260,7 +260,7 @@ func (r *Radiance) ServerLocations() ([]lcommon.ServerLocation, error) {
 		return nil, fmt.Errorf("failed to get config: %w", err)
 	}
 	if cfg == nil {
-		slog.Info("No config available for server locations, returning empty list")
+		slog.Info("No config available for server locations, returning error")
 		return nil, fmt.Errorf("no config available")
 	}
 	slog.Debug("Returning server locations from config", "locations", cfg.ConfigResponse.Servers)


### PR DESCRIPTION
This pull request refactors the `radiance` package by moving the `newFronted` function and its supporting types from `radiance.go` into a new file, `fronted.go`. It also introduces a new method for retrieving server locations from the configuration. The changes improve code organization and add new functionality.

**Refactoring and Code Organization:**

* Extracted the `newFronted` function, the `lazyDialingRoundTripper` type, and the `slogWriter` type from `radiance.go` into a new file, `fronted.go`, to improve code modularity and maintainability. [[1]](diffhunk://#diff-4c0bae8138ac14baaa1ae94e99e7cd771ca5a489668864545f5e95e2707c4491R1-R104) [[2]](diffhunk://#diff-60179a9bacb28016fc7cda79abcad6f09a5c467689999b56f2c6e0cb3d94140cL255-R267)

**New Functionality:**

* Added a new method `ServerLocations` to the `Radiance` struct, which retrieves and returns the list of server locations from the current configuration. This method includes error handling and tracing.

**Dependency and Import Updates:**

* Updated import statements in `radiance.go` to remove unused dependencies and add the correct import for `lcommon.ServerLocation`.