### PR TITLE
add logging to server select function and related ipc handlers

### DIFF
--- a/vpn/ipc/clash_mode.go
+++ b/vpn/ipc/clash_mode.go
@@ -3,10 +3,13 @@ package ipc
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/getlantern/radiance/internal"
 )
 
 type m struct {
@@ -52,6 +55,7 @@ func (s *Server) clashModeHandler(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 		span.SetAttributes(attribute.String("mode", mode.Mode))
+		slog.Log(nil, internal.LevelTrace, "Setting clash mode", "mode", mode.Mode)
 		cs.SetMode(mode.Mode)
 		w.WriteHeader(http.StatusOK)
 	default:


### PR DESCRIPTION
This pull request adds enhanced logging throughout the VPN IPC and control flow to improve observability and debugging. The most significant changes include introducing structured logging at various points in the server and VPN logic, and standardizing log levels using a custom internal logging level system.

**Logging improvements:**

* Added structured logging using `slog` at key points in `clash_mode.go` and `outbound.go`, including when setting clash mode, selecting and setting outbounds, and when changing clash mode, with appropriate log levels for trace and debug messages. [[1]](diffhunk://#diff-3ce324cc266d1c23e1cdd6410073379caa2478bdf4bf7696663584c1bde17d41R6-R12) [[2]](diffhunk://#diff-3ce324cc266d1c23e1cdd6410073379caa2478bdf4bf7696663584c1bde17d41R58) [[3]](diffhunk://#diff-d8c13dcfc9e6e9c418dd3137b7a42beb49cd1841c7605b3de8c5f8474fe5b8b1R8-R17) [[4]](diffhunk://#diff-d8c13dcfc9e6e9c418dd3137b7a42beb49cd1841c7605b3de8c5f8474fe5b8b1R47) [[5]](diffhunk://#diff-d8c13dcfc9e6e9c418dd3137b7a42beb49cd1841c7605b3de8c5f8474fe5b8b1R58-R65)
* Updated `vpn.go` to include `slog.Info` and `slog.Error` calls for major VPN actions such as disconnecting, selecting servers, and error handling, providing more detailed runtime information.
* Standardized logging for tunnel status and active server retrieval in `vpn.go`, switching to trace-level logs with the custom `internal.LevelTrace` for finer-grained diagnostics. [[1]](diffhunk://#diff-25828e7146300d37842032752af02678c7c569a51995a9d0314e1ec400cdb94eL166-R175) [[2]](diffhunk://#diff-25828e7146300d37842032752af02678c7c569a51995a9d0314e1ec400cdb94eR207)
