### PR TITLE
Get public ip

### DIFF
--- a/vpn/ip.go
+++ b/vpn/ip.go
@@ -59,7 +59,7 @@ func getPublicIP(ctx context.Context, urls []string) (string, error) {
 		}
 		lastErr = res.err
 	}
-	return "", lastErr
+	return "", fmt.Errorf("failed to get public IP, error: %w", lastErr)
 }
 
 // fetchIP performs an HTTP GET request to the given URL and returns the trimmed response body as the IP.

--- a/vpn/ip.go
+++ b/vpn/ip.go
@@ -85,7 +85,7 @@ func fetchIP(ctx context.Context, client *http.Client, url string) (string, erro
 		return "", fmt.Errorf("empty response from %s", url)
 	}
 	if _, err := netip.ParseAddr(ip); err != nil {
-		return "", fmt.Errorf("response is not a valid IP: %s -> %s...", url, ip[:7])
+		return "", fmt.Errorf("response is not a valid IP: %s -> %s...", url, ip[:min(len(ip), 7)])
 	}
 	return ip, nil
 }

--- a/vpn/ip.go
+++ b/vpn/ip.go
@@ -52,7 +52,7 @@ func getPublicIP(ctx context.Context, urls []string) (string, error) {
 	}
 
 	var lastErr error
-	for i := 0; i < len(ipURLs); i++ {
+	for i := 0; i < len(urls); i++ {
 		res := <-results
 		if res.err == nil {
 			return res.ip, nil

--- a/vpn/ip.go
+++ b/vpn/ip.go
@@ -1,0 +1,82 @@
+package vpn
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/netip"
+	"strings"
+)
+
+// list of URLs to fetch the public IP address, just in case one is down or blocked
+var ipURLs = []string{
+	"https://ip.me",
+	"https://ifconfig.me/ip",
+	"https://checkip.amazonaws.com",
+	"https://ifconfig.io/ip",
+	"https://ident.me",
+	"https://ipinfo.io/ip",
+	"https://api.ipify.org",
+}
+
+// getPublicIP fetches the public IP address by querying multiple external services concurrently.
+// It returns the first successful response or an error if all requests fail.
+func getPublicIP() (string, error) {
+	type result struct {
+		ip  string
+		err error
+	}
+	results := make(chan result, len(ipURLs))
+	sem := make(chan struct{}, 4)
+
+	client := &http.Client{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for _, url := range ipURLs {
+		go func() {
+			// limit number of concurrent requests
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			ip, err := fetchIP(ctx, client, url)
+			results <- result{ip, err}
+		}()
+	}
+
+	var lastErr error
+	for i := 0; i < len(ipURLs); i++ {
+		res := <-results
+		if res.err == nil {
+			return res.ip, nil
+		}
+		lastErr = res.err
+	}
+	return "", lastErr
+}
+
+// fetchIP performs an HTTP GET request to the given URL and returns the trimmed response body as the IP.
+func fetchIP(ctx context.Context, client *http.Client, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", "curl/8.14.1") // some services return the entire HTML page for non-curl user agents
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	ip := strings.TrimSpace(string(body))
+	if ip == "" {
+		return "", fmt.Errorf("empty response from %s", url)
+	}
+	if _, err := netip.ParseAddr(ip); err != nil {
+		return "", fmt.Errorf("response is not a valid IP: %s -> %s...", url, ip[:7])
+	}
+	return ip, nil
+}

--- a/vpn/ipc/server.go
+++ b/vpn/ipc/server.go
@@ -10,9 +10,10 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/getlantern/radiance/traces"
 	"github.com/go-chi/chi/v5"
 	"github.com/sagernet/sing-box/experimental/clashapi"
+
+	"github.com/getlantern/radiance/traces"
 )
 
 // Service defines the interface that the IPC server uses to interact with the underlying VPN service.
@@ -91,14 +92,18 @@ func CloseService(ctx context.Context) error {
 func (s *Server) closeServiceHandler(w http.ResponseWriter, r *http.Request) {
 	service := s.service
 	s.service = &closedService{}
-	defer func() {
-		go traces.RecordError(r.Context(), s.Close())
-	}()
 	if err := service.Close(); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	w.WriteHeader(http.StatusOK)
+	w.(http.Flusher).Flush()
+
+	go func() {
+		if err := s.Close(); err != nil {
+			traces.RecordError(context.Background(), err)
+		}
+	}()
 }
 
 // closedService is a stub service that always returns "closed" status. It's used to replace the

--- a/vpn/ipc/server.go
+++ b/vpn/ipc/server.go
@@ -97,7 +97,9 @@ func (s *Server) closeServiceHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusOK)
-	w.(http.Flusher).Flush()
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
 
 	go func() {
 		if err := s.Close(); err != nil {

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -153,7 +153,7 @@ func GetStatus() (Status, error) {
 	ctx, span := otel.Tracer(tracerName).Start(context.Background(), "get_status")
 	defer span.End()
 	slog.Debug("Retrieving tunnel status")
-	ip, _ := getPublicIP()
+	ip, _ := GetPublicIP()
 	s := Status{
 		TunnelOpen: isOpen(ctx),
 		IP:         ip,

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -153,7 +153,11 @@ func GetStatus() (Status, error) {
 	ctx, span := otel.Tracer(tracerName).Start(context.Background(), "get_status")
 	defer span.End()
 	slog.Debug("Retrieving tunnel status")
-	ip, _ := GetPublicIP()
+	ip, err := GetPublicIP()
+	if err != nil {
+		slog.Warn("Failed to get public IP", "error", err)
+		ip = "unknown"
+	}
 	s := Status{
 		TunnelOpen: isOpen(ctx),
 		IP:         ip,


### PR DESCRIPTION
This pull request introduces a new utility for fetching the public IP address and integrates it into the VPN status reporting. It also updates the IPC server's shutdown handling for improved reliability. The most important changes are summarized below.

**Public IP Fetching Utility:**

* Added a new `vpn/ip.go` file providing functions to fetch the public IP address from multiple external services, including concurrency, error handling, and a polling mechanism to detect IP changes.

**Status Reporting Improvements:**

* Updated the `Status` struct in `vpn/vpn.go` to include a new `IP` field for reporting the current public IP address. The `GetStatus` function now fetches and populates this field.

**IPC Server Reliability:**

* Improved the shutdown sequence in `vpn/ipc/server.go`'s `closeServiceHandler` by flushing the HTTP response before asynchronously closing the server and recording errors, ensuring clients receive a response before shutdown.