### PR TITLE
add rule for lantern traffic to bypass VPN

### DIFF
--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -161,6 +161,20 @@ func baseOpts() O.Options {
 					Type: C.RuleTypeDefault,
 					DefaultOptions: O.DefaultRule{
 						RawDefaultRule: O.RawDefaultRule{
+							ProcessName: []string{"lantern", "lantern.exe", "Lantern", "Lantern.exe"},
+						},
+						RuleAction: O.RuleAction{
+							Action: C.RuleActionTypeRoute,
+							RouteOptions: O.RouteActionOptions{
+								Outbound: "direct",
+							},
+						},
+					},
+				},
+				{
+					Type: C.RuleTypeDefault,
+					DefaultOptions: O.DefaultRule{
+						RawDefaultRule: O.RawDefaultRule{
 							IPIsPrivate: true,
 						},
 						RuleAction: O.RuleAction{


### PR DESCRIPTION
This pull request introduces a new default rule to the VPN options in `vpn/boxoptions.go`. The rule targets processes named "lantern" or "Lantern" (with both lowercase and capitalized variants, and with or without the `.exe` extension) and ensures that their outbound traffic is routed directly.

New default rule for process routing:

* Added a `RuleTypeDefault` entry to the VPN options, specifying that any process with names matching "lantern", "lantern.exe", "Lantern", or "Lantern.exe" will have its outbound traffic routed directly using the "direct" route option.