### PR TITLE
Set default HTTP client timeout to 60 seconds

### DIFF
--- a/api/webclient.go
+++ b/api/webclient.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
-	"time"
 	"unicode"
 
 	"fmt"
@@ -24,10 +23,10 @@ type webClient struct {
 
 func newWebClient(httpClient *http.Client, baseURL string) *webClient {
 	if httpClient == nil {
-		httpClient = &http.Client{}
+		httpClient = &http.Client{
+			Timeout: common.DefaultHTTPTimeout,
+		}
 	}
-	//Default timeout of 60 seconds
-	httpClient.Timeout = (60 * time.Second)
 	client := resty.NewWithClient(httpClient)
 	if baseURL != "" {
 		client.SetBaseURL(baseURL)

--- a/common/constants.go
+++ b/common/constants.go
@@ -1,6 +1,9 @@
 package common
 
-import "runtime"
+import (
+	"runtime"
+	"time"
+)
 
 const (
 	Name = "lantern"
@@ -12,7 +15,8 @@ const (
 	Platform = runtime.GOOS
 
 	// filenames
-	LogFileName     = "lantern.log"
-	ConfigFileName  = "config.json"
-	ServersFileName = "servers.json"
+	LogFileName        = "lantern.log"
+	ConfigFileName     = "config.json"
+	ServersFileName    = "servers.json"
+	DefaultHTTPTimeout = (60 * time.Second)
 )

--- a/radiance.go
+++ b/radiance.go
@@ -114,8 +114,9 @@ func NewRadiance(opts Options) (*Radiance, error) {
 		kindling.WithDomainFronting(f),
 		kindling.WithProxyless("api.iantem.io"),
 	)
+
 	httpClientWithTimeout := k.NewHTTPClient()
-	httpClientWithTimeout.Timeout = (60 * time.Second)
+	httpClientWithTimeout.Timeout = common.DefaultHTTPTimeout
 
 	userInfo := common.NewUserConfig(platformDeviceID, dataDir, opts.Locale)
 	apiHandler := api.NewAPIClient(httpClientWithTimeout, userInfo, dataDir)


### PR DESCRIPTION
Adds a default timeout of 60 seconds to the HTTP client in newWebClient to prevent indefinite waits for responses.