### PR TITLE
vpn: pre-download remote rule-sets before sing-box init

### DIFF
--- a/vpn/rulesets.go
+++ b/vpn/rulesets.go
@@ -1,0 +1,129 @@
+package vpn
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	C "github.com/sagernet/sing-box/constant"
+	O "github.com/sagernet/sing-box/option"
+
+	"github.com/getlantern/radiance/common/atomicfile"
+)
+
+const (
+	ruleSetsCacheDir     = "rulesets"
+	ruleSetDownloadLimit = 32 << 20 // 32 MiB — upper bound on a single rule-set file
+	ruleSetDownloadTotal = 60 * time.Second
+	defaultRuleSetTTL    = 24 * time.Hour
+)
+
+// preDownloadRuleSets rewrites every remote rule-set in opts to a local one,
+// downloading content via Go's standard net/http (OS resolver, default dialer)
+// into dataPath/rulesets. This sidesteps a bootstrap deadlock on Android where
+// sing-box's DNS/dialers have no registered network interface at rule-set init
+// time, so every hostname lookup fails with "no available network interface"
+// — regardless of which DNS server the route chooses.
+//
+// Successful downloads are cached on disk and reused until UpdateInterval
+// elapses. On download failure we fall back to any existing cached copy; if
+// there is none we leave the entry as remote, preserving current behavior.
+func preDownloadRuleSets(ctx context.Context, opts *O.Options, dataPath string) {
+	if opts.Route == nil || len(opts.Route.RuleSet) == 0 {
+		return
+	}
+	cacheDir := filepath.Join(dataPath, ruleSetsCacheDir)
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		slog.Warn("Failed to create rule-set cache directory, skipping pre-download", "error", err)
+		return
+	}
+
+	client := &http.Client{Timeout: ruleSetDownloadTotal}
+	for i, rs := range opts.Route.RuleSet {
+		if rs.Type != C.RuleSetTypeRemote {
+			continue
+		}
+		url := rs.RemoteOptions.URL
+		if url == "" {
+			continue
+		}
+
+		path := ruleSetCachePath(cacheDir, rs.Tag, url)
+		ttl := time.Duration(rs.RemoteOptions.UpdateInterval)
+		if ttl <= 0 {
+			ttl = defaultRuleSetTTL
+		}
+
+		if fi, err := os.Stat(path); err == nil && time.Since(fi.ModTime()) < ttl {
+			slog.Debug("Using cached rule-set", "tag", rs.Tag, "path", path)
+			opts.Route.RuleSet[i] = toLocalRuleSet(rs, path)
+			continue
+		}
+
+		if err := downloadRuleSet(ctx, client, url, path); err != nil {
+			if _, statErr := os.Stat(path); statErr == nil {
+				slog.Warn("Rule-set download failed, using stale cache", "tag", rs.Tag, "error", err)
+				opts.Route.RuleSet[i] = toLocalRuleSet(rs, path)
+			} else {
+				slog.Warn("Rule-set download failed, leaving as remote", "tag", rs.Tag, "error", err)
+			}
+			continue
+		}
+		slog.Info("Pre-downloaded rule-set", "tag", rs.Tag, "path", path)
+		opts.Route.RuleSet[i] = toLocalRuleSet(rs, path)
+	}
+}
+
+// ruleSetCachePath derives a stable per-URL path under cacheDir. We hash the
+// URL so the filename is fixed-length and contains no untrusted path segments,
+// and preserve .srs/.json as a hint to sing-box's format auto-detection.
+func ruleSetCachePath(cacheDir, tag, url string) string {
+	sum := sha256.Sum256([]byte(url))
+	ext := filepath.Ext(url)
+	switch ext {
+	case ".srs", ".json":
+	default:
+		ext = ".srs"
+	}
+	name := fmt.Sprintf("%s-%s%s", tag, hex.EncodeToString(sum[:8]), ext)
+	return filepath.Join(cacheDir, name)
+}
+
+func toLocalRuleSet(src O.RuleSet, path string) O.RuleSet {
+	return O.RuleSet{
+		Type:         C.RuleSetTypeLocal,
+		Tag:          src.Tag,
+		Format:       src.Format,
+		LocalOptions: O.LocalRuleSet{Path: path},
+	}
+}
+
+func downloadRuleSet(ctx context.Context, client *http.Client, url, path string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("do request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, ruleSetDownloadLimit+1))
+	if err != nil {
+		return fmt.Errorf("read body: %w", err)
+	}
+	if len(body) > ruleSetDownloadLimit {
+		return fmt.Errorf("rule-set exceeds %d bytes", ruleSetDownloadLimit)
+	}
+	return atomicfile.WriteFile(path, body, 0644)
+}

--- a/vpn/rulesets_test.go
+++ b/vpn/rulesets_test.go
@@ -1,0 +1,107 @@
+package vpn
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	C "github.com/sagernet/sing-box/constant"
+	O "github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing/common/json/badoption"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreDownloadRuleSets_RewritesRemoteToLocal(t *testing.T) {
+	body := []byte("rule-set-bytes")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	dataPath := t.TempDir()
+	opts := &O.Options{Route: &O.RouteOptions{RuleSet: []O.RuleSet{{
+		Type:          C.RuleSetTypeRemote,
+		Tag:           "geosite-cn",
+		Format:        C.RuleSetFormatBinary,
+		RemoteOptions: O.RemoteRuleSet{URL: srv.URL + "/cn.srs"},
+	}}}}
+
+	preDownloadRuleSets(context.Background(), opts, dataPath)
+
+	rs := opts.Route.RuleSet[0]
+	require.Equal(t, C.RuleSetTypeLocal, rs.Type)
+	assert.Equal(t, "geosite-cn", rs.Tag)
+	got, err := os.ReadFile(rs.LocalOptions.Path)
+	require.NoError(t, err)
+	assert.Equal(t, body, got)
+}
+
+func TestPreDownloadRuleSets_UsesFreshCacheWithoutHTTP(t *testing.T) {
+	dataPath := t.TempDir()
+	cached := []byte("cached-bytes")
+	url := "https://example.invalid/cn.srs" // would fail if dialed
+	path := ruleSetCachePath(filepath.Join(dataPath, ruleSetsCacheDir), "geosite-cn", url)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+	require.NoError(t, os.WriteFile(path, cached, 0644))
+
+	opts := &O.Options{Route: &O.RouteOptions{RuleSet: []O.RuleSet{{
+		Type:          C.RuleSetTypeRemote,
+		Tag:           "geosite-cn",
+		Format:        C.RuleSetFormatBinary,
+		RemoteOptions: O.RemoteRuleSet{URL: url, UpdateInterval: badoption.Duration(time.Hour)},
+	}}}}
+
+	preDownloadRuleSets(context.Background(), opts, dataPath)
+
+	rs := opts.Route.RuleSet[0]
+	require.Equal(t, C.RuleSetTypeLocal, rs.Type)
+	assert.Equal(t, path, rs.LocalOptions.Path)
+	got, err := os.ReadFile(rs.LocalOptions.Path)
+	require.NoError(t, err)
+	assert.Equal(t, cached, got, "cache was overwritten, download should have been skipped")
+}
+
+func TestPreDownloadRuleSets_FallsBackToStaleCacheOnFailure(t *testing.T) {
+	dataPath := t.TempDir()
+	stale := []byte("stale-but-usable")
+	url := "https://example.invalid/cn.srs"
+	path := ruleSetCachePath(filepath.Join(dataPath, ruleSetsCacheDir), "geosite-cn", url)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+	require.NoError(t, os.WriteFile(path, stale, 0644))
+	// Backdate mtime well beyond the TTL.
+	old := time.Now().Add(-48 * time.Hour)
+	require.NoError(t, os.Chtimes(path, old, old))
+
+	opts := &O.Options{Route: &O.RouteOptions{RuleSet: []O.RuleSet{{
+		Type:          C.RuleSetTypeRemote,
+		Tag:           "geosite-cn",
+		Format:        C.RuleSetFormatBinary,
+		RemoteOptions: O.RemoteRuleSet{URL: url, UpdateInterval: badoption.Duration(time.Hour)},
+	}}}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	preDownloadRuleSets(ctx, opts, dataPath)
+
+	rs := opts.Route.RuleSet[0]
+	require.Equal(t, C.RuleSetTypeLocal, rs.Type, "stale cache should still let us switch to local")
+	assert.Equal(t, path, rs.LocalOptions.Path)
+}
+
+func TestPreDownloadRuleSets_LeavesLocalEntriesAlone(t *testing.T) {
+	opts := &O.Options{Route: &O.RouteOptions{RuleSet: []O.RuleSet{{
+		Type:         C.RuleSetTypeLocal,
+		Tag:          "split-tunnel",
+		Format:       C.RuleSetFormatSource,
+		LocalOptions: O.LocalRuleSet{Path: "/some/path.json"},
+	}}}}
+	preDownloadRuleSets(context.Background(), opts, t.TempDir())
+	rs := opts.Route.RuleSet[0]
+	assert.Equal(t, C.RuleSetTypeLocal, rs.Type)
+	assert.Equal(t, "/some/path.json", rs.LocalOptions.Path)
+}

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -174,6 +174,7 @@ func getOptions() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to build options: %w", err)
 	}
+	preDownloadRuleSets(context.Background(), &options, dataPath)
 	opts, err := sbjson.Marshal(options)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal options: %w", err)


### PR DESCRIPTION
## Summary

On Android, sing-box initializes remote rule-sets (\`geosite-cn\`, smart-routing categories like \`ai-domains\`) *before* the TUN is up. The DNS router has no registered network interface at that point, so every hostname lookup fails with \`exchange4: no available network interface | exchange6: no available network interface\` — including lookups routed to \`dns_local\` (a DoH server reached through sing-box's own dialer). The download blocks libbox startup, so the tunnel never comes up.

This PR fetches remote rule-sets in radiance, *before* handing options to libbox, using \`net/http\` (OS resolver + platform default dialer, both of which work pre-TUN). Each entry is rewritten to \`type=local\` pointing at a cached file under \`{dataPath}/rulesets/\`.

Behavior:
- First start: download via Go stdlib, cache on disk, start sing-box with local paths.
- Cached: skip HTTP if the cache is fresher than \`RemoteRuleSet.UpdateInterval\` (default 24h).
- Offline w/ stale cache: fall back to the stale cache (better than failing startup).
- Offline, no cache: leave as \`remote\` — same failure as today.

No platform-specific branching; every platform benefits from the caching.

## Context

Reproduced and verified on the Android emulator with \`RADIANCE_COUNTRY=MO\` (smart-routing country). Before: libbox fails with \`initial rule-set ... no available network interface\`. After: \`Pre-downloaded rule-set\` ×N → \`Tunnel initializated\` → VPN Status: **Connected**.

Original diagnosis: Freshdesk [#172564](https://lantern.freshdesk.com/a/tickets/172564) (Macao, CN Unicom — geosite-cn bootstrap deadlock) and [#172722](https://lantern.freshdesk.com/a/tickets/172722) (Bulgaria — smart-routing-bg bootstrap deadlock).

This **supersedes** the server-side \`dns_ruleset_host_bypass\` DNS rule in lantern-cloud [#2588](https://github.com/getlantern/lantern-cloud/pull/2588). That fix routed the rule-set hostnames to \`dns_local\`, but \`dns_local\` itself fails for the same reason — sing-box's dialer has no interfaces at init regardless of which DNS server the route chooses. The feature flag can be retired after this lands.

Companion PR against \`refactor\`: #423.

## Test plan

- [x] \`go test ./vpn/... -run TestPreDownloadRuleSets\` — 4 new unit tests (rewrite, cache hit, stale fallback, local passthrough)
- [x] Android emulator with \`RADIANCE_COUNTRY=MO\` — tunnel connects cleanly
- [ ] Desktop regression — rule-sets still update normally (UpdateInterval=24h)
- [ ] iOS — same bootstrap issue theoretically exists; verify no regression