### PR TITLE
feat: remove URL test filtering — all outbounds tested

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/getlantern/fronted v0.0.0-20260325003030-cb5041ba1538
 	github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae
 	github.com/getlantern/kindling v0.0.0-20260329144042-b1825b9cb1bb
-	github.com/getlantern/lantern-box v0.0.61
+	github.com/getlantern/lantern-box v0.0.62
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae h1:NMq3K7h3
 github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260329144042-b1825b9cb1bb h1:A92dC/E/HvkEb1r4tAwCFNlcMsGdqKe5GMmxeUFid9M=
 github.com/getlantern/kindling v0.0.0-20260329144042-b1825b9cb1bb/go.mod h1:c5cFjpNrqX8wQ0PUE2blHrO7knAlRCVx3j1/G6zaVlY=
-github.com/getlantern/lantern-box v0.0.61 h1:TGkzFfikBdLV+VZWZxmNCB8Nr9R2/f5AIGh7Bb65S4g=
-github.com/getlantern/lantern-box v0.0.61/go.mod h1:n5NzI/rqr1USYIQPnEy3oZBYNPDyi8EODXNg8jPsQqY=
+github.com/getlantern/lantern-box v0.0.62 h1:cDijB6Y2dyRa4En8rTIHnj5M07oUDfccrzqKXG3r+F8=
+github.com/getlantern/lantern-box v0.0.62/go.mod h1:n5NzI/rqr1USYIQPnEy3oZBYNPDyi8EODXNg8jPsQqY=
 github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90 h1:P9JX1yAu2uq3b5YiT0sLtHkTrkZuttV8gPZh81nUuag=
 github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90/go.mod h1:3JpJgwi4KEI6rS9loOAvcBp+F2jP65d0tTg2GQcTPBU=
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 h1:3BwvWj0JZzFEvNNiMhCu4bf60nqcIuQpTYb00Ezm1ag=

