### PR TITLE
Add process path regex for directly routing lantern traffic

### DIFF
--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -444,7 +444,12 @@ func lanternRegexForPlatform() []string {
 	case "darwin":
 		return []string{`(?i)^/Lantern.app/Contents/MacOS/lantern$`}
 	case "linux":
-		return []string{`(?i)^/opt/lantern/lantern$`, `(?i)^/usr/bin/lantern$`, `(?i)^/usr/local/bin/lantern$`}
+		return []string{
+			`(?i)^/opt/lantern/lantern$`,
+			`(?i)^/usr/bin/lantern$`,
+			`(?i)^/usr/local/bin/lantern$`,
+			`(?i)^/home/.+/(lantern/(bin/)?)?lantern$`,
+		}
 	default:
 		return []string{}
 	}


### PR DESCRIPTION
For https://github.com/getlantern/engineering/issues/2579

This pull request updates how Lantern processes are identified for VPN routing rules by switching from a simple process name match to platform-specific regular expressions that match the full process path. This makes the identification more precise and reduces the risk of other applications bypassing the VPN by using the same process name. The main changes are:

**Improved Lantern process identification:**

* Replaced the process name matching in `baseRoutingRules` with a call to a new function, `lanternRegexForPlatform`, which returns platform-specific regex patterns for Lantern's process path.

* Added the `lanternRegexForPlatform` function to generate strict regex patterns for Windows, macOS, and Linux, ensuring only the actual Lantern process is matched and minimizing the risk of false positives.