### PR TITLE
fix: preTest should only URL-test smart outbounds

### DIFF
--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -479,25 +479,7 @@ func useIfNotZero[T comparable](newVal, oldVal T) T {
 }
 
 func appendGroupOutbounds(opts *O.Options, serverGroup, autoTag string, tags []string, urlOverrides map[string]string) {
-	// When bandit URL overrides exist, only URL-test the outbounds that have
-	// callback URLs (the smart-selected subset). All outbounds remain in the
-	// selector for manual selection. This prevents OOM on Android from
-	// URL-testing 30+ outbounds concurrently.
-	urlTestTags := tags
-	if len(urlOverrides) > 0 {
-		filtered := make([]string, 0, len(urlOverrides))
-		for _, tag := range tags {
-			if _, hasOverride := urlOverrides[tag]; hasOverride {
-				filtered = append(filtered, tag)
-			}
-		}
-		if len(filtered) > 0 {
-			urlTestTags = filtered
-		} else {
-			slog.Warn("No URL-test tags matched URL overrides, falling back to all tags",
-				"serverGroup", serverGroup, "tagCount", len(tags), "overrideCount", len(urlOverrides))
-		}
-	}
+	urlTestTags := filterURLTestTags(tags, urlOverrides, serverGroup)
 	opts.Outbounds = append(opts.Outbounds, urlTestOutbound(autoTag, urlTestTags, urlOverrides))
 	opts.Outbounds = append(opts.Outbounds, selectorOutbound(serverGroup, append([]string{autoTag}, tags...)))
 	slog.Log(
@@ -653,4 +635,25 @@ func newDNSServerOptions(typ, tag, server, domainResolver string) O.DNSServerOpt
 		Type:    typ,
 		Options: serverOpts,
 	}
+}
+
+// filterURLTestTags returns only the tags that have URL overrides when overrides
+// are present. If no overrides exist or none match, returns all tags unchanged.
+// The context parameter is used for log attribution.
+func filterURLTestTags(tags []string, urlOverrides map[string]string, context string) []string {
+	if len(urlOverrides) == 0 {
+		return tags
+	}
+	filtered := make([]string, 0, len(urlOverrides))
+	for _, tag := range tags {
+		if _, ok := urlOverrides[tag]; ok {
+			filtered = append(filtered, tag)
+		}
+	}
+	if len(filtered) > 0 {
+		return filtered
+	}
+	slog.Warn("No URL-test tags matched URL overrides, falling back to all tags",
+		"context", context, "tagCount", len(tags), "overrideCount", len(urlOverrides))
+	return tags
 }

--- a/vpn/boxoptions_test.go
+++ b/vpn/boxoptions_test.go
@@ -378,3 +378,29 @@ func TestKernelBelow(t *testing.T) {
 		})
 	}
 }
+
+func TestFilterURLTestTags(t *testing.T) {
+	allTags := []string{"a", "b", "c", "d", "e"}
+
+	t.Run("no overrides returns all tags", func(t *testing.T) {
+		result := filterURLTestTags(allTags, nil, "test")
+		assert.Equal(t, allTags, result)
+	})
+
+	t.Run("empty overrides returns all tags", func(t *testing.T) {
+		result := filterURLTestTags(allTags, map[string]string{}, "test")
+		assert.Equal(t, allTags, result)
+	})
+
+	t.Run("overrides with matches filters to matched tags", func(t *testing.T) {
+		overrides := map[string]string{"b": "url1", "d": "url2"}
+		result := filterURLTestTags(allTags, overrides, "test")
+		assert.Equal(t, []string{"b", "d"}, result)
+	})
+
+	t.Run("overrides with no matches falls back to all tags", func(t *testing.T) {
+		overrides := map[string]string{"x": "url1", "y": "url2"}
+		result := filterURLTestTags(allTags, overrides, "test")
+		assert.Equal(t, allTags, result)
+	})
+}

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -531,18 +531,7 @@ func preTest(path string) (map[string]uint16, context.Context, bool, error) {
 	// (those with callback URLs). Extra outbounds remain in the sing-box
 	// instance so we can dial through them, but testing all ~36 wastes
 	// time and delays callbacks past the 30s probe expiry window.
-	urlTestTags := tags
-	if len(cfg.BanditURLOverrides) > 0 {
-		filtered := make([]string, 0, len(cfg.BanditURLOverrides))
-		for _, tag := range tags {
-			if _, ok := cfg.BanditURLOverrides[tag]; ok {
-				filtered = append(filtered, tag)
-			}
-		}
-		if len(filtered) > 0 {
-			urlTestTags = filtered
-		}
-	}
+	urlTestTags := filterURLTestTags(tags, cfg.BanditURLOverrides, "preTest")
 	outbounds = append(outbounds, urlTestOutbound("preTest", urlTestTags, cfg.BanditURLOverrides))
 	options := option.Options{
 		Log:       &option.LogOptions{Disabled: true},

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -527,7 +527,23 @@ func preTest(path string) (map[string]uint16, context.Context, bool, error) {
 	for _, ob := range outbounds {
 		tags = append(tags, ob.Tag)
 	}
-	outbounds = append(outbounds, urlTestOutbound("preTest", tags, cfg.BanditURLOverrides))
+	// When bandit URL overrides exist, only URL-test the smart outbounds
+	// (those with callback URLs). Extra outbounds remain in the sing-box
+	// instance so we can dial through them, but testing all ~36 wastes
+	// time and delays callbacks past the 30s probe expiry window.
+	urlTestTags := tags
+	if len(cfg.BanditURLOverrides) > 0 {
+		filtered := make([]string, 0, len(cfg.BanditURLOverrides))
+		for _, tag := range tags {
+			if _, ok := cfg.BanditURLOverrides[tag]; ok {
+				filtered = append(filtered, tag)
+			}
+		}
+		if len(filtered) > 0 {
+			urlTestTags = filtered
+		}
+	}
+	outbounds = append(outbounds, urlTestOutbound("preTest", urlTestTags, cfg.BanditURLOverrides))
 	options := option.Options{
 		Log:       &option.LogOptions{Disabled: true},
 		Outbounds: outbounds,


### PR DESCRIPTION
## Summary
- Filter preTest URL test group to only outbounds with bandit callback URLs (BanditURLOverrides)
- Previously tested all ~36 outbounds; now tests only the ~10 smart ones
- Extra outbounds stay in the sing-box instance for connectivity but aren't URL-tested
- Matches the existing filtering in `appendGroupOutbounds` for the tunnel's URL test group
- Reduces preTest time from ~5s to ~1-2s, getting callbacks to the server faster

## Context
Each config fetch creates probe tokens on the server with a 30s TTL. The client must fire callback URLs within that window. Testing 36 outbounds unnecessarily delays the 10 callbacks that matter.

## Test plan
- [ ] preTest logs should show ~10 outbounds in results instead of ~36
- [ ] `bandit.callback` probe_age_seconds should drop from avg 2.5s to ~1s
- [ ] Zero `bandit.reaper.expired` spans for the test ASN

🤖 Generated with [Claude Code](https://claude.com/claude-code)