### PR TITLE
ipc: add /config/events SSE endpoint for config-change notifications

### DIFF
--- a/ipc/client.go
+++ b/ipc/client.go
@@ -193,6 +193,21 @@ func (c *Client) AutoSelectedEvents(ctx context.Context, handler func(vpn.AutoSe
 }
 
 ///////////////////////
+// Config events     //
+///////////////////////
+
+// ConfigEvents connects to the config event stream. The server emits a frame
+// on every config.NewConfigEvent; the payload is intentionally empty — callers
+// should treat each frame as a "refresh" signal and fetch any state they need
+// via the other GET endpoints. The handler is called once per frame received
+// until ctx is cancelled or the connection is closed.
+func (c *Client) ConfigEvents(ctx context.Context, handler func()) error {
+	return c.sseStream(ctx, configEventsEndpoint, func(data []byte) {
+		handler()
+	})
+}
+
+///////////////////////
 // Server management //
 ///////////////////////
 

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/getlantern/radiance/account"
 	"github.com/getlantern/radiance/backend"
 	"github.com/getlantern/radiance/common/settings"
+	"github.com/getlantern/radiance/config"
 	"github.com/getlantern/radiance/events"
 	rlog "github.com/getlantern/radiance/log"
 	"github.com/getlantern/radiance/vpn"
@@ -40,6 +41,9 @@ const (
 	serverSelectedEndpoint           = "/server/selected"
 	serverAutoSelectedEndpoint       = "/server/auto-selected"
 	serverAutoSelectedEventsEndpoint = "/server/auto-selected/events"
+
+	// Config endpoints
+	configEventsEndpoint = "/config/events"
 
 	// Server management endpoints
 	serversEndpoint              = "/servers"
@@ -195,6 +199,7 @@ func newLocalAPI(b *backend.LocalBackend, withAuth bool) *localapi {
 	mux.HandleFunc(serverSelectedEndpoint, traced(s.serverSelectedHandler))
 	mux.HandleFunc("GET "+serverAutoSelectedEndpoint, traced(s.serverAutoSelectedHandler))
 	mux.HandleFunc("GET "+serverAutoSelectedEventsEndpoint, s.serverAutoSelectedEventsHandler)
+	mux.HandleFunc("GET "+configEventsEndpoint, s.configEventsHandler)
 
 	// Server management
 	mux.HandleFunc("GET "+serversEndpoint, traced(s.serversHandler))
@@ -460,6 +465,34 @@ func (s *localapi) serverAutoSelectedEventsHandler(w http.ResponseWriter, r *htt
 		select {
 		case data := <-ch:
 			fmt.Fprintf(w, "data: %s\n\n", data)
+			flusher.Flush()
+		case <-r.Context().Done():
+			return
+		}
+	}
+}
+
+// configEventsHandler streams a notification on every config.NewConfigEvent.
+// The payload is always "{}" — subscribers only need to know a change
+// occurred and fetch fresh state through the other GET endpoints, so we don't
+// serialize the (potentially large) full Config.
+func (s *localapi) configEventsHandler(w http.ResponseWriter, r *http.Request) {
+	flusher := sseWriter(w)
+	if flusher == nil {
+		return
+	}
+	ch := make(chan struct{}, 16)
+	sub := events.Subscribe(func(evt config.NewConfigEvent) {
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
+	})
+	defer sub.Unsubscribe()
+	for {
+		select {
+		case <-ch:
+			fmt.Fprint(w, "data: {}\n\n")
 			flusher.Flush()
 		case <-r.Context().Done():
 			return


### PR DESCRIPTION
## Summary

On the refactor branch \`config.NewConfigEvent\` is emitted inside the packet-tunnel extension's radiance process. Subscribers in the host app — notably lantern-core's \`listenConfigEvents\`, which forwards these to Flutter as \`\"config\"\` events driving \`availableServersProvider.forceFetchAvailableServers()\` and \`homeProvider.fetchUserDataIfNeeded()\` — never see them because \`events.Subscribe\` is an in-memory fan-out that doesn't cross the process boundary.

This PR adds \`/config/events\` alongside \`/server/auto-selected/events\` and \`/vpn/status/events\`. Mirrors the existing pattern exactly.

The payload is intentionally empty (\`{}\`) — callers only need to know a change occurred and can fetch fresh state through the other GET endpoints. Streaming the full \`config.NewConfigEvent\` (which holds the entire old + new \`*Config\`) would waste bandwidth for no consumer benefit.

## Client
\`\`\`go
func (c *Client) ConfigEvents(ctx context.Context, handler func()) error
\`\`\`

Handler fires once per frame until ctx is cancelled. Same reconnect semantics as \`AutoSelectedEvents\` / \`DataCapStream\`.

## Companion PR

This is the radiance half. The lantern-core half adds \`go lc.listenConfigEvents()\` back in, now using this SSE stream instead of the in-process \`events.SubscribeContext\` that Patrick removed in \`4d4e06d9d\` (because it was dead on the refactor split).

Tracked overall in getlantern/engineering#3182.

## Test plan
- [x] \`go build ./ipc/...\`
- [x] \`go vet ./ipc/...\`
- [x] \`go test -count=1 ./ipc/...\`
- [ ] Smoke test: Flutter UI refreshes available servers/user data when a new config arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)