### PR TITLE
Persist server location 

### DIFF
--- a/common/settings/settings.go
+++ b/common/settings/settings.go
@@ -38,6 +38,11 @@ const (
 	LoginResponseKey = "login_response"
 	SmartRoutingKey  = "smart_routing"
 	AdBlockKey       = "ad_block"
+	// SelectedServerGroupKey / SelectedServerTagKey persist the user's last
+	// server selection so it survives Android's async tunnel-restart lifecycle
+	// (the new libbox is created without any in-memory selector state).
+	SelectedServerGroupKey = "selected_server_group"
+	SelectedServerTagKey   = "selected_server_tag"
 	DataCapUsageKey  = "datacap_usage"
 	filePathKey      = "file_path"
 

--- a/common/settings/settings.go
+++ b/common/settings/settings.go
@@ -36,14 +36,9 @@ const (
 	DevicesKey       = "devices"
 	LogLevelKey      = "log_level"
 	LoginResponseKey = "login_response"
-	SmartRoutingKey  = "smart_routing"
-	AdBlockKey       = "ad_block"
-	// SelectedServerGroupKey / SelectedServerTagKey persist the user's last
-	// server selection so it survives Android's async tunnel-restart lifecycle
-	// (the new libbox is created without any in-memory selector state).
-	SelectedServerGroupKey = "selected_server_group"
-	SelectedServerTagKey   = "selected_server_tag"
-	DataCapUsageKey  = "datacap_usage"
+	SmartRoutingKey = "smart_routing"
+	AdBlockKey      = "ad_block"
+	DataCapUsageKey = "datacap_usage"
 	filePathKey      = "file_path"
 
 	settingsFileName = "local.json"

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -199,12 +199,7 @@ func Disconnect() error {
 	return traces.RecordError(ctx, ipc.StopService(ctx))
 }
 
-// SelectServer selects the specified server for the tunnel. The tunnel must already be open.
-//
-// The selection is also persisted to settings so that vpn_tunnel.StartVPN can
-// restore it when Android's VPN service lifecycle creates a fresh libbox. The
-// in-memory selector state on the running libbox doesn't survive the OS-driven
-// teardown/start cycle.
+// SelectServer selects the specified server for the tunnel.
 func SelectServer(ctx context.Context, group, tag string) error {
 	if !isOpen(ctx) {
 		return errors.New("tunnel is not open")

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -157,45 +157,20 @@ func connect(group, tag string) error {
 
 // Restart restarts the tunnel by reconnecting to the currently selected server.
 //
-// The selected server is captured before the underlying libbox service is torn
-// down and re-applied after it comes back up. The rebuilt selector always
-// initializes to auto, so without this restore step the user's selection would
-// silently be lost on every restart (e.g. when toggling smart-routing or
-// ad-blocking while connected).
+// On Android, the platform interface restart is asynchronous and tears down the
+// running libbox in favor of a fresh one. Any in-process selection restore here
+// would land on the soon-to-be-destroyed instance and be lost. The user's
+// selection is preserved by SelectServer persisting (group, tag) to settings,
+// which vpn_tunnel.StartVPN reads when bringing the new libbox up.
 func Restart() error {
 	ctx, span := otel.Tracer(tracerName).Start(context.Background(), "restart")
 	defer span.End()
-
-	var selectedGroup, selectedTag string
-	if isOpen(ctx) {
-		slog.Debug("Tunnel is open get connected server")
-		g, t, err := ipc.GetSelected(ctx)
-		slog.Debug("Got connected server", "group", g, "tag", t, "error", err)
-		if err != nil {
-			slog.Warn("Failed to capture selected server before restart", "error", err)
-		} else {
-			selectedGroup, selectedTag = g, t
-		}
-	}
 
 	options, err := getOptions()
 	if err != nil {
 		return err
 	}
-	if err := traces.RecordError(ctx, ipc.RestartService(ctx, options)); err != nil {
-		return err
-	}
-
-	// Skip restoring auto: the rebuilt tunnel already defaults to auto.
-	if selectedGroup == "" || selectedGroup == autoAllTag {
-		return nil
-	}
-	slog.Debug("Restoring selected server after restart", "group", selectedGroup, "tag", selectedTag)
-	if err := Connect(selectedGroup, selectedTag); err != nil {
-		slog.Warn("Failed to restore selected server after restart",
-			"group", selectedGroup, "tag", selectedTag, "error", err)
-	}
-	return nil
+	return traces.RecordError(ctx, ipc.RestartService(ctx, options))
 }
 
 func getOptions() (string, error) {
@@ -230,6 +205,11 @@ func Disconnect() error {
 }
 
 // SelectServer selects the specified server for the tunnel. The tunnel must already be open.
+//
+// The selection is also persisted to settings so that vpn_tunnel.StartVPN can
+// restore it when Android's VPN service lifecycle creates a fresh libbox. The
+// in-memory selector state on the running libbox doesn't survive the OS-driven
+// teardown/start cycle.
 func SelectServer(ctx context.Context, group, tag string) error {
 	if !isOpen(ctx) {
 		return errors.New("tunnel is not open")
@@ -240,6 +220,7 @@ func SelectServer(ctx context.Context, group, tag string) error {
 			slog.Error("Failed to set auto mode", "group", group, "error", err)
 			return fmt.Errorf("failed to set auto mode: %w", err)
 		}
+		persistSelection("", "")
 		return nil
 	}
 	slog.Info("Selecting server", "group", group, "tag", tag)
@@ -247,7 +228,29 @@ func SelectServer(ctx context.Context, group, tag string) error {
 		slog.Error("Failed to select server", "group", group, "tag", tag, "error", err)
 		return fmt.Errorf("failed to select server %s/%s: %w", group, tag, err)
 	}
+	persistSelection(group, tag)
 	return nil
+}
+
+// persistSelection writes the current server selection to settings so it can
+// outlive the libbox instance. Errors are logged but don't fail the caller —
+// the selection still took effect on the live tunnel.
+func persistSelection(group, tag string) {
+	if err := settings.Set(settings.SelectedServerGroupKey, group); err != nil {
+		slog.Warn("Failed to persist selected server group", "error", err)
+	}
+	if err := settings.Set(settings.SelectedServerTagKey, tag); err != nil {
+		slog.Warn("Failed to persist selected server tag", "error", err)
+	}
+}
+
+// LastSelectedServer returns the most recently persisted server selection, or
+// empty strings if the user is on auto / has never selected a server. Used by
+// vpn_tunnel.StartVPN to bring up new libbox instances pinned to the user's
+// choice instead of falling back to auto.
+func LastSelectedServer() (group, tag string) {
+	return settings.GetString(settings.SelectedServerGroupKey),
+		settings.GetString(settings.SelectedServerTagKey)
 }
 
 // Status represents the current status of the tunnel, including whether it is open, the selected

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -156,15 +156,46 @@ func connect(group, tag string) error {
 }
 
 // Restart restarts the tunnel by reconnecting to the currently selected server.
+//
+// The selected server is captured before the underlying libbox service is torn
+// down and re-applied after it comes back up. The rebuilt selector always
+// initializes to auto, so without this restore step the user's selection would
+// silently be lost on every restart (e.g. when toggling smart-routing or
+// ad-blocking while connected).
 func Restart() error {
 	ctx, span := otel.Tracer(tracerName).Start(context.Background(), "restart")
 	defer span.End()
+
+	var selectedGroup, selectedTag string
+	if isOpen(ctx) {
+		slog.Debug("Tunnel is open get connected server")
+		g, t, err := ipc.GetSelected(ctx)
+		slog.Debug("Got connected server", "group", g, "tag", t, "error", err)
+		if err != nil {
+			slog.Warn("Failed to capture selected server before restart", "error", err)
+		} else {
+			selectedGroup, selectedTag = g, t
+		}
+	}
 
 	options, err := getOptions()
 	if err != nil {
 		return err
 	}
-	return traces.RecordError(ctx, ipc.RestartService(ctx, options))
+	if err := traces.RecordError(ctx, ipc.RestartService(ctx, options)); err != nil {
+		return err
+	}
+
+	// Skip restoring auto: the rebuilt tunnel already defaults to auto.
+	if selectedGroup == "" || selectedGroup == autoAllTag {
+		return nil
+	}
+	slog.Debug("Restoring selected server after restart", "group", selectedGroup, "tag", selectedTag)
+	if err := Connect(selectedGroup, selectedTag); err != nil {
+		slog.Warn("Failed to restore selected server after restart",
+			"group", selectedGroup, "tag", selectedTag, "error", err)
+	}
+	return nil
 }
 
 func getOptions() (string, error) {
@@ -368,8 +399,8 @@ func AutoServerSelections() (AutoSelections, error) {
 }
 
 const (
-	rapidPollInterval = 500 * time.Millisecond
-	rapidPollWindow   = 15 * time.Second
+	rapidPollInterval  = 500 * time.Millisecond
+	rapidPollWindow    = 15 * time.Second
 	steadyPollInterval = 10 * time.Second
 )
 
@@ -577,7 +608,6 @@ func preTest(path string) (map[string]uint16, context.Context, bool, error) {
 	return results, traceCtx, hasTrace, nil
 }
 
-
 func saveURLTestResults(storage *urltest.HistoryStorage, path string, results map[string]uint16) error {
 	slog.Debug("Saving URL test history", "path", path)
 	history := make(map[string]*adapter.URLTestHistory, len(results))
@@ -647,11 +677,7 @@ func restartTunnel() error {
 		return nil
 	}
 	slog.Info("Restarting tunnel")
-	options, err := getOptions()
-	if err != nil {
-		return err
-	}
-	if err := ipc.RestartService(ctx, options); err != nil {
+	if err := Restart(); err != nil {
 		return fmt.Errorf("failed to restart tunnel: %w", err)
 	}
 	return nil

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -155,13 +155,7 @@ func connect(group, tag string) error {
 	return SelectServer(ctx, group, tag)
 }
 
-// Restart restarts the tunnel by reconnecting to the currently selected server.
-//
-// On Android, the platform interface restart is asynchronous and tears down the
-// running libbox in favor of a fresh one. Any in-process selection restore here
-// would land on the soon-to-be-destroyed instance and be lost. The user's
-// selection is preserved by SelectServer persisting (group, tag) to settings,
-// which vpn_tunnel.StartVPN reads when bringing the new libbox up.
+// Restart restarts the tunnel by stopping and starting the service.
 func Restart() error {
 	ctx, span := otel.Tracer(tracerName).Start(context.Background(), "restart")
 	defer span.End()

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -103,6 +103,7 @@ func AutoConnect(group string) error {
 			if err := ipc.SetClashMode(ctx, autoAllTag); err != nil {
 				return fmt.Errorf("failed to set auto mode: %w", err)
 			}
+			persistSelection("", "")
 			return nil
 		}
 		return traces.RecordError(ctx, connect(autoAllTag, ""))
@@ -226,25 +227,59 @@ func SelectServer(ctx context.Context, group, tag string) error {
 	return nil
 }
 
-// persistSelection writes the current server selection to settings so it can
-// outlive the libbox instance. Errors are logged but don't fail the caller —
-// the selection still took effect on the live tunnel.
+const selectedServerFileName = "selected_server.json"
+
+type selectedServer struct {
+	Group string `json:"group"`
+	Tag   string `json:"tag"`
+}
+
+// persistSelection saves the server selection to a file (not settings, which is read-only
+// in the tunnel process). Errors are logged but not propagated.
 func persistSelection(group, tag string) {
-	if err := settings.Set(settings.SelectedServerGroupKey, group); err != nil {
-		slog.Warn("Failed to persist selected server group", "error", err)
+	dataPath := settings.GetString(settings.DataPathKey)
+	if dataPath == "" {
+		slog.Warn("Cannot persist server selection: data path not set")
+		return
 	}
-	if err := settings.Set(settings.SelectedServerTagKey, tag); err != nil {
-		slog.Warn("Failed to persist selected server tag", "error", err)
+	filePath := filepath.Join(dataPath, selectedServerFileName)
+	data, err := json.Marshal(selectedServer{Group: group, Tag: tag})
+	if err != nil {
+		slog.Warn("Failed to marshal server selection", "error", err)
+		return
+	}
+	if err := atomicfile.WriteFile(filePath, data, 0o644); err != nil {
+		slog.Warn("Failed to persist server selection", "error", err)
 	}
 }
 
-// LastSelectedServer returns the most recently persisted server selection, or
-// empty strings if the user is on auto / has never selected a server. Used by
-// vpn_tunnel.StartVPN to bring up new libbox instances pinned to the user's
-// choice instead of falling back to auto.
+// ClearLastSelectedServer removes the persisted server selection so the next
+// StartVPN falls through to AutoConnect.
+func ClearLastSelectedServer() {
+	persistSelection("", "")
+}
+
+// LastSelectedServer returns the persisted server selection, or empty strings
+// if on auto or no selection was ever saved.
 func LastSelectedServer() (group, tag string) {
-	return settings.GetString(settings.SelectedServerGroupKey),
-		settings.GetString(settings.SelectedServerTagKey)
+	dataPath := settings.GetString(settings.DataPathKey)
+	if dataPath == "" {
+		return "", ""
+	}
+	filePath := filepath.Join(dataPath, selectedServerFileName)
+	data, err := atomicfile.ReadFile(filePath)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			slog.Warn("Failed to read persisted server selection", "error", err)
+		}
+		return "", ""
+	}
+	var sel selectedServer
+	if err := json.Unmarshal(data, &sel); err != nil {
+		slog.Warn("Failed to unmarshal persisted server selection", "error", err)
+		return "", ""
+	}
+	return sel.Group, sel.Tag
 }
 
 // Status represents the current status of the tunnel, including whether it is open, the selected


### PR DESCRIPTION
This pull request adds persistent storage for the selected VPN server, ensuring that the server choice survives Android VPN service restarts and OS-driven tunnel lifecycle events. It also introduces helper functions to manage this persisted state, updates the `SelectServer` logic to save selections, and refactors tunnel restart logic for clarity.

**Persistent server selection:**
* Added a `persistSelection` function and supporting helpers (`ClearLastSelectedServer`, `LastSelectedServer`) to save and retrieve the selected server to a JSON file in the app's data directory, ensuring the selection can be restored after service restarts.

**Server selection logic:**
* Updated `SelectServer` and `AutoConnect` to call `persistSelection` whenever the server selection changes, so the persisted state always matches the current selection. [[1]](diffhunk://#diff-25828e7146300d37842032752af02678c7c569a51995a9d0314e1ec400cdb94eR106) [[2]](diffhunk://#diff-25828e7146300d37842032752af02678c7c569a51995a9d0314e1ec400cdb94eR218-R284)
* Improved documentation for `SelectServer` to clarify the persistence mechanism and its purpose in the Android VPN lifecycle.

**Tunnel restart logic:**
* Refactored `restartTunnel` to use the new `Restart` function, which now stops and starts the service, improving clarity and reliability.
* Updated the comment for `Restart` to accurately reflect its behavior.

**Other:**
* Minor cleanup in unrelated function (`preTest`), removing an unnecessary blank line.