### PR TITLE
feat: UPnP port forwarding + peer proxy lifecycle

### DIFF
--- a/portforward/portforward.go
+++ b/portforward/portforward.go
@@ -8,8 +8,11 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"io"
 	"math/big"
 	"net"
+	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -252,4 +255,43 @@ func LocalIP() (string, error) {
 	}
 	defer conn.Close()
 	return conn.LocalAddr().(*net.UDPAddr).IP.String(), nil
+}
+
+// ExternalIP discovers this machine's public IP by querying external services.
+// It tries multiple providers for redundancy.
+func ExternalIP(ctx context.Context) (string, error) {
+	providers := []string{
+		"https://api.ipify.org",
+		"https://ifconfig.me/ip",
+		"https://icanhazip.com",
+	}
+	for _, url := range providers {
+		ip, err := fetchExternalIP(ctx, url)
+		if err == nil && ip != "" {
+			return ip, nil
+		}
+	}
+	return "", fmt.Errorf("failed to determine external IP from any provider")
+}
+
+func fetchExternalIP(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64))
+	if err != nil {
+		return "", err
+	}
+	ip := strings.TrimSpace(string(body))
+	if net.ParseIP(ip) == nil {
+		return "", fmt.Errorf("invalid IP: %q", ip)
+	}
+	return ip, nil
 }

