### PR TITLE
env: don't let SetStagingEnv override a shell-set RADIANCE_ENV

### DIFF
--- a/common/env/env.go
+++ b/common/env/env.go
@@ -93,9 +93,19 @@ func Get[T any](key Key) (T, bool) {
 	return zero, false
 }
 
-// SetStagingEnv sets the environment to staging if it has not already been set.
-// This is used for testing that need to interact with staging services,
+// SetStagingEnv sets the environment to staging if it has not already
+// been set. Callers typically invoke this when the Flutter UI's
+// persisted `environment` setting is "staging", but that persisted
+// setting must not override a developer's explicit shell env —
+// RADIANCE_ENV from the shell wins. If RADIANCE_ENV is already set
+// (either via shell or a .env file picked up at init), leave it alone;
+// otherwise fall through to the staging default.
 func SetStagingEnv() {
+	if _, alreadySet := envVars[ENV]; alreadySet {
+		slog.Info("SetStagingEnv called but RADIANCE_ENV already set; honoring existing value", "value", envVars[ENV])
+		envVars[PrintCurl] = true
+		return
+	}
 	slog.Info("setting environment to staging for testing")
 	envVars[ENV] = "staging"
 	envVars[PrintCurl] = true

--- a/common/env/env_test.go
+++ b/common/env/env_test.go
@@ -1,0 +1,43 @@
+package env
+
+import (
+	"testing"
+)
+
+// TestSetStagingEnv_DoesNotOverrideExisting guards the contract
+// spelled out in SetStagingEnv's docstring: the Flutter UI's persisted
+// `environment` app-setting (which triggers SetStagingEnv) must not
+// override a developer's explicit shell RADIANCE_ENV. Without this
+// guard, a CLI override like `RADIANCE_ENV=staging Lantern` ends up
+// silently wiped when Flutter later passes its persisted env through
+// SetStagingEnv — making it near-impossible to run a staging-pointed
+// desktop client when the last GUI session persisted "prod".
+func TestSetStagingEnv_DoesNotOverrideExisting(t *testing.T) {
+	saved := envVars
+	defer func() { envVars = saved }()
+
+	envVars = map[string]any{ENV: "prod"}
+	SetStagingEnv()
+	if got := envVars[ENV]; got != "prod" {
+		t.Fatalf("RADIANCE_ENV=prod should be preserved, got %v", got)
+	}
+	// PrintCurl is an instrumentation side-effect that's safe to set
+	// regardless — assert the helper still primes it for dev ergonomics.
+	if got, _ := envVars[PrintCurl].(bool); !got {
+		t.Fatalf("PrintCurl should be enabled by SetStagingEnv, got %v", envVars[PrintCurl])
+	}
+}
+
+// TestSetStagingEnv_SetsWhenUnset covers the original happy path: if
+// nothing has set RADIANCE_ENV yet (no shell export, no .env file), a
+// Flutter opts.Env="staging" should still result in staging mode.
+func TestSetStagingEnv_SetsWhenUnset(t *testing.T) {
+	saved := envVars
+	defer func() { envVars = saved }()
+
+	envVars = map[string]any{}
+	SetStagingEnv()
+	if got := envVars[ENV]; got != "staging" {
+		t.Fatalf("expected staging, got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

\`SetStagingEnv\`'s docstring says \"sets the environment to staging if it has not already been set\" but the implementation unconditionally overwrote \`envVars[ENV]\`. Honor the docstring.

## Why

The Flutter UI persists its current environment in app settings and passes it as \`Opts.Env\` on every launch. When that persisted setting is \"staging\", lantern-core calls \`SetStagingEnv\` and clobbers whatever the init loop already populated from the shell \`RADIANCE_ENV\` export.

Observed today on a staging unbounded end-to-end test: developer runs

\`\`\`
RADIANCE_ENV=staging RADIANCE_FEATURE_OVERRIDES=bandit_proxy_assignment \\
  /Applications/Lantern.app/Contents/MacOS/Lantern
\`\`\`

— wants staging — but the Flutter UI's persisted setting (from some earlier GUI session) interferes. The mirror-image bug on this main branch is equally silent: shell says \`prod\`, Flutter persisted \`staging\`, SetStagingEnv wipes \`prod\` → developer is unexpectedly pointed at staging.

The fix preserves the dev-ergonomics side effect (\`envVars[PrintCurl] = true\`) so staging-on-request instrumentation still works, and a new test rejects any future regression to unconditional overwrite.

## Test plan
- [x] \`go test ./common/env/...\` — both new tests pass
- [x] \`go build ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)