### PR TITLE
check is vpn service is running in collect loop

### DIFF
--- a/vpn/ipc/server.go
+++ b/vpn/ipc/server.go
@@ -5,6 +5,7 @@ package ipc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -14,6 +15,11 @@ import (
 	"github.com/sagernet/sing-box/experimental/clashapi"
 
 	"github.com/getlantern/radiance/traces"
+)
+
+var (
+	ErrServiceIsNotReady   = errors.New("service is not ready")
+	ErrServiceIsNotRunning = errors.New("service is not running")
 )
 
 // Service defines the interface that the IPC server uses to interact with the underlying VPN service.
@@ -117,5 +123,3 @@ type closedService struct {
 
 func (s *closedService) Status() string { return StatusClosed }
 func (s *closedService) Close() error   { return nil }
-
-var ErrServiceIsNotReady = fmt.Errorf("service is not ready")

--- a/vpn/ipc/status.go
+++ b/vpn/ipc/status.go
@@ -3,6 +3,7 @@ package ipc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"runtime"
 
@@ -64,6 +65,9 @@ type state struct {
 // GetStatus retrieves the current status of the service.
 func GetStatus(ctx context.Context) (string, error) {
 	res, err := sendRequest[state](ctx, "GET", statusEndpoint, nil)
+	if errors.Is(err, ErrServiceIsNotRunning) || errors.Is(err, ErrServiceIsNotReady) {
+		return StatusClosed, nil
+	}
 	if err != nil {
 		return "", err
 	}

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"path/filepath"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/sagernet/sing-box/adapter"
@@ -113,7 +112,7 @@ func Reconnect(platIfce libbox.PlatformInterface) error {
 // Note, this does not check if the tunnel can connect to a server.
 func isOpen(ctx context.Context) bool {
 	state, err := ipc.GetStatus(ctx)
-	if err != nil && !strings.Contains(err.Error(), "no such file") {
+	if err != nil {
 		slog.Warn("Failed to get tunnel state", "error", err)
 	}
 	return state == ipc.StatusRunning


### PR DESCRIPTION
This pull request improves the robustness of connection metrics collection and service status handling in the VPN IPC layer. It introduces clearer error handling for different service states, ensures metrics are only polled when the service is running, and standardizes error definitions across the codebase.

**Service status:**

* Updated `GetStatus` in `vpn/ipc/status.go` to return `StatusClosed` instead of an error when the service is not ready or not running, improving reliability of status checks.
* Modified the error handling in `sendRequest` (`vpn/ipc/http.go`) to return `ErrServiceIsNotRunning` if the IPC socket is missing, unless trace logging is enabled.

**Connection metrics collection:**

* Changed `metrics/connections.go` to check the VPN service status before polling connections, and to log a warning if the service status cannot be retrieved, preventing unnecessary errors when the service is not running.