### PR TITLE
Store the user ID and token for device limit flow

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -780,15 +780,17 @@ func (a *APIClient) setData(data *protos.LoginResponse) {
 			}
 		}
 
-		devices := []settings.Device{}
-		for _, d := range data.Devices {
-			devices = append(devices, settings.Device{
-				Name: d.Name,
-				ID:   d.Id,
-			})
-		}
-		if err := settings.Set(settings.DevicesKey, devices); err != nil {
-			slog.Error("failed to set devices in settings", "error", err)
+		if data.Devices != nil && len(data.Devices) > 0 {
+			devices := []settings.Device{}
+			for _, d := range data.Devices {
+				devices = append(devices, settings.Device{
+					Name: d.Name,
+					ID:   d.Id,
+				})
+			}
+			if err := settings.Set(settings.DevicesKey, devices); err != nil {
+				slog.Error("failed to set devices in settings", "error", err)
+			}
 		}
 		return
 	}
@@ -830,16 +832,17 @@ func (a *APIClient) setData(data *protos.LoginResponse) {
 			slog.Error("failed to set JWT token in settings", "error", err)
 		}
 	}
-
-	devices := []settings.Device{}
-	for _, d := range data.Devices {
-		devices = append(devices, settings.Device{
-			Name: d.Name,
-			ID:   d.Id,
-		})
-	}
-	if err := settings.Set(settings.DevicesKey, devices); err != nil {
-		slog.Error("failed to set devices in settings", "error", err)
+	if data.Devices != nil && len(data.Devices) > 0 {
+		devices := []settings.Device{}
+		for _, d := range data.Devices {
+			devices = append(devices, settings.Device{
+				Name: d.Name,
+				ID:   d.Id,
+			})
+		}
+		if err := settings.Set(settings.DevicesKey, devices); err != nil {
+			slog.Error("failed to set devices in settings", "error", err)
+		}
 	}
 
 	if err := settings.Set(settings.LoginResponseKey, data); err != nil {

--- a/api/user.go
+++ b/api/user.go
@@ -768,7 +768,7 @@ func (a *APIClient) setData(data *protos.LoginResponse) {
 	}
 	var changed bool
 	if data.LegacyUserData == nil {
-		slog.Info("No legacy user data in response, storing user ID and token only")
+		slog.Info("No legacy user data in response, storing legacy ID and pro token only")
 		if data.LegacyID != 0 {
 			if err := settings.Set(settings.UserIDKey, data.LegacyID); err != nil {
 				slog.Error("failed to set user ID in settings", "error", err)
@@ -778,6 +778,17 @@ func (a *APIClient) setData(data *protos.LoginResponse) {
 			if err := settings.Set(settings.TokenKey, data.LegacyToken); err != nil {
 				slog.Error("failed to set token in settings", "error", err)
 			}
+		}
+
+		devices := []settings.Device{}
+		for _, d := range data.Devices {
+			devices = append(devices, settings.Device{
+				Name: d.Name,
+				ID:   d.Id,
+			})
+		}
+		if err := settings.Set(settings.DevicesKey, devices); err != nil {
+			slog.Error("failed to set devices in settings", "error", err)
 		}
 		return
 	}

--- a/api/user.go
+++ b/api/user.go
@@ -768,7 +768,17 @@ func (a *APIClient) setData(data *protos.LoginResponse) {
 	}
 	var changed bool
 	if data.LegacyUserData == nil {
-		slog.Info("no user data to set")
+		slog.Info("No legacy user data in response, storing user ID and token only")
+		if data.LegacyID != 0 {
+			if err := settings.Set(settings.UserIDKey, data.LegacyID); err != nil {
+				slog.Error("failed to set user ID in settings", "error", err)
+			}
+		}
+		if data.LegacyToken != "" {
+			if err := settings.Set(settings.TokenKey, data.LegacyToken); err != nil {
+				slog.Error("failed to set token in settings", "error", err)
+			}
+		}
 		return
 	}
 

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -312,3 +312,35 @@ func (m *mockAuthClient) LoginPrepare(ctx context.Context, req *protos.PrepareRe
 	m.cache[req.Email] = hex.EncodeToString(state)
 	return &protos.PrepareResponse{B: B.Bytes(), Proof: proof}, nil
 }
+
+func TestSetData_NilLegacyUserData(t *testing.T) {
+	settings.InitSettings(t.TempDir())
+	t.Cleanup(settings.Reset)
+
+	ac := &APIClient{}
+
+	data := &protos.LoginResponse{
+		LegacyID:    12345,
+		LegacyToken: "test-pro-token",
+		Devices: []*protos.LoginResponse_Device{
+			{Id: "device-1", Name: "Phone"},
+			{Id: "device-2", Name: "Laptop"},
+		},
+		// LegacyUserData intentionally nil to simulate device-limit flow
+	}
+
+	ac.setData(data)
+
+	// Verify legacy ID and pro token are persisted
+	assert.Equal(t, int64(12345), settings.GetInt64(settings.UserIDKey))
+	assert.Equal(t, "test-pro-token", settings.GetString(settings.TokenKey))
+
+	// Verify devices are persisted
+	devices, err := settings.Devices()
+	require.NoError(t, err)
+	assert.Len(t, devices, 2)
+	assert.Equal(t, "device-1", devices[0].ID)
+	assert.Equal(t, "Phone", devices[0].Name)
+	assert.Equal(t, "device-2", devices[1].ID)
+	assert.Equal(t, "Laptop", devices[1].Name)
+}


### PR DESCRIPTION
This pull request updates the logic for handling login responses when legacy user data is missing. Now, if `LegacyUserData` is absent, the code will still store the user ID and token in the settings, and log more informative messages.

User data handling improvements:

* When `LegacyUserData` is missing in the login response, the code now attempts to store `LegacyID` and `LegacyToken` in the settings, and logs errors if these operations fail. The log message is also updated to clarify what is being stored.