### PR TITLE
add trace logs to AutoServerSelection

### DIFF
--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -270,11 +270,13 @@ func AutoServerSelections() (AutoSelections, error) {
 	if err != nil {
 		return as, fmt.Errorf("failed to get groups: %w", err)
 	}
+	slog.Log(ctx, internal.LevelTrace, "Retrieved groups", "groups", groups)
 	selected := func(tag string) string {
 		idx := slices.IndexFunc(groups, func(g ipc.OutboundGroup) bool {
 			return g.Tag == tag
 		})
 		if idx < 0 || groups[idx].Selected == "" {
+			slog.Log(ctx, internal.LevelTrace, "Group not found or has no selection", "tag", tag)
 			return "Unavailable"
 		}
 		return groups[idx].Selected


### PR DESCRIPTION
This pull request adds additional trace-level logging to the `AutoServerSelections` function in `vpn/vpn.go`. These logs will help with debugging by providing more visibility into the group retrieval and selection logic.

Logging improvements:

* Added a trace-level log statement after retrieving groups to display the fetched groups.
* Added a trace-level log statement when a group is not found or has no selection, including the relevant tag information.