### PR TITLE
refactor: remove redundant RunOffCgoStack wrappers (now in lantern boundary)

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -67,21 +67,17 @@ func (ac *APIClient) NewUser(ctx context.Context) (*protos.LoginResponse, error)
 }
 
 func (ac *APIClient) UserData() ([]byte, error) {
-	return common.RunOffCgoStack(func() ([]byte, error) {
-		slog.Debug("Getting user data")
-		user := &protos.LoginResponse{}
-		err := settings.GetStruct(settings.LoginResponseKey, user)
-		return withMarshalProto(user, err)
-	})
+	slog.Debug("Getting user data")
+	user := &protos.LoginResponse{}
+	err := settings.GetStruct(settings.LoginResponseKey, user)
+	return withMarshalProto(user, err)
 }
 
 // FetchUserData fetches user data from the server.
 func (ac *APIClient) FetchUserData(ctx context.Context) ([]byte, error) {
-	return common.RunOffCgoStack(func() ([]byte, error) {
-		ctx, span := otel.Tracer(tracerName).Start(ctx, "fetch_user_data")
-		defer span.End()
-		return withMarshalProto(ac.fetchUserData(ctx))
-	})
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "fetch_user_data")
+	defer span.End()
+	return withMarshalProto(ac.fetchUserData(ctx))
 }
 
 // fetchUserData calls the /user-data endpoint and stores the result via storeData.
