### PR TITLE
fix: don't fail outbound removal when tag isn't in URL test group

### DIFF
--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -417,19 +417,25 @@ func (t *tunnel) removeOutbounds(group string, tags []string) error {
 			}
 		}
 		err := mutGrpMgr.RemoveFromGroup(group, tag)
-		if err == nil {
-			// remove from urltest
-			err = mutGrpMgr.RemoveFromGroup(autoTag, tag)
-		}
 		if errors.Is(err, groups.ErrIsClosed) {
 			return errLibboxClosed
 		}
 		if err != nil {
 			errs = append(errs, err)
-		} else {
-			t.optsMap.Delete(tag)
-			removed++
+			continue
 		}
+		// Best-effort removal from URL test group — extra outbounds
+		// (non-smart) are only in the selector, not the URL test group,
+		// so this removal is expected to fail for them.
+		if utErr := mutGrpMgr.RemoveFromGroup(autoTag, tag); utErr != nil {
+			if errors.Is(utErr, groups.ErrIsClosed) {
+				return errLibboxClosed
+			}
+			slog.Debug("Outbound not in URL test group, skipping removal",
+				"tag", tag, "group", autoTag)
+		}
+		t.optsMap.Delete(tag)
+		removed++
 	}
 	if t.clientContextTracker != nil {
 		t.updateClientContextTracker()

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -432,7 +432,7 @@ func (t *tunnel) removeOutbounds(group string, tags []string) error {
 				return errLibboxClosed
 			}
 			slog.Debug("Failed best-effort removal from URL test group",
-				"tag", tag, "group", autoTag, "err", utErr)
+				"tag", tag, "group", autoTag, "error", utErr)
 		}
 		t.optsMap.Delete(tag)
 		removed++

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -431,8 +431,8 @@ func (t *tunnel) removeOutbounds(group string, tags []string) error {
 			if errors.Is(utErr, groups.ErrIsClosed) {
 				return errLibboxClosed
 			}
-			slog.Debug("Outbound not in URL test group, skipping removal",
-				"tag", tag, "group", autoTag)
+			slog.Debug("Failed best-effort removal from URL test group",
+				"tag", tag, "group", autoTag, "err", utErr)
 		}
 		t.optsMap.Delete(tag)
 		removed++


### PR DESCRIPTION
## Summary
Extra outbounds (non-smart Pro locations) are only in the selector group, not the URL test group. When `removeOutbounds` tried to remove them from `auto-lantern`, it failed because they were never there. This error propagated up to `updateOutbounds`, causing the entire config refresh IPC to return 500.

## Impact
Every config refresh failed silently on the client. `SetURLOverrides` and `CheckOutbounds` never ran for new callback URLs. Only the initial `preTest` (before tunnel start) fired callbacks. After that, ~50% of bandit probes expired without callbacks.

## Fix
Treat removal from the URL test group as best-effort. Log actual error at debug level and continue. The selector removal still errors normally.

## Test plan
- [ ] Run client with VPN on, check local logs for absence of "Failed to forward event" errors
- [ ] Dashboard should show ~100% callback success rate after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)