### PR TITLE
bump lantern-box to v0.0.65

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/getlantern/fronted v0.0.0-20260325003030-cb5041ba1538
 	github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae
 	github.com/getlantern/kindling v0.0.0-20260329144042-b1825b9cb1bb
-	github.com/getlantern/lantern-box v0.0.62
+	github.com/getlantern/lantern-box v0.0.65
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb

--- a/go.sum
+++ b/go.sum
@@ -246,6 +246,10 @@ github.com/getlantern/kindling v0.0.0-20260329144042-b1825b9cb1bb h1:A92dC/E/Hvk
 github.com/getlantern/kindling v0.0.0-20260329144042-b1825b9cb1bb/go.mod h1:c5cFjpNrqX8wQ0PUE2blHrO7knAlRCVx3j1/G6zaVlY=
 github.com/getlantern/lantern-box v0.0.62 h1:cDijB6Y2dyRa4En8rTIHnj5M07oUDfccrzqKXG3r+F8=
 github.com/getlantern/lantern-box v0.0.62/go.mod h1:n5NzI/rqr1USYIQPnEy3oZBYNPDyi8EODXNg8jPsQqY=
+github.com/getlantern/lantern-box v0.0.64 h1:W9NyW9TK4ML1Htnk6AeLVTFHJrBMH8DLohNJwO68E98=
+github.com/getlantern/lantern-box v0.0.64/go.mod h1:n5NzI/rqr1USYIQPnEy3oZBYNPDyi8EODXNg8jPsQqY=
+github.com/getlantern/lantern-box v0.0.65 h1:/PvWqm61PvSjlYWTpLhUHwacpLQ6gTQGXB6BCrYAdko=
+github.com/getlantern/lantern-box v0.0.65/go.mod h1:n5NzI/rqr1USYIQPnEy3oZBYNPDyi8EODXNg8jPsQqY=
 github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90 h1:P9JX1yAu2uq3b5YiT0sLtHkTrkZuttV8gPZh81nUuag=
 github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90/go.mod h1:3JpJgwi4KEI6rS9loOAvcBp+F2jP65d0tTg2GQcTPBU=
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 h1:3BwvWj0JZzFEvNNiMhCu4bf60nqcIuQpTYb00Ezm1ag=


### PR DESCRIPTION
## Summary

Bumps \`github.com/getlantern/lantern-box\` from v0.0.62 → v0.0.64.

Pulls in:
- Reflex active-probe resistance via silence-timeout + masquerade-upstream (getlantern/lantern-box#237 / engineering#3166)
- TLS 1.3 minimum for Reflex (getlantern/lantern-box#236)
- Reflex E2E test (getlantern/lantern-box#235)
- Reflex README documentation (getlantern/lantern-box#234)

## Client impact

The silence-timeout is a **server-only** feature. The Reflex client-side \`DialContext\` is unchanged; it just connects TCP and waits to receive the server's ClientHello. Silence + masquerade are enforced by the inbound (server) side.

This bump keeps radiance aligned with the lantern-box version that lantern-cloud is about to roll out (lantern-cloud#2556).

## Testing

- \`go build ./...\` clean
- \`go test ./...\` — only pre-existing VPN test failures related to socket permissions in the test sandbox (\`chown ... operation not permitted\`), same on main without this bump. Unrelated to the dependency change.