### PR TITLE
fix: process IPC outbound updates asynchronously

### DIFF
--- a/vpn/ipc/http.go
+++ b/vpn/ipc/http.go
@@ -56,7 +56,7 @@ func sendRequest[T any](ctx context.Context, method, endpoint string, data any) 
 		return res, traces.RecordError(ctx, fmt.Errorf("request failed: %w", err))
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
 		return res, traces.RecordError(ctx, readErrorResponse(resp))
 	}
 	if _, ok := any(&res).(*empty); ok {

--- a/vpn/ipc/outbound.go
+++ b/vpn/ipc/outbound.go
@@ -205,11 +205,17 @@ func (s *Server) updateOutboundsHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	slog.Debug("Updating outbounds")
-	if err := s.service.UpdateOutbounds(data); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusAccepted)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("panic in UpdateOutbounds", "recover", r, "stack", string(runtimeDebug.Stack()))
+			}
+		}()
+		if err := s.service.UpdateOutbounds(data); err != nil {
+			slog.Error("Failed to update outbounds", "error", err)
+		}
+	}()
 }
 
 type newOutbounds struct {
@@ -238,11 +244,17 @@ func (s *Server) addOutboundsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	slog.Debug("Adding outbounds", "group", data.Group)
-	if err := s.service.AddOutbounds(data.Group, data.Servers); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusAccepted)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("panic in AddOutbounds", "recover", r, "stack", string(runtimeDebug.Stack()))
+			}
+		}()
+		if err := s.service.AddOutbounds(data.Group, data.Servers); err != nil {
+			slog.Error("Failed to add outbounds", "error", err)
+		}
+	}()
 }
 
 type outboundsToRemove struct {
@@ -265,9 +277,15 @@ func (s *Server) removeOutboundsHandler(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if err := s.service.RemoveOutbounds(data.Group, data.Tags); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusAccepted)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("panic in RemoveOutbounds", "recover", r, "stack", string(runtimeDebug.Stack()))
+			}
+		}()
+		if err := s.service.RemoveOutbounds(data.Group, data.Tags); err != nil {
+			slog.Error("Failed to remove outbounds", "error", err)
+		}
+	}()
 }


### PR DESCRIPTION
## Summary

Process IPC outbound update/add/remove requests asynchronously. The handlers return `202 Accepted` immediately and process outbound changes in a background goroutine with panic recovery.

### Problem

Every config refresh (~3 min), `updateOutboundsHandler` processes 30+ outbounds (~12s). The IPC HTTP server has a 5s `WriteTimeout`. The server kills the connection after 5s, the handler keeps running (outbounds update successfully), but the client gets EOF.

### Fix

- Handlers return `202 Accepted` after validating the request body, then process asynchronously
- Background goroutines include panic recovery (for the intentional panic at `tunnel.go:455`)
- Client accepts both `200 OK` and `202 Accepted`

## Test plan
- [ ] Verify `Failed to forward event to tunnel` EOF errors stop
- [ ] Verify outbounds still update correctly on config refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)