### PR TITLE
vpn: close MutableGroupManager on tunnel close (refactor)

### DIFF
--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -215,6 +215,12 @@ func (t *tunnel) connect() (err error) {
 		return fmt.Errorf("creating mutable group manager: %w", err)
 	}
 	t.mutGrpMgr = mutGrpMgr
+	// MutableGroupManager owns a removalQueue goroutine that holds a reference to the
+	// sing-box OutboundManager. Without this close hook the goroutine survives a tunnel
+	// restart and keeps calling Remove on the already-closed manager, which panics inside
+	// sing-box-minimal (recovered as "panic during outbound/endpoint removal" spam every
+	// 5s). See Freshdesk #173359, #173158.
+	t.closers = append(t.closers, closerFunc(func() error { mutGrpMgr.Close(); return nil }))
 
 	slog.Info("Tunnel connection established")
 	return nil
@@ -572,6 +578,11 @@ func contextDone(ctx context.Context) bool {
 		return false
 	}
 }
+
+// closerFunc adapts a plain function into an io.Closer.
+type closerFunc func() error
+
+func (f closerFunc) Close() error { return f() }
 
 // streamingRoundTripper defaults Accept to text/event-stream so kindling's
 // race pipeline drops non-streamable transports (AMP) that would otherwise

--- a/vpn/tunnel_test.go
+++ b/vpn/tunnel_test.go
@@ -6,8 +6,12 @@ import (
 
 	lsync "github.com/getlantern/common/sync"
 	box "github.com/getlantern/lantern-box"
+	"github.com/getlantern/lantern-box/adapter/groups"
+	sbA "github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/experimental/clashapi/trafficontrol"
 	O "github.com/sagernet/sing-box/option"
 	"github.com/sagernet/sing/common/json"
+	"github.com/sagernet/sing/common/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -147,4 +151,37 @@ func TestContextDone(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	assert.True(t, contextDone(ctx))
+}
+
+type fakeConnMgr struct{}
+
+func (fakeConnMgr) Connections() []trafficontrol.TrackerMetadata { return nil }
+
+// TestTunnelClose_ClosesMutableGroupManager verifies that when a tunnel closes, the
+// MutableGroupManager registered via t.closers is closed too. If the tunnel forgets
+// to register this closer, the mgm's removalQueue goroutine outlives the tunnel and
+// fires Remove on the already-closed sing-box OutboundManager, which panics inside
+// sing-box-minimal. Regression: Freshdesk #173359, #173158.
+func TestTunnelClose_ClosesMutableGroupManager(t *testing.T) {
+	// Minimal MutableGroupManager — nil outbound/endpoint managers are safe here because
+	// RemoveFromGroup's closed-check runs before touching them, and we never enqueue
+	// anything so the removalQueue goroutine is never started.
+	mgm := groups.NewMutableGroupManager(
+		logger.NOP(),
+		sbA.OutboundManager(nil),
+		sbA.EndpointManager(nil),
+		fakeConnMgr{},
+		nil,
+	)
+
+	tun := &tunnel{}
+	tun.status.Store(Connected)
+	tun.mutGrpMgr = mgm
+	tun.closers = append(tun.closers, closerFunc(func() error { mgm.Close(); return nil }))
+
+	require.NoError(t, tun.close())
+
+	err := mgm.RemoveFromGroup("some-group", "some-tag")
+	assert.ErrorIs(t, err, groups.ErrIsClosed,
+		"MutableGroupManager must be closed when tunnel closes; otherwise its removalQueue outlives the tunnel and panics against the stale outbound manager")
 }


### PR DESCRIPTION
## Summary

Refactor-branch companion to #TBD (same fix against `main`).

Freshdesk #173359 and #173158 (Russia, Android 9.0.25 beta) both showed hundreds of recovered-panic log lines every 5 s:

```
ERROR (*removalQueue).checkPending.func1 manager.go:355
  "panic during outbound/endpoint removal error invalid inbound index"
```

Root cause is a lifecycle bug: `MutableGroupManager` owns a `removalQueue` goroutine (5 s ticker) that holds a reference to the sing-box `OutboundManager` it wraps. When the tunnel tears down (e.g. `SetSmartRouting` / `SetFullTunnel` / any `VPNClient.Restart`), `tunnel.close()` iterates `t.closers`, which contains `lb` (libbox) but **not** `mgm`. libbox closes cleanly and cascades to `outbound.Manager.Close()`. But mgm is never closed — its queue goroutine survives into the new tunnel, still pointing at the old, already-closed Manager.

sing-box-minimal `outbound.Manager.Close()` nils `m.outbounds` but leaves `m.outboundByTag` populated. When the stale removalQueue fires `outMgr.Remove(tag)`, the map lookup says `found=true`, `common.Index(m.outbounds, …)` returns `-1`, and Remove panics on `manager.go:218 "invalid inbound index"`. [lantern-box #80](https://github.com/getlantern/lantern-box/pull/80) wrapped it in `defer recover()` but the cycle continues every 5 s until the pending list drains.

## The fix

Register `mgm.Close()` as a tunnel closer so the queue goroutine exits when the tunnel does.

```go
t.closers = append(t.closers, closerFunc(func() error { mutGrpMgr.Close(); return nil }))
```

## Difference from the main-branch PR

Same fix, adapted to `refactor`'s tunnel.go (line 217 vs. line 205). The test on this branch is a unit-level assertion that `tun.close()` closes mgm; the integration-style test that exercises `tun.start()` end-to-end is in the main-branch PR, since `refactor`'s test harness doesn't currently include a `testConnection` helper.

## Follow-up (separate PR against getlantern/sing-box-minimal)

Defensive fix: `Close()` should clear `m.outboundByTag`, `m.dependByTag`, and `m.defaultOutbound` alongside nilling `m.outbounds`. With this radiance fix in place the bad code path becomes unreachable in practice, but the invariant between slice and map should hold across Close unconditionally.

## Freshdesk

- https://lantern.freshdesk.com/a/tickets/173359
- https://lantern.freshdesk.com/a/tickets/173158

## Test plan

- [x] `go build ./vpn/...` on refactor branch
- [x] `go test ./vpn/` — new `TestTunnelClose_ClosesMutableGroupManager` passes
- [x] Existing `TestTunnelStatus`, `TestTunnelClose_*`, `TestRemoveDuplicates*` still pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)