### PR TITLE
vpn: close MutableGroupManager on tunnel close (cherry-pick of #432 to refactor)

### DIFF
--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -215,6 +215,10 @@ func (t *tunnel) connect() (err error) {
 		return fmt.Errorf("creating mutable group manager: %w", err)
 	}
 	t.mutGrpMgr = mutGrpMgr
+	// Prepend: mgm's removalQueue reads from libbox-managed state, so close it first.
+	t.closers = append([]io.Closer{
+		closerFunc(func() error { mutGrpMgr.Close(); return nil }),
+	}, t.closers...)
 
 	slog.Info("Tunnel connection established")
 	return nil
@@ -563,6 +567,10 @@ func makeOutboundOptsMap(ctx context.Context, options string) *lsync.TypedMap[st
 	}
 	return &optsMap
 }
+
+type closerFunc func() error
+
+func (f closerFunc) Close() error { return f() }
 
 func contextDone(ctx context.Context) bool {
 	select {


### PR DESCRIPTION
Cherry-picks [#432](https://github.com/getlantern/radiance/pull/432) (merged to main at 07b948a) onto refactor.

## Why

The tunnel's `MutableGroupManager` owns a removalQueue goroutine that holds a reference to the sing-box `OutboundManager`. Before this change, tearing down the tunnel closed libbox first and left the removalQueue goroutine reading from now-invalid state. The 8-line fix prepends an explicit `mutGrpMgr.Close()` to the closer chain so it shuts down before libbox.

## Delta vs #432 on main

The test changes in #432 (16 lines in `tunnel_test.go`) use test helpers that don't exist on refactor yet (`testBoxOptions(dataPath)` expects `*testing.T`, `testConnection` undefined, `servers.SGLantern` undefined). I dropped the test portion of the cherry-pick; it'll land naturally when refactor next merges with main. Production change is byte-identical to main.

## Test plan

- [x] `GOWORK=off go vet ./vpn/...` clean
- [x] `GOWORK=off go test -tags with_clash_api ./vpn/` passes
- [ ] CI