@@ -336,62 +332,58 @@ func (a *APIClient) getSalt(ctx context.Context, email string) ([]byte, error) {
 
 // Login logs the user in.
 func (a *APIClient) Login(ctx context.Context, email string, password string) ([]byte, error) {
-	return common.RunOffCgoStack(func() ([]byte, error) {
-		// clear any previous salt value
-		a.salt = nil
-		ctx, span := otel.Tracer(tracerName).Start(ctx, "login")
-		defer span.End()
+	// clear any previous salt value
+	a.salt = nil
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "login")
+	defer span.End()
 
-		salt, err := a.getSalt(ctx, email)
-		if err != nil {
-			return nil, err
-		}
+	salt, err := a.getSalt(ctx, email)
+	if err != nil {
+		return nil, err
+	}
 
-		deviceId := settings.GetString(settings.DeviceIDKey)
-		resp, err := a.authClient.Login(ctx, email, password, deviceId, salt)
-		if err != nil {
-			return nil, traces.RecordError(ctx, err)
-		}
+	deviceId := settings.GetString(settings.DeviceIDKey)
+	resp, err := a.authClient.Login(ctx, email, password, deviceId, salt)
+	if err != nil {
+		return nil, traces.RecordError(ctx, err)
+	}
 
-		//this can be nil if the user has reached the device limit
-		if resp.LegacyUserData != nil {
-			// Append device ID to user data
-			resp.LegacyUserData.DeviceID = deviceId
-		}
+	//this can be nil if the user has reached the device limit
+	if resp.LegacyUserData != nil {
+		// Append device ID to user data
+		resp.LegacyUserData.DeviceID = deviceId
+	}
 
-		// regardless of state we need to save login information
-		// We have device flow limit on login
-		a.setData(resp)
-		a.salt = salt
-		if saltErr := writeSalt(salt, a.saltPath); saltErr != nil {
-			return nil, traces.RecordError(ctx, saltErr)
-		}
-		return withMarshalProto(resp, nil)
-	})
+	// regardless of state we need to save login information
+	// We have device flow limit on login
+	a.setData(resp)
+	a.salt = salt
+	if saltErr := writeSalt(salt, a.saltPath); saltErr != nil {
+		return nil, traces.RecordError(ctx, saltErr)
+	}
+	return withMarshalProto(resp, nil)
 }
 
 // Logout logs the user out. No-op if there is no user account logged in.
 func (a *APIClient) Logout(ctx context.Context, email string) ([]byte, error) {
-	return common.RunOffCgoStack(func() ([]byte, error) {
-		ctx, span := otel.Tracer(tracerName).Start(ctx, "logout")
-		defer span.End()
-		logout := &protos.LogoutRequest{
-			Email:        email,
-			DeviceId:     settings.GetString(settings.DeviceIDKey),
-			LegacyUserID: settings.GetInt64(settings.UserIDKey),
-			LegacyToken:  settings.GetString(settings.TokenKey),
-			Token:        settings.GetString(settings.JwtTokenKey),
-		}
-		if err := a.authClient.SignOut(ctx, logout); err != nil {
-			return nil, traces.RecordError(ctx, fmt.Errorf("logging out: %w", err))
-		}
-		a.Reset()
-		a.salt = nil
-		if err := writeSalt(nil, a.saltPath); err != nil {
-			return nil, traces.RecordError(ctx, fmt.Errorf("writing salt after logout: %w", err))
-		}
-		return withMarshalProto(a.NewUser(context.Background()))
-	})
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "logout")
+	defer span.End()
+	logout := &protos.LogoutRequest{
+		Email:        email,
+		DeviceId:     settings.GetString(settings.DeviceIDKey),
+		LegacyUserID: settings.GetInt64(settings.UserIDKey),
+		LegacyToken:  settings.GetString(settings.TokenKey),
+		Token:        settings.GetString(settings.JwtTokenKey),
+	}
+	if err := a.authClient.SignOut(ctx, logout); err != nil {
+		return nil, traces.RecordError(ctx, fmt.Errorf("logging out: %w", err))
+	}
+	a.Reset()
+	a.salt = nil
+	if err := writeSalt(nil, a.saltPath); err != nil {
+		return nil, traces.RecordError(ctx, fmt.Errorf("writing salt after logout: %w", err))
+	}
+	return withMarshalProto(a.NewUser(context.Background()))
 }
 
 func withMarshalProto(resp *protos.LoginResponse, err error) ([]byte, error) {
@@ -589,89 +581,87 @@ func (a *APIClient) CompleteChangeEmail(ctx context.Context, newEmail, password,
 
 // DeleteAccount deletes this user account.
 func (a *APIClient) DeleteAccount(ctx context.Context, email, password string, isOAuthUser bool) ([]byte, error) {
-	return common.RunOffCgoStack(func() ([]byte, error) {
-		ctx, span := otel.Tracer(tracerName).Start(ctx, "delete_account")
-		defer span.End()
-		var deleteRequestBody *protos.DeleteUserRequest
-		lowerCaseEmail := strings.ToLower(email)
-		if !isOAuthUser {
-			salt, err := a.getSalt(ctx, lowerCaseEmail)
-			if err != nil {
-				return nil, traces.RecordError(ctx, err)
-			}
-
-			// Prepare login request body
-			encKey, err := generateEncryptedKey(password, lowerCaseEmail, salt)
-			if err != nil {
-				return nil, traces.RecordError(ctx, err)
-			}
-			client := srp.NewSRPClient(srp.KnownGroups[group], encKey, nil)
-
-			//Send this key to client
-			A := client.EphemeralPublic()
-
-			//Create body
-			prepareRequestBody := &protos.PrepareRequest{
-				Email: lowerCaseEmail,
-				A:     A.Bytes(),
-			}
-
-			srpB, err := a.authClient.LoginPrepare(ctx, prepareRequestBody)
-			if err != nil {
-				return nil, traces.RecordError(ctx, err)
-			}
-
-			B := big.NewInt(0).SetBytes(srpB.B)
-
-			if err = client.SetOthersPublic(B); err != nil {
-				return nil, traces.RecordError(ctx, err)
-			}
-
-			clientKey, err := client.Key()
-			if err != nil || clientKey == nil {
-				return nil, traces.RecordError(ctx, fmt.Errorf("user_not_found error while generating Client key %w", err))
-			}
-
-			// check if the server proof is valid
-			if !client.GoodServerProof(salt, lowerCaseEmail, srpB.Proof) {
-				return nil, traces.RecordError(ctx, errors.New("user_not_found error while checking server proof"))
-			}
-
-			clientProof, err := client.ClientProof()
-			if err != nil {
-				return nil, traces.RecordError(ctx, fmt.Errorf("user_not_found error while generating client proof %w", err))
-			}
-			deleteRequestBody = &protos.DeleteUserRequest{
-				Email:     lowerCaseEmail,
-				Proof:     clientProof,
-				Permanent: true,
-				DeviceId:  settings.GetString(settings.DeviceIDKey),
-				Token:     settings.GetString(settings.JwtTokenKey),
-			}
-		} else {
-			jwtToken := settings.GetString(settings.JwtTokenKey)
-			if jwtToken == "" {
-				return nil, traces.RecordError(ctx, errors.New("jwt token is required for OAuth account deletion"))
-			}
-			deleteRequestBody = &protos.DeleteUserRequest{
-				Email:     lowerCaseEmail,
-				Permanent: true,
-				Token:     jwtToken,
-				DeviceId:  settings.GetString(settings.DeviceIDKey),
-			}
-		}
-		if err := a.authClient.DeleteAccount(ctx, deleteRequestBody); err != nil {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "delete_account")
+	defer span.End()
+	var deleteRequestBody *protos.DeleteUserRequest
+	lowerCaseEmail := strings.ToLower(email)
+	if !isOAuthUser {
+		salt, err := a.getSalt(ctx, lowerCaseEmail)
+		if err != nil {
 			return nil, traces.RecordError(ctx, err)
 		}
-		// clean up local data
-		a.Reset()
-		a.salt = nil
-		if err := writeSalt(nil, a.saltPath); err != nil {
-			return nil, traces.RecordError(ctx, fmt.Errorf("failed to write salt during account deletion cleanup: %w", err))
+
+		// Prepare login request body
+		encKey, err := generateEncryptedKey(password, lowerCaseEmail, salt)
+		if err != nil {
+			return nil, traces.RecordError(ctx, err)
+		}
+		client := srp.NewSRPClient(srp.KnownGroups[group], encKey, nil)
+
+		//Send this key to client
+		A := client.EphemeralPublic()
+
+		//Create body
+		prepareRequestBody := &protos.PrepareRequest{
+			Email: lowerCaseEmail,
+			A:     A.Bytes(),
 		}
 
-		return withMarshalProto(a.NewUser(context.Background()))
-	})
+		srpB, err := a.authClient.LoginPrepare(ctx, prepareRequestBody)
+		if err != nil {
+			return nil, traces.RecordError(ctx, err)
+		}
+
+		B := big.NewInt(0).SetBytes(srpB.B)
+
+		if err = client.SetOthersPublic(B); err != nil {
+			return nil, traces.RecordError(ctx, err)
+		}
+
+		clientKey, err := client.Key()
+		if err != nil || clientKey == nil {
+			return nil, traces.RecordError(ctx, fmt.Errorf("user_not_found error while generating Client key %w", err))
+		}
+
+		// check if the server proof is valid
+		if !client.GoodServerProof(salt, lowerCaseEmail, srpB.Proof) {
+			return nil, traces.RecordError(ctx, errors.New("user_not_found error while checking server proof"))
+		}
+
+		clientProof, err := client.ClientProof()
+		if err != nil {
+			return nil, traces.RecordError(ctx, fmt.Errorf("user_not_found error while generating client proof %w", err))
+		}
+		deleteRequestBody = &protos.DeleteUserRequest{
+			Email:     lowerCaseEmail,
+			Proof:     clientProof,
+			Permanent: true,
+			DeviceId:  settings.GetString(settings.DeviceIDKey),
+			Token:     settings.GetString(settings.JwtTokenKey),
+		}
+	} else {
+		jwtToken := settings.GetString(settings.JwtTokenKey)
+		if jwtToken == "" {
+			return nil, traces.RecordError(ctx, errors.New("jwt token is required for OAuth account deletion"))
+		}
+		deleteRequestBody = &protos.DeleteUserRequest{
+			Email:     lowerCaseEmail,
+			Permanent: true,
+			Token:     jwtToken,
+			DeviceId:  settings.GetString(settings.DeviceIDKey),
+		}
+	}
+	if err := a.authClient.DeleteAccount(ctx, deleteRequestBody); err != nil {
+		return nil, traces.RecordError(ctx, err)
+	}
+	// clean up local data
+	a.Reset()
+	a.salt = nil
+	if err := writeSalt(nil, a.saltPath); err != nil {
+		return nil, traces.RecordError(ctx, fmt.Errorf("failed to write salt during account deletion cleanup: %w", err))
+	}
+
+	return withMarshalProto(a.NewUser(context.Background()))
 }
 
 // OAuthLoginUrl initiates the OAuth login process for the specified provider.
@@ -690,40 +680,38 @@ func (a *APIClient) OAuthLoginUrl(ctx context.Context, provider string) (string,
 }
 
 func (a *APIClient) OAuthLoginCallback(ctx context.Context, oAuthToken string) ([]byte, error) {
-	return common.RunOffCgoStack(func() ([]byte, error) {
-		slog.Debug("Getting OAuth login callback")
-		jwtUserInfo, err := decodeJWT(oAuthToken)
-		if err != nil {
-			return nil, fmt.Errorf("error decoding JWT: %w", err)
-		}
+	slog.Debug("Getting OAuth login callback")
+	jwtUserInfo, err := decodeJWT(oAuthToken)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding JWT: %w", err)
+	}
 
-		// Temporary  set user data to so api can read it
-		login := &protos.LoginResponse{
-			LegacyID:    jwtUserInfo.LegacyUserID,
-			LegacyToken: jwtUserInfo.LegacyToken,
-			LegacyUserData: &protos.LoginResponse_UserData{
-				UserId:   jwtUserInfo.LegacyUserID,
-				Token:    jwtUserInfo.LegacyToken,
-				DeviceID: jwtUserInfo.DeviceId,
-				Email:    jwtUserInfo.Email,
-			},
-		}
-		a.setData(login)
-		// Get user data from api this will also save data in user config
-		user, err := a.fetchUserData(context.Background())
-		if err != nil {
-			return nil, fmt.Errorf("error getting user data: %w", err)
-		}
+	// Temporary  set user data to so api can read it
+	login := &protos.LoginResponse{
+		LegacyID:    jwtUserInfo.LegacyUserID,
+		LegacyToken: jwtUserInfo.LegacyToken,
+		LegacyUserData: &protos.LoginResponse_UserData{
+			UserId:   jwtUserInfo.LegacyUserID,
+			Token:    jwtUserInfo.LegacyToken,
+			DeviceID: jwtUserInfo.DeviceId,
+			Email:    jwtUserInfo.Email,
+		},
+	}
+	a.setData(login)
+	// Get user data from api this will also save data in user config
+	user, err := a.fetchUserData(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("error getting user data: %w", err)
+	}
 
-		if err := settings.Set(settings.JwtTokenKey, oAuthToken); err != nil {
-			slog.Error("Failed to persist JWT token", "error", err)
-			return nil, fmt.Errorf("failed to persist JWT token: %w", err)
-		}
-		user.Id = jwtUserInfo.Email
-		user.EmailConfirmed = true
-		a.setData(user)
-		return withMarshalProto(user, nil)
-	})
+	if err := settings.Set(settings.JwtTokenKey, oAuthToken); err != nil {
+		slog.Error("Failed to persist JWT token", "error", err)
+		return nil, fmt.Errorf("failed to persist JWT token: %w", err)
+	}
+	user.Id = jwtUserInfo.Email
+	user.EmailConfirmed = true
+	a.setData(user)
+	return withMarshalProto(user, nil)
 }
 
 type LinkResponse struct {

--- a/servers/manager.go
+++ b/servers/manager.go
@@ -184,10 +184,7 @@ type Server struct {
 }
 
 // GetServerByTag returns the server configuration for a given tag and a boolean indicating whether
-// the server was found. The returned Server contains pointer-rich sing-box types in its Options
-// field, so callers on a CGo callback stack should use [GetServerByTagJSON] instead. This method
-// does not use [common.RunOffCgoStack] because its only callers run on regular Go goroutines
-// (event subscribers, private server flows), never on CGo callback stacks.
+// the server was found.
 func (m *Manager) GetServerByTag(tag string) (Server, bool) {
 	m.access.RLock()
 	defer m.access.RUnlock()
@@ -220,38 +217,26 @@ func (m *Manager) getServerByTagLocked(tag string) (Server, bool) {
 }
 
 // ServersJSON returns the current server configurations as pre-marshalled JSON.
-// Safe to call from CGo callback stacks: the work runs on a dedicated Go goroutine
-// (via [common.RunOffCgoStack]) so pointer-rich sing-box types never touch the C stack.
 func (m *Manager) ServersJSON() ([]byte, error) {
-	return common.RunOffCgoStack(func() ([]byte, error) {
-		m.access.RLock()
-		defer m.access.RUnlock()
-		return json.MarshalContext(box.BaseContext(), m.servers)
-	})
+	m.access.RLock()
+	defer m.access.RUnlock()
+	return json.MarshalContext(box.BaseContext(), m.servers)
 }
 
 // GetServerByTagJSON returns the server configuration for a given tag as pre-marshalled JSON.
-// Like [ServersJSON], safe to call from CGo callback stacks.
 func (m *Manager) GetServerByTagJSON(tag string) ([]byte, bool, error) {
-	type result struct {
-		data []byte
-		ok   bool
-	}
-	r, err := common.RunOffCgoStack(func() (result, error) {
-		m.access.RLock()
-		defer m.access.RUnlock()
+	m.access.RLock()
+	defer m.access.RUnlock()
 
-		s, ok := m.getServerByTagLocked(tag)
-		if !ok {
-			return result{}, nil
-		}
-		b, err := json.MarshalContext(box.BaseContext(), s)
-		if err != nil {
-			return result{}, fmt.Errorf("marshal server %q: %w", tag, err)
-		}
-		return result{data: b, ok: true}, nil
-	})
-	return r.data, r.ok, err
+	s, ok := m.getServerByTagLocked(tag)
+	if !ok {
+		return nil, false, nil
+	}
+	b, err := json.MarshalContext(box.BaseContext(), s)
+	if err != nil {
+		return nil, false, fmt.Errorf("marshal server %q: %w", tag, err)
+	}
+	return b, true, nil
 }
 
 type ServersUpdatedEvent struct {

--- a/vpn/split_tunnel.go
+++ b/vpn/split_tunnel.go
@@ -140,7 +140,6 @@ func (s *SplitTunnel) ItemsJSON(filterType string) (string, error) {
 // tunnel configuration as a JSON-encoded []string. It first extracts values
 // from the parsed rule set (current sing-box format with snake_case keys),
 // then falls back to scanning the raw file for legacy camelCase keys.
-// It is safe to call from CGo callback stacks.
 func (s *SplitTunnel) EnabledAppsJSON() (string, error) {
 	seen := map[string]struct{}{}
 	out := make([]string, 0, 16)

--- a/vpn/split_tunnel.go
+++ b/vpn/split_tunnel.go
@@ -121,22 +121,19 @@ func (s *SplitTunnel) Filters() Filter {
 }
 
 // ItemsJSON returns the items for the given filter type as a JSON-encoded []string.
-// It is safe to call from CGo callback stacks (uses RunOffCgoStack internally).
 func (s *SplitTunnel) ItemsJSON(filterType string) (string, error) {
-	return common.RunOffCgoStack(func() (string, error) {
-		items, err := s.Filters().Items(filterType)
-		if err != nil {
-			return "", err
-		}
-		if items == nil {
-			items = []string{}
-		}
-		b, err := json.Marshal(items)
-		if err != nil {
-			return "", err
-		}
-		return string(b), nil
-	})
+	items, err := s.Filters().Items(filterType)
+	if err != nil {
+		return "", err
+	}
+	if items == nil {
+		items = []string{}
+	}
+	b, err := json.Marshal(items)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
 }
 
 // EnabledAppsJSON returns all enabled app/process identifiers from the split
@@ -145,68 +142,66 @@ func (s *SplitTunnel) ItemsJSON(filterType string) (string, error) {
 // then falls back to scanning the raw file for legacy camelCase keys.
 // It is safe to call from CGo callback stacks.
 func (s *SplitTunnel) EnabledAppsJSON() (string, error) {
-	return common.RunOffCgoStack(func() (string, error) {
-		seen := map[string]struct{}{}
-		out := make([]string, 0, 16)
-		isWindows := common.IsWindows()
+	seen := map[string]struct{}{}
+	out := make([]string, 0, 16)
+	isWindows := common.IsWindows()
 
-		addString := func(str string) {
-			str = strings.TrimSpace(str)
-			if str == "" {
-				return
-			}
-			key := str
-			if isWindows {
-				key = strings.ToLower(str)
-			}
-			if _, exists := seen[key]; exists {
-				return
-			}
-			seen[key] = struct{}{}
-			out = append(out, str)
+	addString := func(str string) {
+		str = strings.TrimSpace(str)
+		if str == "" {
+			return
 		}
-
-		addSlice := func(items []string) {
-			for _, str := range items {
-				addString(str)
-			}
+		key := str
+		if isWindows {
+			key = strings.ToLower(str)
 		}
+		if _, exists := seen[key]; exists {
+			return
+		}
+		seen[key] = struct{}{}
+		out = append(out, str)
+	}
 
-		// Extract from the parsed rule set (current format).
-		f := s.Filters()
-		addSlice(f.ProcessPath)
-		addSlice(f.ProcessPathRegex)
-		addSlice(f.ProcessName)
-		addSlice(f.PackageName)
+	addSlice := func(items []string) {
+		for _, str := range items {
+			addString(str)
+		}
+	}
 
-		// Fall back to legacy camelCase top-level keys in the raw file.
-		b, err := atomicfile.ReadFile(s.ruleFile)
-		if err == nil && len(b) > 0 {
-			m, parseErr := singjson.UnmarshalExtended[map[string]any](b)
-			if parseErr == nil {
-				legacyKeys := []string{
-					"processPathRegex", "processPath", "packageName",
+	// Extract from the parsed rule set (current format).
+	f := s.Filters()
+	addSlice(f.ProcessPath)
+	addSlice(f.ProcessPathRegex)
+	addSlice(f.ProcessName)
+	addSlice(f.PackageName)
+
+	// Fall back to legacy camelCase top-level keys in the raw file.
+	b, err := atomicfile.ReadFile(s.ruleFile)
+	if err == nil && len(b) > 0 {
+		m, parseErr := singjson.UnmarshalExtended[map[string]any](b)
+		if parseErr == nil {
+			legacyKeys := []string{
+				"processPathRegex", "processPath", "packageName",
+			}
+			for _, k := range legacyKeys {
+				arr, ok := m[k].([]any)
+				if !ok {
+					continue
 				}
-				for _, k := range legacyKeys {
-					arr, ok := m[k].([]any)
-					if !ok {
-						continue
-					}
-					for _, it := range arr {
-						if str, ok := it.(string); ok {
-							addString(str)
-						}
+				for _, it := range arr {
+					if str, ok := it.(string); ok {
+						addString(str)
 					}
 				}
 			}
 		}
+	}
 
-		encoded, err := json.Marshal(out)
-		if err != nil {
-			return "", err
-		}
-		return string(encoded), nil
-	})
+	encoded, err := json.Marshal(out)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
 }
 
 // AddItem adds a new item to the filter of the given type.


### PR DESCRIPTION
## Summary
Remove 10 `RunOffCgoStack` wrappers from radiance that are now redundant — CGo stack safety is handled at the boundary layer in lantern (lantern#8635).

## Context
Previously, radiance wrapped pointer-allocating functions with `RunOffCgoStack` as defense-in-depth against CGo write barrier panics. With lantern#8635, ALL 124 CGo exports (70 gomobile + 54 FFI) are now wrapped at the boundary layer:
- `mobile.go`: `withCore`/`withCoreR` → `RunOffCgoStack`
- `ffi.go`: every export → `runOnGoStack`

The radiance-level wrappers are now redundant (double goroutine hop per call).

## Removed from

| File | Functions | Count |
|------|-----------|-------|
| api/user.go | UserData, FetchUserData, Login, Logout, DeleteAccount, OAuthLoginCallback | 6 |
| servers/manager.go | ServersJSON, GetServerByTagJSON | 2 |
| vpn/split_tunnel.go | ItemsJSON, EnabledAppsJSON | 2 |

Also cleaned up stale CGo-safety doc comments.

## Merge order
**Merge lantern#8635 first**, then this PR. If this merges before lantern#8635, the FFI path will lose protection for the 7 functions that were only covered by radiance wrappers.

## Test plan
- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] Build lantern with updated radiance — verify no CGo crashes on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)