### PR TITLE
fix: use direct detour for dns_remote to unblock sing-box startup

### DIFF
--- a/vpn/dnsoptions.go
+++ b/vpn/dnsoptions.go
@@ -43,7 +43,12 @@ func buildDNSServers() []option.DNSServerOptions {
 	}
 
 	// quad9 doesn't transmit EDNS Client-Subnet data in order to avoid
-	// transmitting the user IP  address to the remote site.
+	// transmitting the user IP address to the remote site.
+	// Use detour "direct" so that DNS resolution works at sing-box startup
+	// before the proxy URL-test group has a known network interface. A/AAAA
+	// queries for user traffic are routed through dns_fakeip anyway, so
+	// dns_remote is only used for non-A/AAAA lookups and rule-set downloads —
+	// neither of which requires proxying.
 	remote := option.DNSServerOptions{
 		Type: constant.DNSTypeHTTPS,
 		Tag:  "dns_remote",
@@ -57,7 +62,7 @@ func buildDNSServers() []option.DNSServerOptions {
 					},
 					LocalDNSServerOptions: option.LocalDNSServerOptions{
 						DialerOptions: option.DialerOptions{
-							Detour: "auto",
+							Detour: "direct",
 						},
 					},
 				},


### PR DESCRIPTION
## Summary

- `dns_remote` previously used `detour: "auto"` (the URL-test proxy group)
- At sing-box startup, that group has no known network interface yet — so any DNS lookup routed through `dns_remote` (including the synchronous initial rule-set fetch for smart routing) fails with `"no available network interface"`, preventing the VPN from starting and snapping the toggle back to Off
- Switch to `detour: "direct"` so `dns_remote` resolves hostnames before the proxy group is ready

## Why this is safe

- A/AAAA queries for user traffic are intercepted by the `dns_fakeip` rule; actual DNS resolution happens server-side via TUN routing — `dns_remote` is not involved
- `dns_remote` is only used for: (1) non-A/AAAA queries (PTR, MX, etc.), and (2) rule-set/ad-block downloads — neither of which needs to be routed through a proxy

## Test plan

- [ ] On an Android device with smart routing configured, toggle VPN On — it should no longer snap back to Off
- [ ] Confirm `dns_remote` successfully resolves hostnames during sing-box startup (no "no available network interface" errors in logs)

Fixes the client-side root cause identified in Freshdesk ticket #172573 (v9.0.24 beta, Bulgaria).
See also: getlantern/lantern-cloud#2564 (server-side mitigation disabling smart routing until this ships)

🤖 Generated with [Claude Code](https://claude.com/claude-code)