### PR TITLE
chore: bump lantern-box to v0.0.67

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/getlantern/fronted v0.0.0-20260325003030-cb5041ba1538
 	github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae
 	github.com/getlantern/kindling v0.0.0-20260329144042-b1825b9cb1bb
-	github.com/getlantern/lantern-box v0.0.65
+	github.com/getlantern/lantern-box v0.0.67
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb

--- a/go.sum
+++ b/go.sum
@@ -244,12 +244,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae h1:NMq3K7h3
 github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260329144042-b1825b9cb1bb h1:A92dC/E/HvkEb1r4tAwCFNlcMsGdqKe5GMmxeUFid9M=
 github.com/getlantern/kindling v0.0.0-20260329144042-b1825b9cb1bb/go.mod h1:c5cFjpNrqX8wQ0PUE2blHrO7knAlRCVx3j1/G6zaVlY=
-github.com/getlantern/lantern-box v0.0.62 h1:cDijB6Y2dyRa4En8rTIHnj5M07oUDfccrzqKXG3r+F8=
-github.com/getlantern/lantern-box v0.0.62/go.mod h1:n5NzI/rqr1USYIQPnEy3oZBYNPDyi8EODXNg8jPsQqY=
-github.com/getlantern/lantern-box v0.0.64 h1:W9NyW9TK4ML1Htnk6AeLVTFHJrBMH8DLohNJwO68E98=
-github.com/getlantern/lantern-box v0.0.64/go.mod h1:n5NzI/rqr1USYIQPnEy3oZBYNPDyi8EODXNg8jPsQqY=
-github.com/getlantern/lantern-box v0.0.65 h1:/PvWqm61PvSjlYWTpLhUHwacpLQ6gTQGXB6BCrYAdko=
-github.com/getlantern/lantern-box v0.0.65/go.mod h1:n5NzI/rqr1USYIQPnEy3oZBYNPDyi8EODXNg8jPsQqY=
+github.com/getlantern/lantern-box v0.0.67 h1:0uDILTY2fVzy47IoEecsMoeplqdxFU/KE/izaZXwM/Q=
+github.com/getlantern/lantern-box v0.0.67/go.mod h1:n5NzI/rqr1USYIQPnEy3oZBYNPDyi8EODXNg8jPsQqY=
 github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90 h1:P9JX1yAu2uq3b5YiT0sLtHkTrkZuttV8gPZh81nUuag=
 github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90/go.mod h1:3JpJgwi4KEI6rS9loOAvcBp+F2jP65d0tTg2GQcTPBU=
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 h1:3BwvWj0JZzFEvNNiMhCu4bf60nqcIuQpTYb00Ezm1ag=


### PR DESCRIPTION
Bumps lantern-box from v0.0.65 to v0.0.67. Includes go mod tidy to keep go.sum consistent.

Release notes: https://github.com/getlantern/lantern-box/releases/tag/v0.0.67

🤖 Generated with [Claude Code](https://claude.com/claude-code)