### PR TITLE
vpn: heal tunnels stuck in Restarting on Connect

### DIFF
--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -117,8 +117,18 @@ func (c *VPNClient) Connect(boxOptions BoxOptions) error {
 		switch status := c.tunnel.Status(); status {
 		case Connected:
 			return ErrTunnelAlreadyConnected
-		case Restarting, Connecting, Disconnecting:
+		case Connecting, Disconnecting:
 			return fmt.Errorf("tunnel is currently %s", status)
+		case Restarting:
+			// Restart() sets this status before delegating to the platform
+			// (platformIfce.RestartService) and returns immediately; on Android
+			// the platform may tear down the VPN service before the restart
+			// completes, in which case nothing ever transitions the tunnel
+			// back out of Restarting. If Connect is being called, either that
+			// restart was lost or the caller wants a fresh connection anyway
+			// — clean up and proceed rather than wedging the client.
+			c.logger.Warn("tunnel stuck in Restarting, cleaning up and reconnecting")
+			c.tunnel = nil
 		case Disconnected, ErrorStatus:
 			// Clean up the stale tunnel so we can reconnect.
 			c.tunnel = nil

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -127,7 +127,10 @@ func (c *VPNClient) Connect(boxOptions BoxOptions) error {
 			// back out of Restarting. If Connect is being called, either that
 			// restart was lost or the caller wants a fresh connection anyway
 			// — clean up and proceed rather than wedging the client.
+			// Emit a Disconnected event so event-driven consumers transition
+			// out of Restarting even if Connect fails before start() runs.
 			c.logger.Warn("tunnel stuck in Restarting, cleaning up and reconnecting")
+			c.tunnel.setStatus(Disconnected, nil)
 			c.tunnel = nil
 		case Disconnected, ErrorStatus:
 			// Clean up the stale tunnel so we can reconnect.

--- a/vpn/vpn_test.go
+++ b/vpn/vpn_test.go
@@ -99,7 +99,7 @@ func TestConnect_AlreadyConnected(t *testing.T) {
 }
 
 func TestConnect_TransientStates(t *testing.T) {
-	for _, status := range []VPNStatus{Restarting, Connecting, Disconnecting} {
+	for _, status := range []VPNStatus{Connecting, Disconnecting} {
 		t.Run(string(status), func(t *testing.T) {
 			c := NewVPNClient(t.TempDir(), rlog.NoOpLogger(), nil)
 			tun := &tunnel{}
@@ -114,7 +114,12 @@ func TestConnect_TransientStates(t *testing.T) {
 }
 
 func TestConnect_CleansUpStaleTunnel(t *testing.T) {
-	for _, status := range []VPNStatus{Disconnected, ErrorStatus} {
+	// Restarting is included because Restart() delegates to the platform and
+	// the platform may tear down the service before completing the restart
+	// (Android onDestroy without stopVPN), leaving the tunnel wedged in
+	// Restarting. Connect should be able to recover by cleaning up and
+	// starting fresh.
+	for _, status := range []VPNStatus{Disconnected, ErrorStatus, Restarting} {
 		t.Run(string(status), func(t *testing.T) {
 			c := NewVPNClient(t.TempDir(), rlog.NoOpLogger(), nil)
 			tun := &tunnel{}

--- a/vpn/vpn_test.go
+++ b/vpn/vpn_test.go
@@ -5,11 +5,13 @@ import (
 	"log/slog"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/sagernet/sing-box/experimental/libbox"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/getlantern/radiance/events"
 	rlog "github.com/getlantern/radiance/log"
 	"github.com/getlantern/radiance/servers"
 )
@@ -133,6 +135,41 @@ func TestConnect_CleansUpStaleTunnel(t *testing.T) {
 			// The tunnel should have been nilled out before buildOptions was called
 			assert.Contains(t, err.Error(), "no outbounds")
 		})
+	}
+}
+
+func TestConnect_RestartingEmitsDisconnectedEvent(t *testing.T) {
+	// When a stale tunnel is cleaned up from the Restarting state, we must
+	// emit a Disconnected status event so event-driven consumers transition
+	// out of Restarting even if Connect fails before start() runs.
+	c := NewVPNClient(t.TempDir(), rlog.NoOpLogger(), nil)
+	tun := &tunnel{}
+	tun.status.Store(Restarting)
+	c.tunnel = tun
+
+	received := make(chan StatusUpdateEvent, 4)
+	sub := events.Subscribe(func(evt StatusUpdateEvent) {
+		received <- evt
+	})
+	defer events.Unsubscribe(sub)
+
+	// Connect will fail at buildOptions (no outbounds), so tunnel.start() never
+	// runs. Without the explicit setStatus call, no event would be emitted and
+	// subscribers would remain stuck on whatever the last event was.
+	err := c.Connect(BoxOptions{BasePath: t.TempDir()})
+	require.Error(t, err)
+
+	var sawDisconnected bool
+	deadline := time.After(time.Second)
+	for !sawDisconnected {
+		select {
+		case evt := <-received:
+			if evt.Status == Disconnected {
+				sawDisconnected = true
+			}
+		case <-deadline:
+			t.Fatal("expected Disconnected StatusUpdateEvent, none received")
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

`Restart()` on platforms with a `platformIfce` is a two-step handoff: it sets status to `Restarting` then calls `platformIfce.RestartService()` and returns immediately. The platform is supposed to tear down the VPN service and spin up a new one, which goes through Connect again.

On Android, `LanternVpnService.onDestroy` only calls `Mobile.stopVPN()` when `Mobile.isVPNConnected()` returns true — and `isVPNConnected` is `status == Connected`. When the tunnel is already in `Restarting`, onDestroy skips stopVPN (logs `Skipping stopVPN — VPN tunnel was never started`) and the radiance tunnel is left non-nil with status `Restarting`. **Nothing ever transitions it out.** The next Connect attempt hits:

```go
case Restarting, Connecting, Disconnecting:
    return fmt.Errorf("tunnel is currently %s", status)
```

…and returns `tunnel is currently Restarting`, which surfaces to the user as `Error in VPN operation` with no recovery short of killing the process. This explains the Android symptoms from Derek's refactor-build testing in [getlantern/engineering#3297](https://github.com/getlantern/engineering/issues/3297) — issue 1 (Smart Location while connected), issue 2 (routing-mode toggle while connected), and issue 3 (after pro login, can't connect): in each case, something triggered a `Restart`, the Android service died before the restart completed, and the tunnel was wedged.

Confirmed in Freshdesk #173681 logs:
- `15:17:34` `VPNClient.Restart` called → `Tunnel restarted successfully` (platformIfce delegated, no new init follows)
- `15:19:10` `onDestroy — radianceConnected=true vpnConnected=false` → `Skipping stopVPN — VPN tunnel was never started`
- `15:21:48` Connect → POST `/vpn/connect` → error 2ms later → `Error in VPN operation (start_vpn)` to the UI

## Change

Treat `Restarting` the same as `Disconnected` / `ErrorStatus` in the stale-tunnel cleanup branch. `Connecting` / `Disconnecting` still return the transient-state error because those are driven by an active goroutine in this process and indicate a real in-flight operation.

Rationale: the `Restarting` state is load-bearing only while an active platform restart is in progress. Once `platformIfce.RestartService()` returns, nothing in radiance is working on it — the platform either completes the restart (which goes through Connect and resets status) or doesn't. If the user calls Connect, the intent is "I want a connection now," and the right answer is to clean up and start fresh rather than refuse forever.

## Test plan
- [x] `TestConnect_CleansUpStaleTunnel` extended to cover `Restarting` ✓
- [x] `TestConnect_TransientStates` trimmed to `Connecting` / `Disconnecting` ✓
- [x] `go test ./vpn/...` passes ✓
- [ ] Android repro: trigger a settings change that fires `Restart` while connected, force-stop the service, reconnect — should now succeed instead of wedging

## Related
- [getlantern/engineering#3297](https://github.com/getlantern/engineering/issues/3297) — Android refactor testing (issues 1–3)
- Freshdesk #173681 — log evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)