### PR TITLE
ci: run Go workflow on every PR (not just PRs targeting main)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,9 +5,12 @@ name: Go
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "refactor" ]
+  # No branch filter here — run CI on every pull request regardless of target
+  # branch. This catches PRs aimed at refactor, feature branches, or anything
+  # else, not just main. The previous filter ("branches: [ main ]") silently
+  # skipped CI for PRs into refactor, which is our active dev branch.
   pull_request:
-    branches: [ "main" ]
 
 jobs:
 


### PR DESCRIPTION
## Summary

Drop the `pull_request: { branches: [main] }` filter in `.github/workflows/go.yml`. PRs targeting any branch other than `main` (notably `refactor`, our long-lived dev branch) were silently skipping CI. Exposed by #430, which I opened against `refactor` — no CI checks ran.

**New trigger matrix:**
- `push`: `main` + `refactor` (adds `refactor` — was `main` only)
- `pull_request`: any target branch (no filter)

## Why no filter on `pull_request`

Every PR represents a merge intent; it should always be checked. Filter here just reintroduces the bug we're fixing (some branch grows long-lived, PRs into it skip CI until someone remembers to add it to the list).

## After merge

PRs into `refactor` (like #430, #429) will start getting CI automatically. Pushing a new commit to an existing PR branch after this lands will trigger CI retroactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)