### PR TITLE
Add config listener

### DIFF
--- a/radiance.go
+++ b/radiance.go
@@ -43,6 +43,9 @@ type configHandler interface {
 	// GetConfig returns the current configuration.
 	// It returns an error if the configuration is not yet available.
 	GetConfig() (*config.Config, error)
+
+	// AddConfigListener adds a listener that is called whenever the configuration changes.
+	AddConfigListener(listener config.ListenerFunc)
 }
 
 type issueReporter interface {
@@ -141,7 +144,6 @@ func NewRadiance(opts Options) (*Radiance, error) {
 		slog.Info("Disabling config fetch")
 	}
 	confHandler := config.NewConfigHandler(cOpts)
-
 	r := &Radiance{
 		confHandler:   confHandler,
 		issueReporter: issueReporter,
@@ -177,6 +179,14 @@ func (r *Radiance) Close() {
 		}
 	})
 	<-r.stopChan
+}
+
+func (r *Radiance) AddConfigListener(fetched func()) {
+	r.confHandler.AddConfigListener(func(oldCfg, newCfg *config.Config) error {
+		slog.Debug("Config Listener called")
+		fetched()
+		return nil
+	})
 }
 
 // APIHandler returns the API handler for the Radiance client.

--- a/radiance_test.go
+++ b/radiance_test.go
@@ -92,3 +92,7 @@ func (m *mockConfigHandler) SetPreferredServerLocation(country string, city stri
 func (m *mockConfigHandler) GetConfig() (*config.Config, error) {
 	return &config.Config{}, nil
 }
+
+func (m *mockConfigHandler) AddConfigListener(listener config.ListenerFunc) {
+	listener(&config.Config{}, &config.Config{})
+}


### PR DESCRIPTION
This pull request introduces support for configuration change listeners in the `Radiance` system, allowing external code to react to configuration updates. The main changes add an interface for registering listeners, implement the mechanism in the main code, and update the test mock accordingly.

**Configuration Listener Support:**

* Added `AddConfigListener` method to the `configHandler` interface, enabling registration of functions to be called on configuration changes.
* Implemented the `AddConfigListener` method in the `Radiance` struct, allowing consumers to provide a callback function that is invoked when the configuration changes.
* Updated the `mockConfigHandler` in tests to implement the new `AddConfigListener` method, immediately invoking the listener for testing purposes.

**Codebase Maintenance:**

* Minor code cleanup in `NewRadiance` by removing an unnecessary blank line after initializing `confHandler`.