### PR TITLE
backend: treat ConnectVPN while connected as a server swap

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -647,6 +647,13 @@ func (r *LocalBackend) ConnectVPN(tag string) error {
 			return fmt.Errorf("no server found with tag %s", tag)
 		}
 	}
+	// If the tunnel is already up, treat ConnectVPN as a request to switch the
+	// active outbound. The UI calls into this path when the user picks a new
+	// server (or Smart Routing) while already connected, and expects a seamless
+	// swap instead of a "tunnel already connected" rejection.
+	if r.vpnClient.Status() == vpn.Connected {
+		return r.selectServer(tag)
+	}
 	bOptions := r.getBoxOptions()
 	if err := r.vpnClient.Connect(bOptions); err != nil {
 		return fmt.Errorf("failed to connect VPN: %w", err)


### PR DESCRIPTION
## Summary
- When the UI picks a new server or Smart Routing while the tunnel is already up, it calls `ConnectVPN` with the new tag expecting a seamless outbound swap. The backend was unconditionally invoking `VPNClient.Connect`, which returns `ErrTunnelAlreadyConnected`, surfacing to the user as `start service failed: ipc: status 500: failed to connect VPN: tunnel already connected`.
- Short-circuits to `selectServer` when `Status() == Connected`, so the active outbound switches in place without tearing down and rebuilding the tunnel.

## Context
Reported in [getlantern/engineering#3291](https://github.com/getlantern/engineering/issues/3291) against Windows 9.0.29 build 481 (Freshdesk #173656). Log evidence shows seven occurrences of `error="tunnel already connected"` during Derek's test session every time he picked a server while connected.

The Flutter side already documents the expected behavior — see the comment in `lib/features/vpn/server_selection.dart:228-233`:

> Already connected — switch to auto via connectToServer so the native side handles the reconnect instead of rejecting a duplicate start.

This PR makes the native side actually handle that.

## Test plan
- [ ] Connect to VPN, then click Smart Routing from server selection screen → expect outbound to swap to auto, no error
- [ ] Connect to VPN, then pick a different server → expect outbound swap, no error
- [ ] Start disconnected, click Connect → still uses the full connect path
- [ ] Restart-required settings changes (e.g. ad-block toggle) still go through `RestartVPN` and rebuild the tunnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)