--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -480,7 +480,7 @@ func useIfNotZero[T comparable](newVal, oldVal T) T {
 
 func appendGroupOutbounds(opts *O.Options, serverGroup, autoTag string, tags []string, urlOverrides map[string]string) {
 	// All outbounds go in the URL test group — the server now sends callback
-	// URLs for every outbound, and the worker pool (N=6) bounds memory.
+	// URLs for every outbound, and the dependency's worker pool bounds memory.
 	opts.Outbounds = append(opts.Outbounds, urlTestOutbound(autoTag, tags, urlOverrides))
 	opts.Outbounds = append(opts.Outbounds, selectorOutbound(serverGroup, append([]string{autoTag}, tags...)))
 	slog.Log(

--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -479,8 +479,9 @@ func useIfNotZero[T comparable](newVal, oldVal T) T {
 }
 
 func appendGroupOutbounds(opts *O.Options, serverGroup, autoTag string, tags []string, urlOverrides map[string]string) {
-	urlTestTags := filterURLTestTags(tags, urlOverrides, serverGroup)
-	opts.Outbounds = append(opts.Outbounds, urlTestOutbound(autoTag, urlTestTags, urlOverrides))
+	// All outbounds go in the URL test group — the server now sends callback
+	// URLs for every outbound, and the worker pool (N=6) bounds memory.
+	opts.Outbounds = append(opts.Outbounds, urlTestOutbound(autoTag, tags, urlOverrides))
 	opts.Outbounds = append(opts.Outbounds, selectorOutbound(serverGroup, append([]string{autoTag}, tags...)))
 	slog.Log(
 		nil, internal.LevelTrace, "Added group outbounds",
@@ -637,23 +638,3 @@ func newDNSServerOptions(typ, tag, server, domainResolver string) O.DNSServerOpt
 	}
 }
 
-// filterURLTestTags returns only the tags that have URL overrides when overrides
-// are present. If no overrides exist or none match, returns all tags unchanged.
-// The context parameter is used for log attribution.
-func filterURLTestTags(tags []string, urlOverrides map[string]string, context string) []string {
-	if len(urlOverrides) == 0 {
-		return tags
-	}
-	filtered := make([]string, 0, len(urlOverrides))
-	for _, tag := range tags {
-		if _, ok := urlOverrides[tag]; ok {
-			filtered = append(filtered, tag)
-		}
-	}
-	if len(filtered) > 0 {
-		return filtered
-	}
-	slog.Warn("No URL-test tags matched URL overrides, falling back to all tags",
-		"context", context, "tagCount", len(tags), "overrideCount", len(urlOverrides))
-	return tags
-}

--- a/vpn/boxoptions_test.go
+++ b/vpn/boxoptions_test.go
@@ -379,28 +379,3 @@ func TestKernelBelow(t *testing.T) {
 	}
 }
 
-func TestFilterURLTestTags(t *testing.T) {
-	allTags := []string{"a", "b", "c", "d", "e"}
-
-	t.Run("no overrides returns all tags", func(t *testing.T) {
-		result := filterURLTestTags(allTags, nil, "test")
-		assert.Equal(t, allTags, result)
-	})
-
-	t.Run("empty overrides returns all tags", func(t *testing.T) {
-		result := filterURLTestTags(allTags, map[string]string{}, "test")
-		assert.Equal(t, allTags, result)
-	})
-
-	t.Run("overrides with matches filters to matched tags", func(t *testing.T) {
-		overrides := map[string]string{"b": "url1", "d": "url2"}
-		result := filterURLTestTags(allTags, overrides, "test")
-		assert.Equal(t, []string{"b", "d"}, result)
-	})
-
-	t.Run("overrides with no matches falls back to all tags", func(t *testing.T) {
-		overrides := map[string]string{"x": "url1", "y": "url2"}
-		result := filterURLTestTags(allTags, overrides, "test")
-		assert.Equal(t, allTags, result)
-	})
-}

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -294,41 +294,16 @@ func (t *tunnel) addOutbounds(group string, options servers.Options) (err error)
 		autoTag   = groupAutoTag(group)
 		added     = 0
 	)
-	// Determine whether to selectively URL-test only overridden outbounds.
-	// When overrides exist and at least one matches a new tag, only add
-	// matching outbounds to the URL test group. Otherwise test all.
-	selectiveURLTest := false
-	if len(options.URLOverrides) > 0 {
-		for _, ob := range newOptions.Outbounds {
-			if _, ok := options.URLOverrides[ob.Tag]; ok {
-				selectiveURLTest = true
-				break
-			}
-		}
-		if !selectiveURLTest {
-			for _, ep := range newOptions.Endpoints {
-				if _, ok := options.URLOverrides[ep.Tag]; ok {
-					selectiveURLTest = true
-					break
-				}
-			}
-		}
-	}
-
-	// for each outbound/endpoint in new add to group
+	// for each outbound/endpoint in new add to group.
+	// All outbounds go in the URL test group — the server now sends callback
+	// URLs for every outbound, and the worker pool (N=6) bounds memory.
 	for _, outbound := range newOptions.Outbounds {
 		logger := t.logFactory.NewLogger("outbound/" + outbound.Tag + "[" + outbound.Type + "]")
 		err := mutGrpMgr.CreateOutboundForGroup(
 			ctx, router, logger, group, outbound.Tag, outbound.Type, outbound.Options,
 		)
 		if err == nil {
-			// Only add to URL test group if this outbound has a bandit callback
-			// URL override (or if no applicable overrides exist). Extra outbounds
-			// (Pro user non-smart locations) are available for manual selection
-			// but not URL-tested, avoiding OOM on Android.
-			if _, hasOverride := options.URLOverrides[outbound.Tag]; hasOverride || !selectiveURLTest {
-				err = mutGrpMgr.AddToGroup(autoTag, outbound.Tag)
-			}
+			err = mutGrpMgr.AddToGroup(autoTag, outbound.Tag)
 		}
 		if errors.Is(err, groups.ErrIsClosed) {
 			return errLibboxClosed
@@ -358,9 +333,7 @@ func (t *tunnel) addOutbounds(group string, options servers.Options) (err error)
 			ctx, router, logger, group, endpoint.Tag, endpoint.Type, endpoint.Options,
 		)
 		if err == nil {
-			if _, hasOverride := options.URLOverrides[endpoint.Tag]; hasOverride || !selectiveURLTest {
-				err = mutGrpMgr.AddToGroup(autoTag, endpoint.Tag)
-			}
+			err = mutGrpMgr.AddToGroup(autoTag, endpoint.Tag)
 		}
 		if errors.Is(err, groups.ErrIsClosed) {
 			return errLibboxClosed

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -296,7 +296,7 @@ func (t *tunnel) addOutbounds(group string, options servers.Options) (err error)
 	)
 	// for each outbound/endpoint in new add to group.
 	// All outbounds go in the URL test group — the server now sends callback
-	// URLs for every outbound, and the worker pool (N=6) bounds memory.
+	// URLs for every outbound, and the bounded worker pool helps limit memory usage.
 	for _, outbound := range newOptions.Outbounds {
 		logger := t.logFactory.NewLogger("outbound/" + outbound.Tag + "[" + outbound.Type + "]")
 		err := mutGrpMgr.CreateOutboundForGroup(

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -527,8 +527,8 @@ func preTest(path string) (map[string]uint16, context.Context, bool, error) {
 	for _, ob := range outbounds {
 		tags = append(tags, ob.Tag)
 	}
-	// All outbounds get URL-tested — the server now sends callback URLs for
-	// every outbound, and the worker pool (N=6) bounds memory.
+	// All outbounds get URL-tested — the server now sends callback
+	// URLs for every outbound, and the dependency's worker pool bounds memory.
 	outbounds = append(outbounds, urlTestOutbound("preTest", tags, cfg.BanditURLOverrides))
 	options := option.Options{
 		Log:       &option.LogOptions{Disabled: true},

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -527,12 +527,9 @@ func preTest(path string) (map[string]uint16, context.Context, bool, error) {
 	for _, ob := range outbounds {
 		tags = append(tags, ob.Tag)
 	}
-	// When bandit URL overrides exist, only URL-test the smart outbounds
-	// (those with callback URLs). Extra outbounds remain in the sing-box
-	// instance so we can dial through them, but testing all ~36 wastes
-	// time and delays callbacks past the 30s probe expiry window.
-	urlTestTags := filterURLTestTags(tags, cfg.BanditURLOverrides, "preTest")
-	outbounds = append(outbounds, urlTestOutbound("preTest", urlTestTags, cfg.BanditURLOverrides))
+	// All outbounds get URL-tested — the server now sends callback URLs for
+	// every outbound, and the worker pool (N=6) bounds memory.
+	outbounds = append(outbounds, urlTestOutbound("preTest", tags, cfg.BanditURLOverrides))
 	options := option.Options{
 		Log:       &option.LogOptions{Disabled: true},
 		Outbounds: outbounds,


### PR DESCRIPTION
## Summary
Removes the selective URL test logic. All outbounds now go in the URL test group — the server sends callback URLs for everything, and the worker pool (N=6) bounds memory.

## What's removed
- \`filterURLTestTags\` function and test
- \`selectiveURLTest\` flag in \`addOutbounds\`
- preTest tag filtering

## Dependencies
- Server: lantern-cloud PR #2550 (callbacks for all outbounds)
- lantern-box PR #232 (6-worker pool + client delay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)