### PR TITLE
vpn: direct-transport + streaming wrapper for Unbounded signaling (plus env propagation)

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"os"
 	"path/filepath"
 	"reflect"
 	"slices"
@@ -87,11 +88,26 @@ type Options struct {
 	// User choice for telemetry consent
 	TelemetryConsent  bool
 	PlatformInterface vpn.PlatformInterface
+	// EnvOverrides, if non-empty, are applied via os.Setenv before common.Init
+	// runs. This is how RADIANCE_* shell vars from the main Lantern process
+	// reach a sandboxed system extension (macOS/iOS), which has no shell env
+	// inheritance of its own. Callers pack these in the host-app layer and
+	// forward them through gomobile; see lantern/lantern-core/mobile.
+	EnvOverrides map[string]string
 }
 
 // NewLocalBackend performs global initialization and returns a new LocalBackend instance.
 // It should be called once at the start of the application.
 func NewLocalBackend(ctx context.Context, opts Options) (*LocalBackend, error) {
+	// Apply env overrides BEFORE common.Init — common.Init reads
+	// RADIANCE_VERSION once and freezes it into common.Version, so any
+	// later write (via /env IPC, env.Set, or os.Setenv) is ignored by
+	// the header-fill path. Must land here, before the first read.
+	for k, v := range opts.EnvOverrides {
+		if err := os.Setenv(k, v); err != nil {
+			slog.Warn("failed to apply env override", slog.String("key", k), slog.Any("error", err))
+		}
+	}
 	if err := common.Init(opts.DataDir, opts.LogDir, opts.LogLevel); err != nil {
 		return nil, fmt.Errorf("failed to initialize common components: %w", err)
 	}

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -88,34 +88,18 @@ type Options struct {
 	// User choice for telemetry consent
 	TelemetryConsent  bool
 	PlatformInterface vpn.PlatformInterface
-	// EnvOverrides, if non-empty, are applied via os.Setenv before common.Init
-	// runs. The primary use case is forwarding RADIANCE_* shell vars from
-	// the main Lantern process to a sandboxed system extension (macOS/iOS),
-	// which has no shell env inheritance of its own. Callers pack these in
-	// the host-app layer and forward them through gomobile; see
-	// lantern/lantern-core/mobile.
-	//
-	// Note: every entry is applied verbatim via os.Setenv — no key
-	// validation or prefix filtering. Don't put anything here that you
-	// wouldn't put on the process's own shell env. The map is owned by
-	// the host-app, not by arbitrary callers, so the trust boundary is
-	// already above this point.
+	// EnvOverrides are applied via os.Setenv before common.Init so sandboxed
+	// system extensions (macOS/iOS), which don't inherit shell env, still see
+	// RADIANCE_* vars from the host process. Entries are set verbatim — no
+	// filtering.
 	EnvOverrides map[string]string
 }
 
 // NewLocalBackend performs global initialization and returns a new LocalBackend instance.
 // It should be called once at the start of the application.
 func NewLocalBackend(ctx context.Context, opts Options) (*LocalBackend, error) {
-	// Apply env overrides BEFORE common.Init — common.Init reads
-	// RADIANCE_VERSION once and freezes it into common.Version, so any
-	// later write (via /env IPC, env.Set, or os.Setenv) is ignored by
-	// the header-fill path. Must land here, before the first read.
-	//
-	// Aggregate failures rather than log-and-continue: if a key like
-	// RADIANCE_VERSION silently fails to apply, the backend would boot
-	// with the wrong version in every outbound request header, and the
-	// misconfiguration wouldn't surface until someone noticed server-
-	// side metrics were wrong.
+	// Must run before common.Init: it reads RADIANCE_VERSION once and
+	// freezes it, so a later Setenv is ignored by the header-fill path.
 	var envOverrideErrs error
 	for k, v := range opts.EnvOverrides {
 		if err := os.Setenv(k, v); err != nil {

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -89,10 +89,17 @@ type Options struct {
 	TelemetryConsent  bool
 	PlatformInterface vpn.PlatformInterface
 	// EnvOverrides, if non-empty, are applied via os.Setenv before common.Init
-	// runs. This is how RADIANCE_* shell vars from the main Lantern process
-	// reach a sandboxed system extension (macOS/iOS), which has no shell env
-	// inheritance of its own. Callers pack these in the host-app layer and
-	// forward them through gomobile; see lantern/lantern-core/mobile.
+	// runs. The primary use case is forwarding RADIANCE_* shell vars from
+	// the main Lantern process to a sandboxed system extension (macOS/iOS),
+	// which has no shell env inheritance of its own. Callers pack these in
+	// the host-app layer and forward them through gomobile; see
+	// lantern/lantern-core/mobile.
+	//
+	// Note: every entry is applied verbatim via os.Setenv — no key
+	// validation or prefix filtering. Don't put anything here that you
+	// wouldn't put on the process's own shell env. The map is owned by
+	// the host-app, not by arbitrary callers, so the trust boundary is
+	// already above this point.
 	EnvOverrides map[string]string
 }
 
@@ -103,10 +110,20 @@ func NewLocalBackend(ctx context.Context, opts Options) (*LocalBackend, error) {
 	// RADIANCE_VERSION once and freezes it into common.Version, so any
 	// later write (via /env IPC, env.Set, or os.Setenv) is ignored by
 	// the header-fill path. Must land here, before the first read.
+	//
+	// Aggregate failures rather than log-and-continue: if a key like
+	// RADIANCE_VERSION silently fails to apply, the backend would boot
+	// with the wrong version in every outbound request header, and the
+	// misconfiguration wouldn't surface until someone noticed server-
+	// side metrics were wrong.
+	var envOverrideErrs error
 	for k, v := range opts.EnvOverrides {
 		if err := os.Setenv(k, v); err != nil {
-			slog.Warn("failed to apply env override", slog.String("key", k), slog.Any("error", err))
+			envOverrideErrs = errors.Join(envOverrideErrs, fmt.Errorf("apply env override %q: %w", k, err))
 		}
+	}
+	if envOverrideErrs != nil {
+		return nil, fmt.Errorf("failed to apply environment overrides: %w", envOverrideErrs)
 	}
 	if err := common.Init(opts.DataDir, opts.LogDir, opts.LogLevel); err != nil {
 		return nil, fmt.Errorf("failed to initialize common components: %w", err)

--- a/common/env/env.go
+++ b/common/env/env.go
@@ -64,17 +64,8 @@ func init() {
 	}
 }
 
-// Get resolves a key with OS environment variables taking precedence
-// over values loaded from a .env file or written at runtime via Set.
-// This matches the package-level docstring ("environment variables >
-// configurations set at .env file") and lets a developer's explicit
-// shell export (e.g. `RADIANCE_ENV=staging Lantern`) win over whatever
-// the Flutter UI's persisted app-settings ends up passing through
-// SetStagingEnv or the /env IPC endpoint — otherwise a stale persisted
-// setting silently overrides the command-line intent.
-//
-// The dotenv map is still consulted as a fallback so runtime overrides
-// (from .env file or IPC) take effect for keys the shell hasn't set.
+// Get returns the value for key. OS env takes precedence over .env / runtime
+// Set values (matching the package docstring); dotenv is the fallback.
 func Get(key _key) (string, bool) {
 	if value, exists := os.LookupEnv(key.String()); exists {
 		return value, true
@@ -88,10 +79,8 @@ func Get(key _key) (string, bool) {
 	return "", false
 }
 
-// Set writes a key to the in-memory dotenv map. Note: if the same key is
-// present in the OS environment, Get will still return the OS value —
-// shell env wins. This is intended for dev/testing use via IPC for keys
-// the shell hasn't explicitly set.
+// Set writes a key to the in-memory dotenv map. If the same key is set in
+// the OS env, Get still returns the OS value — shell env wins.
 func Set(key string, value string) {
 	mu.Lock()
 	dotenv[key] = value

--- a/common/env/env.go
+++ b/common/env/env.go
@@ -64,21 +64,34 @@ func init() {
 	}
 }
 
+// Get resolves a key with OS environment variables taking precedence
+// over values loaded from a .env file or written at runtime via Set.
+// This matches the package-level docstring ("environment variables >
+// configurations set at .env file") and lets a developer's explicit
+// shell export (e.g. `RADIANCE_ENV=staging Lantern`) win over whatever
+// the Flutter UI's persisted app-settings ends up passing through
+// SetStagingEnv or the /env IPC endpoint — otherwise a stale persisted
+// setting silently overrides the command-line intent.
+//
+// The dotenv map is still consulted as a fallback so runtime overrides
+// (from .env file or IPC) take effect for keys the shell hasn't set.
 func Get(key _key) (string, bool) {
+	if value, exists := os.LookupEnv(key.String()); exists {
+		return value, true
+	}
 	mu.RLock()
 	value, exists := dotenv[key.String()]
 	mu.RUnlock()
 	if exists {
 		return value, true
 	}
-	if value, exists := os.LookupEnv(key.String()); exists {
-		return value, true
-	}
 	return "", false
 }
 
-// Set sets a key in the in-memory dotenv map, overriding any .env file or OS
-// environment variable value. This is intended for dev/testing use via IPC.
+// Set writes a key to the in-memory dotenv map. Note: if the same key is
+// present in the OS environment, Get will still return the OS value —
+// shell env wins. This is intended for dev/testing use via IPC for keys
+// the shell hasn't explicitly set.
 func Set(key string, value string) {
 	mu.Lock()
 	dotenv[key] = value

--- a/common/env/env_test.go
+++ b/common/env/env_test.go
@@ -19,10 +19,15 @@ func TestGet_OSEnvWinsOverDotenv(t *testing.T) {
 	saved := cloneDotenv()
 	defer restoreDotenv(saved)
 
-	t.Setenv(ENV.String(), "prod")
-	Set(ENV.String(), "staging")
+	// Use a test-only key so this precedence check doesn't mutate the
+	// real RADIANCE_ENV process variable. Go runs package tests in
+	// parallel by default; a stray `RADIANCE_ENV=prod` set here could
+	// leak into sibling packages that call common.Env()/env.Get(ENV).
+	const testKey = "RADIANCE_UNIT_TEST_OS_WINS_KEY_DOES_NOT_EXIST"
+	t.Setenv(testKey, "prod")
+	Set(testKey, "staging")
 
-	got, ok := Get(ENV)
+	got, ok := Get(_key(testKey))
 	if !ok {
 		t.Fatal("Get returned ok=false")
 	}

--- a/common/env/env_test.go
+++ b/common/env/env_test.go
@@ -5,24 +5,13 @@ import (
 	"testing"
 )
 
-// TestGet_OSEnvWinsOverDotenv guards the precedence promised by the
-// package docstring: OS env > .env / runtime Set values.
-//
-// The regression this catches: the Flutter UI persists its current
-// environment as an app-setting and passes it to lantern-core on every
-// launch. When persisted = "staging", core calls SetStagingEnv which
-// writes dotenv[RADIANCE_ENV]="staging". If a developer starts the app
-// with `RADIANCE_ENV=prod Lantern` expecting prod, the dotenv value
-// silently wins without this fix — making it near-impossible to point
-// a desktop client at a different env than the last GUI session used.
+// Guards the precedence promised by the package docstring: OS env > dotenv.
 func TestGet_OSEnvWinsOverDotenv(t *testing.T) {
 	saved := cloneDotenv()
 	defer restoreDotenv(saved)
 
-	// Use a test-only key so this precedence check doesn't mutate the
-	// real RADIANCE_ENV process variable. Go runs package tests in
-	// parallel by default; a stray `RADIANCE_ENV=prod` set here could
-	// leak into sibling packages that call common.Env()/env.Get(ENV).
+	// Test-only key — don't mutate real RADIANCE_* vars that sibling
+	// packages may read during parallel test execution.
 	const testKey = "RADIANCE_UNIT_TEST_OS_WINS_KEY_DOES_NOT_EXIST"
 	t.Setenv(testKey, "prod")
 	Set(testKey, "staging")
@@ -36,18 +25,14 @@ func TestGet_OSEnvWinsOverDotenv(t *testing.T) {
 	}
 }
 
-// TestGet_DotenvFallsBackWhenOSUnset documents the other half of the
-// contract: Set / .env values are still consulted for keys the shell
-// hasn't explicitly set, so runtime instrumentation like SetStagingEnv
-// keeps working for users who don't export anything themselves.
+// Other half of the contract: dotenv is still consulted when OS env is unset,
+// so runtime instrumentation like SetStagingEnv keeps working.
 func TestGet_DotenvFallsBackWhenOSUnset(t *testing.T) {
 	saved := cloneDotenv()
 	defer restoreDotenv(saved)
 
-	// Use a test-only key to avoid colliding with anything the init
-	// loop may have read from .env or inherited from the process env.
 	const testKey = "RADIANCE_UNIT_TEST_KEY_DOES_NOT_EXIST"
-	_ = os.Unsetenv(testKey) // make absolutely sure OS doesn't have it
+	_ = os.Unsetenv(testKey)
 
 	Set(testKey, "from-dotenv")
 	got, ok := Get(_key(testKey))

--- a/common/env/env_test.go
+++ b/common/env/env_test.go
@@ -1,0 +1,71 @@
+package env
+
+import (
+	"os"
+	"testing"
+)
+
+// TestGet_OSEnvWinsOverDotenv guards the precedence promised by the
+// package docstring: OS env > .env / runtime Set values.
+//
+// The regression this catches: the Flutter UI persists its current
+// environment as an app-setting and passes it to lantern-core on every
+// launch. When persisted = "staging", core calls SetStagingEnv which
+// writes dotenv[RADIANCE_ENV]="staging". If a developer starts the app
+// with `RADIANCE_ENV=prod Lantern` expecting prod, the dotenv value
+// silently wins without this fix — making it near-impossible to point
+// a desktop client at a different env than the last GUI session used.
+func TestGet_OSEnvWinsOverDotenv(t *testing.T) {
+	saved := cloneDotenv()
+	defer restoreDotenv(saved)
+
+	t.Setenv(ENV.String(), "prod")
+	Set(ENV.String(), "staging")
+
+	got, ok := Get(ENV)
+	if !ok {
+		t.Fatal("Get returned ok=false")
+	}
+	if got != "prod" {
+		t.Fatalf("OS env should win; got %q, want %q", got, "prod")
+	}
+}
+
+// TestGet_DotenvFallsBackWhenOSUnset documents the other half of the
+// contract: Set / .env values are still consulted for keys the shell
+// hasn't explicitly set, so runtime instrumentation like SetStagingEnv
+// keeps working for users who don't export anything themselves.
+func TestGet_DotenvFallsBackWhenOSUnset(t *testing.T) {
+	saved := cloneDotenv()
+	defer restoreDotenv(saved)
+
+	// Use a test-only key to avoid colliding with anything the init
+	// loop may have read from .env or inherited from the process env.
+	const testKey = "RADIANCE_UNIT_TEST_KEY_DOES_NOT_EXIST"
+	_ = os.Unsetenv(testKey) // make absolutely sure OS doesn't have it
+
+	Set(testKey, "from-dotenv")
+	got, ok := Get(_key(testKey))
+	if !ok {
+		t.Fatal("Get returned ok=false when only dotenv had the value")
+	}
+	if got != "from-dotenv" {
+		t.Fatalf("dotenv should be used when OS env unset; got %q", got)
+	}
+}
+
+func cloneDotenv() map[string]string {
+	mu.RLock()
+	defer mu.RUnlock()
+	out := make(map[string]string, len(dotenv))
+	for k, v := range dotenv {
+		out[k] = v
+	}
+	return out
+}
+
+func restoreDotenv(m map[string]string) {
+	mu.Lock()
+	defer mu.Unlock()
+	dotenv = m
+}

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -24,6 +24,7 @@ import (
 	"github.com/getlantern/radiance/common"
 	"github.com/getlantern/radiance/common/settings"
 	"github.com/getlantern/radiance/events"
+	"github.com/getlantern/radiance/kindling"
 	rlog "github.com/getlantern/radiance/log"
 	"github.com/getlantern/radiance/servers"
 
@@ -62,7 +63,12 @@ func (t *tunnel) start(options string, platformIfce libbox.PlatformInterface) (e
 	if t.status.Load() != Restarting {
 		t.setStatus(Connecting, nil)
 	}
-	t.ctx, t.cancel = context.WithCancel(box.BaseContext())
+	// Unbounded signaling (and any other outbound that reads this value) must
+	// dial freddie outside the user's VPN tunnel, otherwise it recursively
+	// re-enters itself. kindling's RoundTripper dials via the physical
+	// interface and blocks until kindling init completes.
+	baseCtx := lbA.ContextWithDirectTransport(box.BaseContext(), kindling.HTTPClient().Transport)
+	t.ctx, t.cancel = context.WithCancel(baseCtx)
 	defer func() {
 		if err != nil {
 			t.setStatus(ErrorStatus, err)

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"net/http"
 	"path/filepath"
 	runtimeDebug "runtime/debug"
 	"slices"
@@ -25,6 +24,7 @@ import (
 	"github.com/getlantern/radiance/common"
 	"github.com/getlantern/radiance/common/settings"
 	"github.com/getlantern/radiance/events"
+	"github.com/getlantern/radiance/kindling"
 	rlog "github.com/getlantern/radiance/log"
 	"github.com/getlantern/radiance/servers"
 
@@ -65,13 +65,9 @@ func (t *tunnel) start(options string, platformIfce libbox.PlatformInterface) (e
 	}
 	// Unbounded signaling (and any other outbound that reads this value) must
 	// dial freddie outside the user's VPN tunnel, otherwise it recursively
-	// re-enters itself. On macOS/iOS system extensions the PacketTunnelProvider
-	// process is the TUN's origin — its own outgoing connections bypass the
-	// TUN automatically — so a plain transport is enough to escape the loop.
-	// Kindling would also work but its fronted/race pipeline buffers streaming
-	// responses (breaks freddie's long-poll genesis subscription); a naked
-	// transport keeps the stream intact.
-	baseCtx := lbA.ContextWithDirectTransport(box.BaseContext(), http.DefaultTransport)
+	// re-enters itself. kindling's RoundTripper dials via the physical
+	// interface and blocks until kindling init completes.
+	baseCtx := lbA.ContextWithDirectTransport(box.BaseContext(), kindling.HTTPClient().Transport)
 	t.ctx, t.cancel = context.WithCancel(baseCtx)
 	defer func() {
 		if err != nil {

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	runtimeDebug "runtime/debug"
 	"slices"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -65,20 +64,9 @@ func (t *tunnel) start(options string, platformIfce libbox.PlatformInterface) (e
 	if t.status.Load() != Restarting {
 		t.setStatus(Connecting, nil)
 	}
-	// Unbounded signaling (and any other outbound that reads this value) must
-	// dial freddie outside the user's VPN tunnel, otherwise it recursively
-	// re-enters itself. kindling's RoundTripper dials via the physical
-	// interface and blocks until kindling init completes.
-	//
-	// We wrap it in a streaming-aware transport: kindling's race pipeline
-	// includes a non-streamable AMP transport that can win the race and
-	// buffer the full response body. Freddie's genesis endpoint is a
-	// long-poll SSE-style stream, so a buffered responder returns an
-	// immediate short body and the broflake consumer FSM sees EOF before
-	// any genesis message arrives, restarting forever without ever
-	// sending an offer. Setting Accept: text/event-stream on freddie
-	// requests makes kindling skip AMP and race only the streamable
-	// transports (fronted, smart), so the stream stays open.
+	// Unbounded signaling must dial freddie outside the VPN tunnel or it
+	// recursively re-enters itself. streamingRoundTripper forces kindling to
+	// skip AMP (non-streamable) so freddie's long-poll genesis stream works.
 	baseCtx := lbA.ContextWithDirectTransport(box.BaseContext(), streamingRoundTripper{inner: kindling.HTTPClient().Transport})
 	t.ctx, t.cancel = context.WithCancel(baseCtx)
 	defer func() {
@@ -585,19 +573,9 @@ func contextDone(ctx context.Context) bool {
 	}
 }
 
-// streamingRoundTripper wraps an inner RoundTripper and sets
-// `Accept: text/event-stream` on outgoing requests that don't already have
-// an Accept header. This is specifically to work around kindling's race
-// pipeline: the AMP transport is non-streamable, so if it wins the race
-// against fronted/smart it buffers the full response body — which breaks
-// freddie's long-poll genesis subscription. Kindling filters non-streamable
-// transports only when the request Accept header is text/event-stream, so
-// we force it here.
-//
-// We don't override an already-set Accept (some callers may legitimately
-// ask for other content types); callers that expect streaming but omit
-// Accept get the streaming-friendly default, which matches what SSE
-// clients typically send anyway.
+// streamingRoundTripper defaults Accept to text/event-stream so kindling's
+// race pipeline drops non-streamable transports (AMP) that would otherwise
+// buffer freddie's long-poll body and break broflake's genesis subscription.
 type streamingRoundTripper struct {
 	inner http.RoundTripper
 }
@@ -607,24 +585,12 @@ func (s streamingRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 		req = req.Clone(req.Context())
 		req.Header.Set("Accept", "text/event-stream")
 	}
-	slog.Info("unbounded signaling RoundTrip start",
-		slog.String("method", req.Method),
-		slog.String("url", req.URL.String()),
-		slog.String("accept", req.Header.Get("Accept")))
-	start := time.Now()
 	resp, err := s.inner.RoundTrip(req)
 	if err != nil {
 		slog.Error("unbounded signaling RoundTrip error",
 			slog.String("url", req.URL.String()),
-			slog.Duration("duration", time.Since(start)),
 			slog.Any("error", err))
 		return nil, err
 	}
-	slog.Info("unbounded signaling RoundTrip ok",
-		slog.String("url", req.URL.String()),
-		slog.Int("status", resp.StatusCode),
-		slog.String("content_length", resp.Header.Get("Content-Length")),
-		slog.String("transfer_encoding", strings.Join(resp.TransferEncoding, ",")),
-		slog.Duration("duration_to_headers", time.Since(start)))
 	return resp, nil
 }

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	runtimeDebug "runtime/debug"
 	"slices"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -606,5 +607,24 @@ func (s streamingRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 		req = req.Clone(req.Context())
 		req.Header.Set("Accept", "text/event-stream")
 	}
-	return s.inner.RoundTrip(req)
+	slog.Info("unbounded signaling RoundTrip start",
+		slog.String("method", req.Method),
+		slog.String("url", req.URL.String()),
+		slog.String("accept", req.Header.Get("Accept")))
+	start := time.Now()
+	resp, err := s.inner.RoundTrip(req)
+	if err != nil {
+		slog.Error("unbounded signaling RoundTrip error",
+			slog.String("url", req.URL.String()),
+			slog.Duration("duration", time.Since(start)),
+			slog.Any("error", err))
+		return nil, err
+	}
+	slog.Info("unbounded signaling RoundTrip ok",
+		slog.String("url", req.URL.String()),
+		slog.Int("status", resp.StatusCode),
+		slog.String("content_length", resp.Header.Get("Content-Length")),
+		slog.String("transfer_encoding", strings.Join(resp.TransferEncoding, ",")),
+		slog.Duration("duration_to_headers", time.Since(start)))
+	return resp, nil
 }

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"path/filepath"
 	runtimeDebug "runtime/debug"
 	"slices"
@@ -67,7 +68,17 @@ func (t *tunnel) start(options string, platformIfce libbox.PlatformInterface) (e
 	// dial freddie outside the user's VPN tunnel, otherwise it recursively
 	// re-enters itself. kindling's RoundTripper dials via the physical
 	// interface and blocks until kindling init completes.
-	baseCtx := lbA.ContextWithDirectTransport(box.BaseContext(), kindling.HTTPClient().Transport)
+	//
+	// We wrap it in a streaming-aware transport: kindling's race pipeline
+	// includes a non-streamable AMP transport that can win the race and
+	// buffer the full response body. Freddie's genesis endpoint is a
+	// long-poll SSE-style stream, so a buffered responder returns an
+	// immediate short body and the broflake consumer FSM sees EOF before
+	// any genesis message arrives, restarting forever without ever
+	// sending an offer. Setting Accept: text/event-stream on freddie
+	// requests makes kindling skip AMP and race only the streamable
+	// transports (fronted, smart), so the stream stays open.
+	baseCtx := lbA.ContextWithDirectTransport(box.BaseContext(), streamingRoundTripper{inner: kindling.HTTPClient().Transport})
 	t.ctx, t.cancel = context.WithCancel(baseCtx)
 	defer func() {
 		if err != nil {
@@ -571,4 +582,29 @@ func contextDone(ctx context.Context) bool {
 	default:
 		return false
 	}
+}
+
+// streamingRoundTripper wraps an inner RoundTripper and sets
+// `Accept: text/event-stream` on outgoing requests that don't already have
+// an Accept header. This is specifically to work around kindling's race
+// pipeline: the AMP transport is non-streamable, so if it wins the race
+// against fronted/smart it buffers the full response body — which breaks
+// freddie's long-poll genesis subscription. Kindling filters non-streamable
+// transports only when the request Accept header is text/event-stream, so
+// we force it here.
+//
+// We don't override an already-set Accept (some callers may legitimately
+// ask for other content types); callers that expect streaming but omit
+// Accept get the streaming-friendly default, which matches what SSE
+// clients typically send anyway.
+type streamingRoundTripper struct {
+	inner http.RoundTripper
+}
+
+func (s streamingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get("Accept") == "" {
+		req = req.Clone(req.Context())
+		req.Header.Set("Accept", "text/event-stream")
+	}
+	return s.inner.RoundTrip(req)
 }

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"path/filepath"
 	runtimeDebug "runtime/debug"
 	"slices"
@@ -24,7 +25,6 @@ import (
 	"github.com/getlantern/radiance/common"
 	"github.com/getlantern/radiance/common/settings"
 	"github.com/getlantern/radiance/events"
-	"github.com/getlantern/radiance/kindling"
 	rlog "github.com/getlantern/radiance/log"
 	"github.com/getlantern/radiance/servers"
 
@@ -65,9 +65,13 @@ func (t *tunnel) start(options string, platformIfce libbox.PlatformInterface) (e
 	}
 	// Unbounded signaling (and any other outbound that reads this value) must
 	// dial freddie outside the user's VPN tunnel, otherwise it recursively
-	// re-enters itself. kindling's RoundTripper dials via the physical
-	// interface and blocks until kindling init completes.
-	baseCtx := lbA.ContextWithDirectTransport(box.BaseContext(), kindling.HTTPClient().Transport)
+	// re-enters itself. On macOS/iOS system extensions the PacketTunnelProvider
+	// process is the TUN's origin — its own outgoing connections bypass the
+	// TUN automatically — so a plain transport is enough to escape the loop.
+	// Kindling would also work but its fronted/race pipeline buffers streaming
+	// responses (breaks freddie's long-poll genesis subscription); a naked
+	// transport keeps the stream intact.
+	baseCtx := lbA.ContextWithDirectTransport(box.BaseContext(), http.DefaultTransport)
 	t.ctx, t.cancel = context.WithCancel(baseCtx)
 	defer func() {
 		if err != nil {


### PR DESCRIPTION
## Summary

Six commits on top of `refactor`, grouped into two unrelated concerns that happened to land on the same branch. The VPN-layer changes are the substantive ones — they're the runtime fix that lets Unbounded signaling reach freddie without self-routing through the VPN or getting eaten by kindling's non-streaming AMP transport. The env-propagation changes are smaller and mostly plumbing.

---

### Group 1 — VPN: make Unbounded signaling bypass the tunnel correctly

The Unbounded signaling path (freddie long-poll genesis-message stream) has two problems a naive implementation hits:

**Problem A: self-routing through the VPN.** When the host process is also serving the TUN, a regular HTTP dial from the same process lands back in the TUN, loops through the extension, and dies. The consumer FSM sees freddie unreachable and restarts forever.

**Problem B: non-streaming transport winning the race.** kindling races multiple transports (smart, fronted, AMP). AMP is not streamable — it buffers the full response body. If AMP wins the race for a genesis long-poll, the consumer FSM gets an immediate EOF with no genesis message, restarts, and never sends an offer. This is the bug that kept the consumer stuck in "No answer for genesis!" loops for hours during 2026-04-20 debugging.

**Fix:** inject a direct-transport via `ContextWithDirectTransport` (`b815123`) using kindling's own `HTTPClient().Transport`, then wrap it with a `streamingRoundTripper` that sets `Accept: text/event-stream` on outgoing freddie requests so kindling skips AMP and races only streamable transports (`78eb345`). kindling handles its own DNS and dialing — critically, we do **not** use 1.1.1.1/8.8.8.8 or any specific resolver, because those addresses are typically blocked in censored countries and would defeat the whole purpose. All freddie traffic goes through kindling's censorship-circumvention stack (fronted CDNs, smart dialer), just with AMP filtered out.

Intermediate "use plain transport" (`2d2521d`) was a debugging step, reverted in `8967fb6`. `eb42480` adds diagnostic counters that help catch this class of regression early next time.

Commits in order:
- `b815123` vpn: wire direct transport so unbounded signaling bypasses the tunnel
- `2d2521d` vpn: use plain transport for unbounded signaling direct path
- `8967fb6` Revert "vpn: use plain transport for unbounded signaling direct path"
- `78eb345` vpn: force streaming on unbounded signaling transport
- `eb42480` vpn: instrument streaming RoundTripper for debugging unbounded signaling

### Group 2 — Env propagation from main Lantern process to sandboxed system extension

Two changes that together let a dev run `RADIANCE_VERSION=9.1.1 RADIANCE_ENV=staging Lantern` and have those vars actually reach the macOS/iOS system extension:

1. **Flip `env.Get()` precedence** so OS env wins over the in-memory dotenv map. The package docstring always promised "environment variables > configurations set at .env file" but the code did the opposite — Flutter's persisted app-settings (pushed through `SetStagingEnv` / the `/env` IPC endpoint) silently clobbered a shell-set `RADIANCE_ENV`.
2. **Add `Options.EnvOverrides`** to `backend.NewLocalBackend` and apply via `os.Setenv` *before* `common.Init` runs. `common.Init` reads `RADIANCE_VERSION` once into `common.Version`, so any later write (via `/env` IPC or `env.Set`) is ignored by the header-fill path.

The single commit:
- `713149a` env: propagate shell env to sandboxed subprocesses + OS-env precedence

Closes #428. Companion PR in lantern wires the Swift main-app → extension plumbing that consumes `EnvOverrides`.

### Group 3 — Review fixes (smallest)

- `f945b50` review: don't mutate real RADIANCE_ENV in tests + fail fast on env-override errors (Copilot feedback)

---

## Test plan

- [x] `go test ./common/env/` passes (two precedence-guarding tests)
- [x] `go build -tags \"with_gvisor,with_quic,with_dhcp,with_wireguard,with_utls,with_acme,with_clash_api\" ./vpn/... ./backend/...` clean
- [x] End-to-end verified 2026-04-21: desktop Lantern built against this branch connects through widget → egress (Linode us-east); consumer state progresses to signaling-complete, datachannel opens, traffic flows through to the destination. Prior to the streaming wrapper, this bounced forever on \"No answer for genesis!\".
- [ ] Build Lantern against this branch + companion lantern PR, verify that \`RADIANCE_VERSION=9.1.1 RADIANCE_ENV=staging Lantern\` makes the system extension hit \`api.staging.iantem.io\` with \`X-Lantern-App-Version: 9.1.1\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)