--- a/portforward/portforward.go
+++ b/portforward/portforward.go
@@ -1,0 +1,255 @@
+// Package portforward opens ports on the local network gateway via UPnP IGD.
+// It is used by the "Share My Connection" feature to make a peer proxy
+// reachable from the internet.
+package portforward
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/huin/goupnp/dcps/internetgateway2"
+)
+
+// ErrNoPortForwarding is returned when no port forwarding method (UPnP, NAT-PMP)
+// is available on the network.
+var ErrNoPortForwarding = errors.New("no port forwarding method available")
+
+// Mapping holds the details of an active port mapping.
+type Mapping struct {
+	ExternalPort  uint16
+	InternalPort  uint16
+	InternalIP    string
+	Protocol      string // "TCP" or "UDP"
+	LeaseDuration time.Duration
+	Method        string // "upnp-igd2", "upnp-igd1"
+}
+
+// Forwarder manages port mappings on the local gateway via UPnP IGD.
+type Forwarder struct {
+	mu      sync.Mutex
+	mapping *Mapping
+	stopC   chan struct{}
+
+	igd2Client *internetgateway2.WANIPConnection2
+	igd1Client *internetgateway2.WANIPConnection1
+}
+
+// New creates a Forwarder. Call MapPort to actually open a port.
+func New() *Forwarder {
+	return &Forwarder{}
+}
+
+// MapPort opens a port on the gateway, forwarding external traffic to the given
+// internal port on this machine. It tries UPnP IGDv2, then IGDv1. If the
+// requested external port is taken, it retries with random ports.
+func (f *Forwarder) MapPort(ctx context.Context, internalPort uint16, description string) (*Mapping, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.mapping != nil {
+		return f.mapping, nil
+	}
+
+	localIP, err := LocalIP()
+	if err != nil {
+		return nil, fmt.Errorf("determine local IP: %w", err)
+	}
+
+	// Try IGDv2 first
+	if m, err := f.tryIGD2(ctx, localIP, internalPort, description); err == nil {
+		f.mapping = m
+		return m, nil
+	}
+
+	// Fall back to IGDv1
+	if m, err := f.tryIGD1(ctx, localIP, internalPort, description); err == nil {
+		f.mapping = m
+		return m, nil
+	}
+
+	return nil, fmt.Errorf("%w: UPnP IGD not available or port mapping denied", ErrNoPortForwarding)
+}
+
+// UnmapPort removes the active port mapping from the gateway.
+func (f *Forwarder) UnmapPort(ctx context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.mapping == nil {
+		return nil
+	}
+
+	f.stopRenewal()
+
+	var err error
+	switch {
+	case f.igd2Client != nil:
+		err = f.igd2Client.DeletePortMappingCtx(ctx, "", f.mapping.ExternalPort, f.mapping.Protocol)
+	case f.igd1Client != nil:
+		err = f.igd1Client.DeletePortMappingCtx(ctx, "", f.mapping.ExternalPort, f.mapping.Protocol)
+	}
+
+	f.mapping = nil
+	f.igd2Client = nil
+	f.igd1Client = nil
+	return err
+}
+
+// Active returns the current active mapping, or nil if none.
+func (f *Forwarder) Active() *Mapping {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.mapping
+}
+
+// StartRenewal begins a background goroutine that refreshes the port mapping
+// at half the lease interval. Stopped automatically by UnmapPort.
+func (f *Forwarder) StartRenewal(ctx context.Context) {
+	f.mu.Lock()
+	if f.mapping == nil || f.stopC != nil {
+		f.mu.Unlock()
+		return
+	}
+	f.stopC = make(chan struct{})
+	m := *f.mapping
+	pf := f // capture for goroutine
+	f.mu.Unlock()
+
+	renewInterval := m.LeaseDuration / 2
+	if renewInterval < time.Minute {
+		renewInterval = time.Minute
+	}
+
+	go func() {
+		ticker := time.NewTicker(renewInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				pf.renewMapping(ctx, m)
+			case <-pf.stopC:
+				return
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func (f *Forwarder) renewMapping(ctx context.Context, m Mapping) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.mapping == nil {
+		return
+	}
+	switch {
+	case f.igd2Client != nil:
+		_ = f.igd2Client.AddPortMappingCtx(ctx,
+			"", m.ExternalPort, m.Protocol,
+			m.InternalPort, m.InternalIP,
+			true, "Lantern Peer Proxy",
+			uint32(m.LeaseDuration.Seconds()),
+		)
+	case f.igd1Client != nil:
+		_ = f.igd1Client.AddPortMappingCtx(ctx,
+			"", m.ExternalPort, m.Protocol,
+			m.InternalPort, m.InternalIP,
+			true, "Lantern Peer Proxy",
+			uint32(m.LeaseDuration.Seconds()),
+		)
+	}
+}
+
+func (f *Forwarder) stopRenewal() {
+	if f.stopC != nil {
+		close(f.stopC)
+		f.stopC = nil
+	}
+}
+
+const (
+	maxRetries    = 10
+	leaseDuration = 3600 // 1 hour in seconds
+	portRangeMin  = 10000
+	portRangeMax  = 60000
+)
+
+func (f *Forwarder) tryIGD2(ctx context.Context, localIP string, internalPort uint16, desc string) (*Mapping, error) {
+	clients, _, err := internetgateway2.NewWANIPConnection2ClientsCtx(ctx)
+	if err != nil || len(clients) == 0 {
+		return nil, fmt.Errorf("no IGDv2 gateway found")
+	}
+	client := clients[0]
+
+	for i := 0; i < maxRetries; i++ {
+		extPort := randomPort()
+		err = client.AddPortMappingCtx(ctx,
+			"", extPort, "TCP",
+			internalPort, localIP,
+			true, desc, leaseDuration,
+		)
+		if err == nil {
+			f.igd2Client = client
+			return &Mapping{
+				ExternalPort:  extPort,
+				InternalPort:  internalPort,
+				InternalIP:    localIP,
+				Protocol:      "TCP",
+				LeaseDuration: time.Duration(leaseDuration) * time.Second,
+				Method:        "upnp-igd2",
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("IGDv2 failed after %d attempts: %w", maxRetries, err)
+}
+
+func (f *Forwarder) tryIGD1(ctx context.Context, localIP string, internalPort uint16, desc string) (*Mapping, error) {
+	clients, _, err := internetgateway2.NewWANIPConnection1ClientsCtx(ctx)
+	if err != nil || len(clients) == 0 {
+		return nil, fmt.Errorf("no IGDv1 gateway found")
+	}
+	client := clients[0]
+
+	for i := 0; i < maxRetries; i++ {
+		extPort := randomPort()
+		err = client.AddPortMappingCtx(ctx,
+			"", extPort, "TCP",
+			internalPort, localIP,
+			true, desc, leaseDuration,
+		)
+		if err == nil {
+			f.igd1Client = client
+			return &Mapping{
+				ExternalPort:  extPort,
+				InternalPort:  internalPort,
+				InternalIP:    localIP,
+				Protocol:      "TCP",
+				LeaseDuration: time.Duration(leaseDuration) * time.Second,
+				Method:        "upnp-igd1",
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("IGDv1 failed after %d attempts: %w", maxRetries, err)
+}
+
+func randomPort() uint16 {
+	n, _ := rand.Int(rand.Reader, big.NewInt(int64(portRangeMax-portRangeMin)))
+	return uint16(n.Int64()) + portRangeMin
+}
+
+// LocalIP determines this machine's LAN IP by dialing a UDP socket to a
+// well-known address. No actual traffic is sent.
+func LocalIP() (string, error) {
+	conn, err := net.Dial("udp4", "8.8.8.8:53")
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+	return conn.LocalAddr().(*net.UDPAddr).IP.String(), nil
+}

--- a/portforward/portforward.go
+++ b/portforward/portforward.go
@@ -31,6 +31,7 @@ type Mapping struct {
 	Protocol      string // "TCP" or "UDP"
 	LeaseDuration time.Duration
 	Method        string // "upnp-igd2", "upnp-igd1"
+	Description   string // UPnP mapping description
 }
 
 // Forwarder manages port mappings on the local gateway via UPnP IGD.
@@ -49,8 +50,8 @@ func New() *Forwarder {
 }
 
 // MapPort opens a port on the gateway, forwarding external traffic to the given
-// internal port on this machine. It tries UPnP IGDv2, then IGDv1. If the
-// requested external port is taken, it retries with random ports.
+// internal port on this machine. It tries UPnP IGDv2, then IGDv1, selecting a
+// random external port and retrying if the chosen port cannot be mapped.
 func (f *Forwarder) MapPort(ctx context.Context, internalPort uint16, description string) (*Mapping, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -120,8 +121,9 @@ func (f *Forwarder) StartRenewal(ctx context.Context) {
 		return
 	}
 	f.stopC = make(chan struct{})
+	stopC := f.stopC // capture for goroutine to avoid race with stopRenewal
 	m := *f.mapping
-	pf := f // capture for goroutine
+	pf := f
 	f.mu.Unlock()
 
 	renewInterval := m.LeaseDuration / 2
@@ -136,7 +138,7 @@ func (f *Forwarder) StartRenewal(ctx context.Context) {
 			select {
 			case <-ticker.C:
 				pf.renewMapping(ctx, m)
-			case <-pf.stopC:
+			case <-stopC:
 				return
 			case <-ctx.Done():
 				return
@@ -151,19 +153,23 @@ func (f *Forwarder) renewMapping(ctx context.Context, m Mapping) {
 	if f.mapping == nil {
 		return
 	}
+	desc := m.Description
+	if desc == "" {
+		desc = "Lantern Peer Proxy"
+	}
 	switch {
 	case f.igd2Client != nil:
 		_ = f.igd2Client.AddPortMappingCtx(ctx,
 			"", m.ExternalPort, m.Protocol,
 			m.InternalPort, m.InternalIP,
-			true, "Lantern Peer Proxy",
+			true, desc,
 			uint32(m.LeaseDuration.Seconds()),
 		)
 	case f.igd1Client != nil:
 		_ = f.igd1Client.AddPortMappingCtx(ctx,
 			"", m.ExternalPort, m.Protocol,
 			m.InternalPort, m.InternalIP,
-			true, "Lantern Peer Proxy",
+			true, desc,
 			uint32(m.LeaseDuration.Seconds()),
 		)
 	}
@@ -188,28 +194,32 @@ func (f *Forwarder) tryIGD2(ctx context.Context, localIP string, internalPort ui
 	if err != nil || len(clients) == 0 {
 		return nil, fmt.Errorf("no IGDv2 gateway found")
 	}
-	client := clients[0]
 
-	for i := 0; i < maxRetries; i++ {
-		extPort := randomPort()
-		err = client.AddPortMappingCtx(ctx,
-			"", extPort, "TCP",
-			internalPort, localIP,
-			true, desc, leaseDuration,
-		)
-		if err == nil {
-			f.igd2Client = client
-			return &Mapping{
-				ExternalPort:  extPort,
-				InternalPort:  internalPort,
-				InternalIP:    localIP,
-				Protocol:      "TCP",
-				LeaseDuration: time.Duration(leaseDuration) * time.Second,
-				Method:        "upnp-igd2",
-			}, nil
+	var lastErr error
+	for _, client := range clients {
+		for i := 0; i < maxRetries; i++ {
+			extPort := randomPort()
+			err = client.AddPortMappingCtx(ctx,
+				"", extPort, "TCP",
+				internalPort, localIP,
+				true, desc, leaseDuration,
+			)
+			if err == nil {
+				f.igd2Client = client
+				return &Mapping{
+					ExternalPort:  extPort,
+					InternalPort:  internalPort,
+					InternalIP:    localIP,
+					Protocol:      "TCP",
+					LeaseDuration: time.Duration(leaseDuration) * time.Second,
+					Method:        "upnp-igd2",
+					Description:   desc,
+				}, nil
+			}
+			lastErr = err
 		}
 	}
-	return nil, fmt.Errorf("IGDv2 failed after %d attempts: %w", maxRetries, err)
+	return nil, fmt.Errorf("IGDv2 failed after %d attempts on %d clients: %w", maxRetries, len(clients), lastErr)
 }
 
 func (f *Forwarder) tryIGD1(ctx context.Context, localIP string, internalPort uint16, desc string) (*Mapping, error) {
@@ -217,32 +227,40 @@ func (f *Forwarder) tryIGD1(ctx context.Context, localIP string, internalPort ui
 	if err != nil || len(clients) == 0 {
 		return nil, fmt.Errorf("no IGDv1 gateway found")
 	}
-	client := clients[0]
 
-	for i := 0; i < maxRetries; i++ {
-		extPort := randomPort()
-		err = client.AddPortMappingCtx(ctx,
-			"", extPort, "TCP",
-			internalPort, localIP,
-			true, desc, leaseDuration,
-		)
-		if err == nil {
-			f.igd1Client = client
-			return &Mapping{
-				ExternalPort:  extPort,
-				InternalPort:  internalPort,
-				InternalIP:    localIP,
-				Protocol:      "TCP",
-				LeaseDuration: time.Duration(leaseDuration) * time.Second,
-				Method:        "upnp-igd1",
-			}, nil
+	var lastErr error
+	for _, client := range clients {
+		for i := 0; i < maxRetries; i++ {
+			extPort := randomPort()
+			if err := client.AddPortMappingCtx(ctx,
+				"", extPort, "TCP",
+				internalPort, localIP,
+				true, desc, leaseDuration,
+			); err == nil {
+				f.igd1Client = client
+				return &Mapping{
+					ExternalPort:  extPort,
+					InternalPort:  internalPort,
+					InternalIP:    localIP,
+					Protocol:      "TCP",
+					LeaseDuration: time.Duration(leaseDuration) * time.Second,
+					Method:        "upnp-igd1",
+					Description:   desc,
+				}, nil
+			} else {
+				lastErr = err
+			}
 		}
 	}
-	return nil, fmt.Errorf("IGDv1 failed after %d attempts: %w", maxRetries, err)
+	return nil, fmt.Errorf("IGDv1 failed after %d attempts on %d clients: %w", maxRetries, len(clients), lastErr)
 }
 
 func randomPort() uint16 {
-	n, _ := rand.Int(rand.Reader, big.NewInt(int64(portRangeMax-portRangeMin)))
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(portRangeMax-portRangeMin+1)))
+	if err != nil {
+		// Fallback to time-based if CSPRNG fails (should never happen)
+		return uint16(time.Now().UnixNano()%int64(portRangeMax-portRangeMin+1)) + portRangeMin
+	}
 	return uint16(n.Int64()) + portRangeMin
 }
 

--- a/portforward/portforward_test.go
+++ b/portforward/portforward_test.go
@@ -21,7 +21,7 @@ func TestRandomPort(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		p := randomPort()
 		assert.GreaterOrEqual(t, p, uint16(portRangeMin))
-		assert.Less(t, p, uint16(portRangeMax))
+		assert.LessOrEqual(t, p, uint16(portRangeMax))
 		seen[p] = true
 	}
 	// With 100 draws from a 50000-range, we should get many distinct values

--- a/portforward/portforward_test.go
+++ b/portforward/portforward_test.go
@@ -1,0 +1,49 @@
+package portforward
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalIP(t *testing.T) {
+	ip, err := LocalIP()
+	require.NoError(t, err)
+	assert.NotEmpty(t, ip)
+	// Should be a private network IP
+	assert.Regexp(t, `^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.)`, ip)
+}
+
+func TestRandomPort(t *testing.T) {
+	seen := make(map[uint16]bool)
+	for i := 0; i < 100; i++ {
+		p := randomPort()
+		assert.GreaterOrEqual(t, p, uint16(portRangeMin))
+		assert.Less(t, p, uint16(portRangeMax))
+		seen[p] = true
+	}
+	// With 100 draws from a 50000-range, we should get many distinct values
+	assert.Greater(t, len(seen), 50)
+}
+
+func TestNewForwarder(t *testing.T) {
+	f := New()
+	assert.NotNil(t, f)
+	assert.Nil(t, f.Active())
+}
+
+func TestUnmapPort_NoMapping(t *testing.T) {
+	f := New()
+	// Should be a no-op, not an error
+	err := f.UnmapPort(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestStartRenewal_NoMapping(t *testing.T) {
+	f := New()
+	// Should be a no-op when there's no active mapping
+	f.StartRenewal(context.Background())
+	assert.Nil(t, f.stopC) // no goroutine started
+}

--- a/vpn/ipc/peer.go
+++ b/vpn/ipc/peer.go
@@ -27,7 +27,8 @@ type PeerStatus struct {
 }
 
 // SetPeerController registers the peer proxy controller with the IPC server.
-// Must be called before Start(). If not called, peer endpoints return 501.
+// Must be called before Start(). If not called, start/stop return 501 and
+// status returns {active: false}.
 func (s *Server) SetPeerController(pc PeerController) {
 	s.peerController = pc
 }
@@ -58,14 +59,14 @@ func (s *Server) peerStartHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "peer proxy not available", http.StatusNotImplemented)
 		return
 	}
-	ctx := r.Context()
 	slog.Info("IPC: starting peer proxy")
 
 	// Process asynchronously — starting the peer proxy involves UPnP discovery
-	// and API registration which can take several seconds.
+	// and API registration which can take several seconds. Use the service
+	// context (not the request context, which is canceled when the handler returns).
 	w.WriteHeader(http.StatusAccepted)
 	go func() {
-		if err := s.peerController.Start(ctx); err != nil {
+		if err := s.peerController.Start(s.service.Ctx()); err != nil {
 			slog.Error("Failed to start peer proxy", "error", err)
 		}
 	}()

--- a/vpn/ipc/peer.go
+++ b/vpn/ipc/peer.go
@@ -1,0 +1,101 @@
+package ipc
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+const (
+	peerStartEndpoint  = "/peer/start"
+	peerStopEndpoint   = "/peer/stop"
+	peerStatusEndpoint = "/peer/status"
+)
+
+// PeerController is implemented by the peer proxy manager.
+// The IPC server calls these methods in response to client requests.
+type PeerController interface {
+	Start(ctx context.Context) error
+	Stop(ctx context.Context) error
+	Active() bool
+}
+
+// PeerStatus is the response from the peer status endpoint.
+type PeerStatus struct {
+	Active bool `json:"active"`
+}
+
+// SetPeerController registers the peer proxy controller with the IPC server.
+// Must be called before Start(). If not called, peer endpoints return 501.
+func (s *Server) SetPeerController(pc PeerController) {
+	s.peerController = pc
+}
+
+// --- Client-side functions ---
+
+// StartPeerProxy requests the IPC server to start the peer proxy.
+func StartPeerProxy(ctx context.Context) error {
+	_, err := sendRequest[empty](ctx, "POST", peerStartEndpoint, nil)
+	return err
+}
+
+// StopPeerProxy requests the IPC server to stop the peer proxy.
+func StopPeerProxy(ctx context.Context) error {
+	_, err := sendRequest[empty](ctx, "POST", peerStopEndpoint, nil)
+	return err
+}
+
+// GetPeerStatus returns the current peer proxy status.
+func GetPeerStatus(ctx context.Context) (*PeerStatus, error) {
+	return sendRequest[*PeerStatus](ctx, "GET", peerStatusEndpoint, nil)
+}
+
+// --- Server-side handlers ---
+
+func (s *Server) peerStartHandler(w http.ResponseWriter, r *http.Request) {
+	if s.peerController == nil {
+		http.Error(w, "peer proxy not available", http.StatusNotImplemented)
+		return
+	}
+	ctx := r.Context()
+	slog.Info("IPC: starting peer proxy")
+
+	// Process asynchronously — starting the peer proxy involves UPnP discovery
+	// and API registration which can take several seconds.
+	w.WriteHeader(http.StatusAccepted)
+	go func() {
+		if err := s.peerController.Start(ctx); err != nil {
+			slog.Error("Failed to start peer proxy", "error", err)
+		}
+	}()
+}
+
+func (s *Server) peerStopHandler(w http.ResponseWriter, r *http.Request) {
+	if s.peerController == nil {
+		http.Error(w, "peer proxy not available", http.StatusNotImplemented)
+		return
+	}
+	ctx := r.Context()
+	slog.Info("IPC: stopping peer proxy")
+
+	if err := s.peerController.Stop(ctx); err != nil {
+		slog.Error("Failed to stop peer proxy", "error", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) peerStatusHandler(w http.ResponseWriter, r *http.Request) {
+	if s.peerController == nil {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(PeerStatus{Active: false})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(PeerStatus{
+		Active: s.peerController.Active(),
+	})
+}

--- a/vpn/ipc/server.go
+++ b/vpn/ipc/server.go
@@ -44,11 +44,12 @@ type Service interface {
 // Server represents the IPC server that communicates over a Unix domain socket for Unix-like
 // systems, and a named pipe for Windows.
 type Server struct {
-	svr       *http.Server
-	service   Service
-	router    chi.Router
-	vpnStatus atomic.Value // string
-	closed    atomic.Bool
+	svr            *http.Server
+	service        Service
+	peerController PeerController
+	router         chi.Router
+	vpnStatus      atomic.Value // string
+	closed         atomic.Bool
 }
 
 // StatusUpdateEvent is emitted when the VPN status changes.
@@ -108,6 +109,11 @@ func NewServer(service Service) *Server {
 	s.router.Post(addOutboundsEndpoint, s.addOutboundsHandler)
 	s.router.Post(removeOutboundsEndpoint, s.removeOutboundsHandler)
 	s.router.Post(closeConnectionsEndpoint, s.closeConnectionHandler)
+
+	// Peer proxy endpoints
+	s.router.Post(peerStartEndpoint, s.peerStartHandler)
+	s.router.Post(peerStopEndpoint, s.peerStopHandler)
+	s.router.Get(peerStatusEndpoint, s.peerStatusHandler)
 
 	svr := &http.Server{
 		Handler:      s.router,

--- a/vpn/peer.go
+++ b/vpn/peer.go
@@ -112,7 +112,7 @@ func (p *PeerProxy) Start(ctx context.Context) error {
 	slog.Info("Peer proxy registered", "route_id", p.routeID)
 
 	// 4. Start sing-box instance with the server config
-	instance, err := p.startSingbox(ctx, regResp.ServerConfig)
+	instance, err := p.startSingbox(regResp.ServerConfig)
 	if err != nil {
 		_ = p.deregister(ctx)
 		_ = p.forwarder.UnmapPort(ctx)
@@ -207,6 +207,9 @@ func (p *PeerProxy) register(ctx context.Context, externalIP string, externalPor
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Lantern-Device-Id", p.deviceID)
+	if p.userToken != "" {
+		req.Header.Set("X-Lantern-Pro-Token", p.userToken)
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -259,6 +262,9 @@ func (p *PeerProxy) heartbeat(ctx context.Context) error {
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Lantern-Device-Id", p.deviceID)
+	if p.userToken != "" {
+		req.Header.Set("X-Lantern-Pro-Token", p.userToken)
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -284,17 +290,23 @@ func (p *PeerProxy) deregister(ctx context.Context) error {
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Lantern-Device-Id", p.deviceID)
+	if p.userToken != "" {
+		req.Header.Set("X-Lantern-Pro-Token", p.userToken)
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("deregister: %s", resp.Status)
+	}
 	return nil
 }
 
 // startSingbox creates and starts a sing-box instance with the given server config JSON.
-func (p *PeerProxy) startSingbox(ctx context.Context, serverConfigJSON string) (*sbox.Box, error) {
+func (p *PeerProxy) startSingbox(serverConfigJSON string) (*sbox.Box, error) {
 	opts, err := singjson.UnmarshalExtendedContext[sboxOption.Options](box.BaseContext(), []byte(serverConfigJSON))
 	if err != nil {
 		return nil, fmt.Errorf("parsing server config: %w", err)

--- a/vpn/peer.go
+++ b/vpn/peer.go
@@ -1,0 +1,322 @@
+// Package vpn contains the peer proxy lifecycle for "Share My Connection."
+// When enabled, the local Lantern client runs a samizdat inbound proxy on a
+// UPnP-mapped port and registers with the API so censored users can connect.
+package vpn
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	sbox "github.com/sagernet/sing-box"
+	sboxOption "github.com/sagernet/sing-box/option"
+
+	box "github.com/getlantern/lantern-box"
+	singjson "github.com/sagernet/sing/common/json"
+
+	"github.com/getlantern/radiance/portforward"
+)
+
+// PeerProxy manages the lifecycle of a residential peer proxy: UPnP port
+// mapping, API registration, sing-box server instance, and heartbeat.
+type PeerProxy struct {
+	mu sync.Mutex
+
+	apiBase   string // e.g. "https://api.example.com/v1"
+	deviceID  string
+	userToken string
+
+	forwarder  *portforward.Forwarder
+	routeID    string
+	instance   *sbox.Box
+	cancelFunc context.CancelFunc
+
+	active bool
+}
+
+// PeerProxyConfig holds the configuration needed to start a peer proxy.
+type PeerProxyConfig struct {
+	APIBase   string // API base URL (e.g. "https://api.getiantem.org/v1")
+	DeviceID  string
+	UserToken string
+}
+
+type peerRegisterRequest struct {
+	ExternalIP   string `json:"external_ip"`
+	ExternalPort uint16 `json:"external_port"`
+	InternalPort uint16 `json:"internal_port"`
+}
+
+type peerRegisterResponse struct {
+	RouteID                  string `json:"route_id"`
+	ServerConfig             string `json:"server_config"`
+	HeartbeatIntervalSeconds int    `json:"heartbeat_interval_seconds"`
+}
+
+// NewPeerProxy creates a new peer proxy manager.
+func NewPeerProxy(cfg PeerProxyConfig) *PeerProxy {
+	return &PeerProxy{
+		apiBase:   cfg.APIBase,
+		deviceID:  cfg.DeviceID,
+		userToken: cfg.UserToken,
+		forwarder: portforward.New(),
+	}
+}
+
+// Start initiates the peer proxy: maps a port via UPnP, registers with the
+// API, starts a sing-box instance with the returned server config, and begins
+// heartbeating.
+func (p *PeerProxy) Start(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.active {
+		return nil
+	}
+
+	slog.Info("Starting peer proxy")
+
+	// 1. Pick a random internal port and map via UPnP
+	internalPort := randomInternalPort()
+	mapping, err := p.forwarder.MapPort(ctx, internalPort, "Lantern Peer Proxy")
+	if err != nil {
+		return fmt.Errorf("UPnP port mapping failed: %w", err)
+	}
+	slog.Info("UPnP port mapped",
+		"internal_port", mapping.InternalPort,
+		"external_port", mapping.ExternalPort,
+		"method", mapping.Method,
+	)
+
+	// 2. Discover external IP
+	externalIP, err := portforward.ExternalIP(ctx)
+	if err != nil {
+		_ = p.forwarder.UnmapPort(ctx)
+		return fmt.Errorf("external IP discovery failed: %w", err)
+	}
+	slog.Info("External IP discovered", "ip", externalIP)
+
+	// 3. Register with API — server generates credentials and returns sing-box config
+	regResp, err := p.register(ctx, externalIP, mapping.ExternalPort, mapping.InternalPort)
+	if err != nil {
+		_ = p.forwarder.UnmapPort(ctx)
+		return fmt.Errorf("peer registration failed: %w", err)
+	}
+	p.routeID = regResp.RouteID
+	slog.Info("Peer proxy registered", "route_id", p.routeID)
+
+	// 4. Start sing-box instance with the server config
+	instance, err := p.startSingbox(ctx, regResp.ServerConfig)
+	if err != nil {
+		_ = p.deregister(ctx)
+		_ = p.forwarder.UnmapPort(ctx)
+		return fmt.Errorf("failed to start sing-box: %w", err)
+	}
+	p.instance = instance
+
+	// 5. Start background goroutines
+	peerCtx, cancel := context.WithCancel(ctx)
+	p.cancelFunc = cancel
+
+	// UPnP lease renewal
+	p.forwarder.StartRenewal(peerCtx)
+
+	// Heartbeat
+	heartbeatInterval := time.Duration(regResp.HeartbeatIntervalSeconds) * time.Second
+	if heartbeatInterval < time.Minute {
+		heartbeatInterval = 5 * time.Minute
+	}
+	go p.heartbeatLoop(peerCtx, heartbeatInterval)
+
+	p.active = true
+	slog.Info("Peer proxy active",
+		"external", fmt.Sprintf("%s:%d", externalIP, mapping.ExternalPort),
+		"route_id", p.routeID,
+	)
+	return nil
+}
+
+// Stop shuts down the peer proxy: deregisters, stops sing-box, unmaps port.
+func (p *PeerProxy) Stop(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if !p.active {
+		return nil
+	}
+
+	slog.Info("Stopping peer proxy", "route_id", p.routeID)
+
+	// Cancel background goroutines
+	if p.cancelFunc != nil {
+		p.cancelFunc()
+		p.cancelFunc = nil
+	}
+
+	// Deregister from API
+	if err := p.deregister(ctx); err != nil {
+		slog.Warn("Failed to deregister peer proxy", "error", err)
+	}
+
+	// Stop sing-box
+	if p.instance != nil {
+		if err := p.instance.Close(); err != nil {
+			slog.Warn("Failed to close sing-box instance", "error", err)
+		}
+		p.instance = nil
+	}
+
+	// Unmap UPnP port
+	if err := p.forwarder.UnmapPort(ctx); err != nil {
+		slog.Warn("Failed to unmap UPnP port", "error", err)
+	}
+
+	p.routeID = ""
+	p.active = false
+	slog.Info("Peer proxy stopped")
+	return nil
+}
+
+// Active returns true if the peer proxy is running.
+func (p *PeerProxy) Active() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.active
+}
+
+// register calls POST /v1/peer/register on the API.
+func (p *PeerProxy) register(ctx context.Context, externalIP string, externalPort, internalPort uint16) (*peerRegisterResponse, error) {
+	body, err := json.Marshal(peerRegisterRequest{
+		ExternalIP:   externalIP,
+		ExternalPort: externalPort,
+		InternalPort: internalPort,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.apiBase+"/peer/register", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Lantern-Device-Id", p.deviceID)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("register failed: %s: %s", resp.Status, string(respBody))
+	}
+
+	var result peerRegisterResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding register response: %w", err)
+	}
+	return &result, nil
+}
+
+// heartbeatLoop sends periodic heartbeats to keep the route alive.
+func (p *PeerProxy) heartbeatLoop(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if err := p.heartbeat(ctx); err != nil {
+				slog.Warn("Peer proxy heartbeat failed", "error", err)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (p *PeerProxy) heartbeat(ctx context.Context) error {
+	p.mu.Lock()
+	routeID := p.routeID
+	p.mu.Unlock()
+
+	if routeID == "" {
+		return nil
+	}
+
+	body, _ := json.Marshal(map[string]string{"route_id": routeID})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.apiBase+"/peer/heartbeat", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Lantern-Device-Id", p.deviceID)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("heartbeat: %s", resp.Status)
+	}
+	return nil
+}
+
+func (p *PeerProxy) deregister(ctx context.Context) error {
+	if p.routeID == "" {
+		return nil
+	}
+
+	body, _ := json.Marshal(map[string]string{"route_id": p.routeID})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.apiBase+"/peer/deregister", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Lantern-Device-Id", p.deviceID)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+// startSingbox creates and starts a sing-box instance with the given server config JSON.
+func (p *PeerProxy) startSingbox(ctx context.Context, serverConfigJSON string) (*sbox.Box, error) {
+	opts, err := singjson.UnmarshalExtendedContext[sboxOption.Options](box.BaseContext(), []byte(serverConfigJSON))
+	if err != nil {
+		return nil, fmt.Errorf("parsing server config: %w", err)
+	}
+
+	instance, err := sbox.New(sbox.Options{
+		Context: box.BaseContext(),
+		Options: opts,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating sing-box instance: %w", err)
+	}
+
+	if err := instance.Start(); err != nil {
+		instance.Close()
+		return nil, fmt.Errorf("starting sing-box: %w", err)
+	}
+
+	return instance, nil
+}
+
+func randomInternalPort() uint16 {
+	// Use a port in the high range to avoid conflicts with common services
+	return uint16(30000 + time.Now().UnixNano()%20000)
+}


### PR DESCRIPTION
## Summary

Enables uncensored Lantern users to act as full samizdat proxy servers on residential IPs, directly accessible to censored users.

### Port forwarding (`portforward/portforward.go`)
- UPnP IGD v2/v1 port mapping with retry logic (10 attempts, random ports 10000-60000)
- 1-hour lease with automatic renewal at 50% interval
- `ExternalIP()` discovery via multiple providers (ipify, ifconfig.me, icanhazip)
- Clean unmapping on shutdown

### Peer proxy lifecycle (`vpn/peer.go`)
- `PeerProxy.Start()`: Map UPnP port → discover external IP → register with API → start sing-box with server config → start heartbeat
- `PeerProxy.Stop()`: Deregister → stop sing-box → unmap port
- API generates all credentials (X25519, short ID, TLS cert, masquerade domain) and returns complete sing-box config
- Heartbeat every 5 minutes keeps route alive; missed heartbeat auto-deprecates

### Why
Residential IPs fall outside the GFW's monitoring scope ([~2% of IPs, datacenter ranges only](https://gfw.report/publications/usenixsecurity23/en/)). See [full analysis](https://github.com/getlantern/engineering/blob/main/docs/peer-proxy-analysis.md).

### Server-side companion PR
getlantern/lantern-cloud#2553 — peer registration API

## Test plan
- [ ] UPnP port mapping on a home router
- [ ] External IP discovery returns correct public IP
- [ ] Full lifecycle: start → register → heartbeat → stop → deregister
- [ ] sing-box starts with API-generated config and accepts samizdat connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)