### PR TITLE
vpn: close MutableGroupManager on tunnel close

### DIFF
--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -203,6 +203,12 @@ func (t *tunnel) connect() (err error) {
 		return fmt.Errorf("creating mutable group manager: %w", err)
 	}
 	t.mutGrpMgr = mutGrpMgr
+	// MutableGroupManager owns a removalQueue goroutine that holds a reference to the
+	// sing-box OutboundManager. Without this close hook the goroutine survives a tunnel
+	// restart and keeps calling Remove on the already-closed manager, which panics inside
+	// sing-box-minimal (recovered as "panic during outbound/endpoint removal" spam every
+	// 5s). See Freshdesk #173359, #173158.
+	t.closers = append(t.closers, closerFunc(func() error { mutGrpMgr.Close(); return nil }))
 
 	slog.Info("Tunnel connection established")
 	return nil
@@ -557,6 +563,11 @@ func makeOutboundOptsMap(ctx context.Context, options string) *lsync.TypedMap[st
 	}
 	return &optsMap
 }
+
+// closerFunc adapts a plain function into an io.Closer.
+type closerFunc func() error
+
+func (f closerFunc) Close() error { return f() }
 
 func contextDone(ctx context.Context) bool {
 	select {

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -208,7 +208,13 @@ func (t *tunnel) connect() (err error) {
 	// restart and keeps calling Remove on the already-closed manager, which panics inside
 	// sing-box-minimal (recovered as "panic during outbound/endpoint removal" spam every
 	// 5s). See Freshdesk #173359, #173158.
-	t.closers = append(t.closers, closerFunc(func() error { mutGrpMgr.Close(); return nil }))
+	//
+	// Prepend so this closer runs before libbox/sing-box managers: t.close() iterates
+	// t.closers in append order, and we want the removalQueue goroutine to exit before
+	// the OutboundManager it reads from is torn down.
+	t.closers = append([]io.Closer{
+		closerFunc(func() error { mutGrpMgr.Close(); return nil }),
+	}, t.closers...)
 
 	slog.Info("Tunnel connection established")
 	return nil

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -203,15 +203,7 @@ func (t *tunnel) connect() (err error) {
 		return fmt.Errorf("creating mutable group manager: %w", err)
 	}
 	t.mutGrpMgr = mutGrpMgr
-	// MutableGroupManager owns a removalQueue goroutine that holds a reference to the
-	// sing-box OutboundManager. Without this close hook the goroutine survives a tunnel
-	// restart and keeps calling Remove on the already-closed manager, which panics inside
-	// sing-box-minimal (recovered as "panic during outbound/endpoint removal" spam every
-	// 5s). See Freshdesk #173359, #173158.
-	//
-	// Prepend so this closer runs before libbox/sing-box managers: t.close() iterates
-	// t.closers in append order, and we want the removalQueue goroutine to exit before
-	// the OutboundManager it reads from is torn down.
+	// Prepend: mgm's removalQueue reads from libbox-managed state, so close it first.
 	t.closers = append([]io.Closer{
 		closerFunc(func() error { mutGrpMgr.Close(); return nil }),
 	}, t.closers...)
@@ -570,7 +562,6 @@ func makeOutboundOptsMap(ctx context.Context, options string) *lsync.TypedMap[st
 	return &optsMap
 }
 
-// closerFunc adapts a plain function into an io.Closer.
 type closerFunc func() error
 
 func (f closerFunc) Close() error { return f() }

--- a/vpn/tunnel_test.go
+++ b/vpn/tunnel_test.go
@@ -163,29 +163,17 @@ func testConnection(t *testing.T, opts sbO.Options) *tunnel {
 	return tun
 }
 
-// TestTunnelClose_ClosesMutableGroupManager verifies that the MutableGroupManager owned
-// by a tunnel is closed when the tunnel closes. This prevents the MutableGroupManager's
-// removalQueue goroutine from outliving the tunnel and firing Remove on the already-
-// closed sing-box OutboundManager, which panics inside sing-box-minimal.
-//
-// Regression: see Freshdesk #173359 and #173158 — users toggling Smart Routing
-// triggered a tunnel restart; the stale removalQueue from the previous tunnel kept
-// panicking every 5s as it drained its pending list against the dead Manager.
 func TestTunnelClose_ClosesMutableGroupManager(t *testing.T) {
 	testutil.SetPathsForTesting(t)
 	testOpts, _, err := testBoxOptions(settings.GetString(settings.DataPathKey))
-	require.NoError(t, err, "failed to get test box options")
+	require.NoError(t, err)
 
 	tun := testConnection(t, *testOpts)
-	require.NotNil(t, tun.mutGrpMgr, "tunnel should own a MutableGroupManager after start")
+	require.NotNil(t, tun.mutGrpMgr)
 	mgm := tun.mutGrpMgr
 
-	require.NoError(t, tun.close(), "tunnel close should succeed")
+	require.NoError(t, tun.close())
 
-	// After tun.close(), the MutableGroupManager must be closed too. Its mutating
-	// methods guard on m.closed and return ErrIsClosed; if the tunnel forgot to
-	// register mgm as a closer, this check returns nil and the test fails.
 	err = mgm.RemoveFromGroup(servers.SGLantern, "some-unknown-tag")
-	assert.ErrorIs(t, err, lbgroups.ErrIsClosed,
-		"MutableGroupManager must be closed when tunnel closes, otherwise its removalQueue outlives the tunnel")
+	assert.ErrorIs(t, err, lbgroups.ErrIsClosed)
 }

--- a/vpn/tunnel_test.go
+++ b/vpn/tunnel_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/getlantern/lantern-box/adapter"
+	"github.com/getlantern/lantern-box/adapter/groups"
 
 	"github.com/getlantern/radiance/common/settings"
 	"github.com/getlantern/radiance/internal/testutil"
@@ -160,4 +161,31 @@ func testConnection(t *testing.T, opts sbO.Options) *tunnel {
 
 	assert.Equal(t, ipc.Connected, tun.Status(), "tunnel should be running")
 	return tun
+}
+
+// TestTunnelClose_ClosesMutableGroupManager verifies that the MutableGroupManager owned
+// by a tunnel is closed when the tunnel closes. This prevents the MutableGroupManager's
+// removalQueue goroutine from outliving the tunnel and firing Remove on the already-
+// closed sing-box OutboundManager, which panics inside sing-box-minimal.
+//
+// Regression: see Freshdesk #173359 and #173158 — users toggling Smart Routing
+// triggered a tunnel restart; the stale removalQueue from the previous tunnel kept
+// panicking every 5s as it drained its pending list against the dead Manager.
+func TestTunnelClose_ClosesMutableGroupManager(t *testing.T) {
+	testutil.SetPathsForTesting(t)
+	testOpts, _, err := testBoxOptions(settings.GetString(settings.DataPathKey))
+	require.NoError(t, err, "failed to get test box options")
+
+	tun := testConnection(t, *testOpts)
+	require.NotNil(t, tun.mutGrpMgr, "tunnel should own a MutableGroupManager after start")
+	mgm := tun.mutGrpMgr
+
+	require.NoError(t, tun.close(), "tunnel close should succeed")
+
+	// After tun.close(), the MutableGroupManager must be closed too. Its mutating
+	// methods guard on m.closed and return ErrIsClosed; if the tunnel forgot to
+	// register mgm as a closer, this check returns nil and the test fails.
+	err = mgm.RemoveFromGroup(servers.SGLantern, "some-unknown-tag")
+	assert.ErrorIs(t, err, groups.ErrIsClosed,
+		"MutableGroupManager must be closed when tunnel closes, otherwise its removalQueue outlives the tunnel")
 }

--- a/vpn/tunnel_test.go
+++ b/vpn/tunnel_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/getlantern/lantern-box/adapter"
-	"github.com/getlantern/lantern-box/adapter/groups"
+	lbgroups "github.com/getlantern/lantern-box/adapter/groups"
 
 	"github.com/getlantern/radiance/common/settings"
 	"github.com/getlantern/radiance/internal/testutil"
@@ -186,6 +186,6 @@ func TestTunnelClose_ClosesMutableGroupManager(t *testing.T) {
 	// methods guard on m.closed and return ErrIsClosed; if the tunnel forgot to
 	// register mgm as a closer, this check returns nil and the test fails.
 	err = mgm.RemoveFromGroup(servers.SGLantern, "some-unknown-tag")
-	assert.ErrorIs(t, err, groups.ErrIsClosed,
+	assert.ErrorIs(t, err, lbgroups.ErrIsClosed,
 		"MutableGroupManager must be closed when tunnel closes, otherwise its removalQueue outlives the tunnel")
 }


### PR DESCRIPTION
## Summary

Freshdesk #173359 and #173158 (Russia, Android 9.0.25 beta) both showed hundreds of recovered-panic log lines every 5 s:

```
ERROR (*removalQueue).checkPending.func1 manager.go:355
  "panic during outbound/endpoint removal error invalid inbound index"
```

Root cause is a lifecycle bug in radiance, stacked on top of a latent Close-order bug in sing-box-minimal.

### The race

`MutableGroupManager` owns a `removalQueue` goroutine (5 s ticker) that holds a reference to the sing-box `OutboundManager` it wraps. When the tunnel tears down (e.g. `SetSmartRouting` / `SetFullTunnel` / any `VPNClient.Restart`), `tunnel.close()` iterates `t.closers`, which contains `lb` (libbox) but **not** `mgm`. libbox closes cleanly and cascades to `outbound.Manager.Close()`. But mgm is never closed — its queue goroutine survives into the new tunnel, still pointing at the old, already-closed Manager.

sing-box-minimal `outbound.Manager.Close()` (adapter/outbound/manager.go:160-182) nils `m.outbounds` but leaves `m.outboundByTag` populated. When the stale removalQueue fires `outMgr.Remove(tag)`, the map-lookup says `found=true`, `delete(map,tag)` runs, `common.Index(m.outbounds, …)` returns `-1` (slice is nil), and Remove panics on `manager.go:218 "invalid inbound index"`.

[lantern-box #80](https://github.com/getlantern/lantern-box/pull/80) (d187a54, Jan 2026) wrapped the removal loop in `defer recover()` so the process doesn't die — but it did nothing to stop the cycle. The pre-check `outMgr.Outbound(tag)` only consults `outboundByTag`, which `Close()` didn't clear, so the check passes, Remove panics, recovery logs it, and on the next tick the same mechanism fires for a different pending tag.

### The fix

Register `mgm.Close()` as a tunnel closer so the queue goroutine exits when the tunnel does.

```go
t.closers = append(t.closers, closerFunc(func() error { mutGrpMgr.Close(); return nil }))
```

This addresses the radiance lifecycle bug. The defensive sing-box-minimal fix (clearing `outboundByTag` / `dependByTag` / `defaultOutbound` in `Close()`) should follow in a separate PR against `getlantern/sing-box-minimal`; with this change, the bad code path becomes unreachable in practice.

### Evidence from logs (ticket #173359)

```
08:20:20.591  SetSmartRouting enabled=false
08:20:20.593  Restarting tunnel                ← triggers tunnel.close()
08:20:20.827  Failed best-effort removal from URL test group: "group is closed"
08:20:20.836  removing outbound tag hysteria2-...-a3d31236...
08:20:20.836  panic during outbound/endpoint removal error invalid inbound index
08:20:25.840  outbound already removed tag hysteria2-...-a3d31236...  ← next tick
08:20:25.840  removing outbound tag reflex-...-99173228...
08:20:25.840  panic during outbound/endpoint removal error invalid inbound index
... 5 more panics in a row, then silence
```

Same pattern in #173158 (3 recovered panics).

### Related

- Companion branch: `fisk/fix-mutGrpMgr-close-refactor` (same fix for the `refactor` branch)
- Freshdesk: https://lantern.freshdesk.com/a/tickets/173359, https://lantern.freshdesk.com/a/tickets/173158
- Follow-up PR to file against `getlantern/sing-box-minimal`: make `Close()` clear `outboundByTag`/`dependByTag`/`defaultOutbound` for defensive robustness.

## Test plan

- [x] `go build ./...` on main branch
- [x] `go test ./vpn/` — new `TestTunnelClose_ClosesMutableGroupManager` passes with the fix, fails without it (verified by stashing and re-running; without the fix `RemoveFromGroup` returns "group lantern not found" instead of `ErrIsClosed`)
- [x] Existing `TestConnection`, `TestUpdateServers`, `TestTunnelClose_*` still pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)