### PR TITLE
config: match main's UserID format in ConfigRequest

### DIFF
--- a/config/fetcher.go
+++ b/config/fetcher.go
@@ -78,7 +78,7 @@ func (f *fetcher) fetchConfig(ctx context.Context, preferred common.PreferredLoc
 		Platform:       common.Platform,
 		AppName:        common.Name,
 		DeviceID:       settings.GetString(settings.DeviceIDKey),
-		UserID:         settings.GetString(settings.UserIDKey),
+		UserID:         fmt.Sprintf("%d", settings.GetInt64(settings.UserIDKey)),
 		ProToken:       settings.GetString(settings.TokenKey),
 		WGPublicKey:    wgPublicKey,
 		Backend:        C.SINGBOX,

--- a/config/fetcher_test.go
+++ b/config/fetcher_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -91,10 +92,42 @@ func TestFetchConfig(t *testing.T) {
 			assert.Equal(t, common.Platform, confReq.Platform)
 			assert.Equal(t, common.Name, confReq.AppName)
 			assert.Equal(t, settings.GetString(settings.DeviceIDKey), confReq.DeviceID)
+			assert.Equal(t, "1234567890", confReq.UserID,
+				"UserID must serialize as a base-10 decimal string matching main's format")
 			assert.Equal(t, privateKey.PublicKey().String(), confReq.WGPublicKey)
 			if tt.preferredServerLoc != nil {
 				assert.Equal(t, tt.preferredServerLoc, confReq.PreferredLocation)
 			}
+		})
+	}
+}
+
+// TestUserIDFormatMatchesMain exercises the same expression used in
+// fetchConfig to build ConfigRequest.UserID. It guards the regression
+// fixed in this PR: on main the value is serialized as a base-10
+// decimal string ("0" when unset, "<digits>" when set), and we need
+// refactor to match so server-side strconv.ParseInt doesn't treat an
+// empty string as malformed.
+func TestUserIDFormatMatchesMain(t *testing.T) {
+	cases := []struct {
+		name   string
+		set    bool
+		value  int64
+		expect string
+	}{
+		{name: "unset -> zero", set: false, expect: "0"},
+		{name: "small id", set: true, value: 42, expect: "42"},
+		{name: "large id (exercises float64 JSON round-trip)", set: true, value: 1234567890, expect: "1234567890"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, settings.InitSettings(t.TempDir()))
+			settings.Clear(settings.UserIDKey)
+			if tc.set {
+				require.NoError(t, settings.Set(settings.UserIDKey, tc.value))
+			}
+			got := fmt.Sprintf("%d", settings.GetInt64(settings.UserIDKey))
+			assert.Equal(t, tc.expect, got)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- The refactor branch sends `settings.GetString(settings.UserIDKey)` in the `ConfigRequest.UserID` field
- `main` sends `fmt.Sprintf("%d", settings.GetInt64(settings.UserIDKey))`
- For an authenticated user these **should** be equivalent (GetString handles the JSON-roundtripped float64 by converting back to int64 decimal — see the comment in \`common/settings/settings.go\`)
- But when `UserIDKey` is unset, `GetString` returns `""` while `fmt.Sprintf("%d", ...)` returns `"0"`. Server-side code (lantern-cloud \`assign_legacy.go:191\`) parses this via \`strconv.ParseInt(userId, 10, 64)\`, which treats `""` as a parse error and `"0"` as zero
- Suspected to be contributing to the **fewer-servers-for-Pro-users** regression on the refactor branch — even though Pro users have a non-zero UserID, bit-for-bit parity with main is the safest path while we bisect

## Test plan
- [x] Config package builds clean
- [ ] CI
- [x] Smoke test: Pro user on refactor build sees the same number of servers as on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)