### PR TITLE
Add process path regex for bypassing the VPN on desktop

### DIFF
--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -161,7 +161,7 @@ func baseOpts() O.Options {
 					Type: C.RuleTypeDefault,
 					DefaultOptions: O.DefaultRule{
 						RawDefaultRule: O.RawDefaultRule{
-							ProcessName: []string{"lantern", "lantern.exe", "Lantern", "Lantern.exe"},
+							ProcessPathRegex: lanternRegexForPlatform(),
 						},
 						RuleAction: O.RuleAction{
 							Action: C.RuleActionTypeRoute,
@@ -221,6 +221,21 @@ func baseOpts() O.Options {
 				CacheID: cacheID,
 			},
 		},
+	
+}
+
+// lanternRegexForPlatform returns the regex patterns to match Lantern process path for the current platform. We want this
+// to be as limited as possible to avoid cases where other applications can bypass the VPN.
+func lanternRegexForPlatform() []string {
+	switch common.Platform {
+	case "windows":
+		return []string{`(?i)^.*\\lantern.exe$`}
+	case "darwin":
+		return []string{`(?i)^/Lantern.app/Contents/MacOS/lantern$`}
+	case "linux":
+		return []string{`(?i)^/opt/lantern/lantern$`, `(?i)^/usr/bin/lantern$`, `(?i)^/usr/local/bin/lantern$`}
+	default:
+		return []string{}
 	}
 }
 


### PR DESCRIPTION
This is for https://github.com/getlantern/engineering/issues/2579 and ultimately will require the latest sing-box-minimal on MacOS.

This pull request updates the way Lantern processes are identified in VPN rule configuration to use more precise regular expressions matching the full process path, rather than just matching process names. This change increases security by reducing the risk of unintended applications bypassing the VPN.

**VPN rule matching improvements:**

* Replaced process name matching with platform-specific process path regular expressions in the `RawDefaultRule` configuration, using the new `lanternRegexForPlatform()` function.
* Added the `lanternRegexForPlatform()` function to return tailored regex patterns for Windows, macOS, and Linux, ensuring only the legitimate Lantern process can bypass the VPN.