### PR TITLE
vpn: instrument tunnel.start phases + TunnelService.Restart

### DIFF
--- a/vpn/service.go
+++ b/vpn/service.go
@@ -12,6 +12,9 @@ import (
 	"sync"
 
 	"github.com/sagernet/sing-box/experimental/clashapi"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/getlantern/radiance/common/settings"
 	"github.com/getlantern/radiance/internal"
@@ -83,7 +86,7 @@ func (s *TunnelService) start(ctx context.Context, options string) error {
 	t := tunnel{
 		dataPath: path,
 	}
-	if err := t.start(options, s.platformIfce); err != nil {
+	if err := t.start(ctx, options, s.platformIfce); err != nil {
 		return fmt.Errorf("failed to start tunnel: %w", err)
 	}
 	s.tunnel = &t
@@ -122,6 +125,10 @@ func (s *TunnelService) close() error {
 // Restart closes and restarts the tunnel if it is currently running. Returns an error if the tunnel
 // is not running or restart fails.
 func (s *TunnelService) Restart(ctx context.Context, options string) error {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "TunnelService.Restart",
+		trace.WithAttributes(attribute.Int("options_size", len(options))))
+	defer span.End()
+
 	s.mu.Lock()
 	if s.tunnel == nil {
 		s.mu.Unlock()
@@ -134,6 +141,7 @@ func (s *TunnelService) Restart(ctx context.Context, options string) error {
 
 	s.logger.Info("Restarting tunnel")
 	if s.platformIfce != nil {
+		span.SetAttributes(attribute.String("path", "platform_ifce"))
 		s.mu.Unlock()
 		if err := s.platformIfce.RestartService(); err != nil {
 			s.logger.Error("Failed to restart tunnel via platform interface", "error", err)
@@ -141,6 +149,7 @@ func (s *TunnelService) Restart(ctx context.Context, options string) error {
 		}
 		return nil
 	}
+	span.SetAttributes(attribute.String("path", "direct"))
 
 	defer s.mu.Unlock()
 	if err := s.close(); err != nil {

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sagernet/sing/service"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
 	lcommon "github.com/getlantern/common"
@@ -154,13 +155,17 @@ func (t *tunnel) init(ctx context.Context, options string, platformIfce libbox.P
 	return nil
 }
 
-// traceSpan wraps fn in a child span of the caller's context. Captures duration
-// even when fn returns an error; span.RecordError isn't called because the
-// caller already wraps the error with context before returning.
+// traceSpan wraps fn in a child span of the caller's context and records any
+// error on the child span so failures show up per-phase in the trace.
 func traceSpan(ctx context.Context, name string, fn func() error) error {
 	_, span := otel.Tracer(tracerName).Start(ctx, name)
 	defer span.End()
-	return fn()
+	err := fn()
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	return err
 }
 
 func newClientContextInjector(outboundMgr adapter.OutboundManager, dataPath string) *clientcontext.ClientContextInjector {

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -12,21 +12,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	lcommon "github.com/getlantern/common"
-	lsync "github.com/getlantern/common/sync"
-	box "github.com/getlantern/lantern-box"
-
-	lbA "github.com/getlantern/lantern-box/adapter"
-	"github.com/getlantern/lantern-box/adapter/groups"
-	lblog "github.com/getlantern/lantern-box/log"
-	"github.com/getlantern/lantern-box/tracker/clientcontext"
-
-	"github.com/getlantern/radiance/common"
-	"github.com/getlantern/radiance/common/settings"
-	"github.com/getlantern/radiance/internal"
-	"github.com/getlantern/radiance/servers"
-	"github.com/getlantern/radiance/vpn/ipc"
-
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/common/urltest"
 	"github.com/sagernet/sing-box/experimental/clashapi"
@@ -35,6 +20,22 @@ import (
 	O "github.com/sagernet/sing-box/option"
 	"github.com/sagernet/sing/common/json"
 	"github.com/sagernet/sing/service"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	lcommon "github.com/getlantern/common"
+	lsync "github.com/getlantern/common/sync"
+	box "github.com/getlantern/lantern-box"
+	lbA "github.com/getlantern/lantern-box/adapter"
+	"github.com/getlantern/lantern-box/adapter/groups"
+	lblog "github.com/getlantern/lantern-box/log"
+	"github.com/getlantern/lantern-box/tracker/clientcontext"
+	"github.com/getlantern/radiance/common"
+	"github.com/getlantern/radiance/common/settings"
+	"github.com/getlantern/radiance/internal"
+	"github.com/getlantern/radiance/servers"
+	"github.com/getlantern/radiance/vpn/ipc"
 )
 
 type tunnel struct {
@@ -57,17 +58,24 @@ type tunnel struct {
 	closers []io.Closer
 }
 
-func (t *tunnel) start(options string, platformIfce libbox.PlatformInterface) error {
+func (t *tunnel) start(ctx context.Context, options string, platformIfce libbox.PlatformInterface) error {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "tunnel.start",
+		trace.WithAttributes(
+			attribute.Int("options_size", len(options)),
+			attribute.String("platform", common.Platform),
+		))
+	defer span.End()
+
 	t.status.Store(ipc.Connecting)
 	t.ctx, t.cancel = context.WithCancel(box.BaseContext())
 
-	if err := t.init(options, platformIfce); err != nil {
+	if err := t.init(ctx, options, platformIfce); err != nil {
 		t.close()
 		slog.Error("Failed to initialize tunnel", "error", err)
 		return fmt.Errorf("initializing tunnel: %w", err)
 	}
 
-	if err := t.connect(); err != nil {
+	if err := t.connect(ctx); err != nil {
 		t.close()
 		slog.Error("Failed to connect tunnel", "error", err)
 		return fmt.Errorf("connecting tunnel: %w", err)
@@ -77,7 +85,10 @@ func (t *tunnel) start(options string, platformIfce libbox.PlatformInterface) er
 	return nil
 }
 
-func (t *tunnel) init(options string, platformIfce libbox.PlatformInterface) error {
+func (t *tunnel) init(ctx context.Context, options string, platformIfce libbox.PlatformInterface) error {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "tunnel.init")
+	defer span.End()
+
 	slog.Log(nil, internal.LevelTrace, "Initializing tunnel")
 
 	// setup libbox service
@@ -94,7 +105,9 @@ func (t *tunnel) init(options string, platformIfce libbox.PlatformInterface) err
 	}
 
 	slog.Log(nil, internal.LevelTrace, "Setting up libbox", "setup_options", setupOpts)
-	if err := libbox.Setup(setupOpts); err != nil {
+	if err := traceSpan(ctx, "libbox.Setup", func() error {
+		return libbox.Setup(setupOpts)
+	}); err != nil {
 		return fmt.Errorf("setup libbox: %w", err)
 	}
 
@@ -102,8 +115,12 @@ func (t *tunnel) init(options string, platformIfce libbox.PlatformInterface) err
 	service.MustRegister[sblog.Factory](t.ctx, t.logFactory)
 
 	slog.Log(nil, internal.LevelTrace, "Creating libbox service")
-	lb, err := libbox.NewServiceWithContext(t.ctx, options, platformIfce)
-	if err != nil {
+	var lb *libbox.BoxService
+	if err := traceSpan(ctx, "libbox.NewServiceWithContext", func() error {
+		var err error
+		lb, err = libbox.NewServiceWithContext(t.ctx, options, platformIfce)
+		return err
+	}); err != nil {
 		return fmt.Errorf("create libbox service: %w", err)
 	}
 
@@ -119,7 +136,9 @@ func (t *tunnel) init(options string, platformIfce libbox.PlatformInterface) err
 	t.lbService = lb
 
 	history := service.PtrFromContext[urltest.HistoryStorage](t.ctx)
-	if err := loadURLTestHistory(history, filepath.Join(dataPath, urlTestHistoryFileName)); err != nil {
+	if err := traceSpan(ctx, "loadURLTestHistory", func() error {
+		return loadURLTestHistory(history, filepath.Join(dataPath, urlTestHistoryFileName))
+	}); err != nil {
 		return fmt.Errorf("load urltest history: %w", err)
 	}
 
@@ -133,6 +152,15 @@ func (t *tunnel) init(options string, platformIfce libbox.PlatformInterface) err
 
 	slog.Info("Tunnel initializated")
 	return nil
+}
+
+// traceSpan wraps fn in a child span of the caller's context. Captures duration
+// even when fn returns an error; span.RecordError isn't called because the
+// caller already wraps the error with context before returning.
+func traceSpan(ctx context.Context, name string, fn func() error) error {
+	_, span := otel.Tracer(tracerName).Start(ctx, name)
+	defer span.End()
+	return fn()
 }
 
 func newClientContextInjector(outboundMgr adapter.OutboundManager, dataPath string) *clientcontext.ClientContextInjector {
@@ -179,7 +207,10 @@ func newMutableGroupManager(
 	return groups.NewMutableGroupManager(logger, oMgr, epMgr, connMgr, mutGroups), nil
 }
 
-func (t *tunnel) connect() (err error) {
+func (t *tunnel) connect(ctx context.Context) (err error) {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "tunnel.connect")
+	defer span.End()
+
 	slog.Log(nil, internal.LevelTrace, "Starting libbox service")
 
 	defer func() {
@@ -188,7 +219,9 @@ func (t *tunnel) connect() (err error) {
 			err = fmt.Errorf("panic starting libbox service: %v", r)
 		}
 	}()
-	if err := t.lbService.Start(); err != nil {
+	if err := traceSpan(ctx, "libbox.BoxService.Start", func() error {
+		return t.lbService.Start()
+	}); err != nil {
 		slog.Error("Failed to start libbox service", "error", err)
 		return fmt.Errorf("starting libbox service: %w", err)
 	}
@@ -196,10 +229,14 @@ func (t *tunnel) connect() (err error) {
 
 	t.clashServer = service.FromContext[adapter.ClashServer](t.ctx).(*clashapi.Server)
 
-	mutGrpMgr, err := newMutableGroupManager(
-		t.ctx, t.logFactory.NewLogger("groupsManager"), t.clashServer.TrafficManager(),
-	)
-	if err != nil {
+	var mutGrpMgr *groups.MutableGroupManager
+	if err := traceSpan(ctx, "newMutableGroupManager", func() error {
+		var err error
+		mutGrpMgr, err = newMutableGroupManager(
+			t.ctx, t.logFactory.NewLogger("groupsManager"), t.clashServer.TrafficManager(),
+		)
+		return err
+	}); err != nil {
 		return fmt.Errorf("creating mutable group manager: %w", err)
 	}
 	t.mutGrpMgr = mutGrpMgr

--- a/vpn/tunnel_test.go
+++ b/vpn/tunnel_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/getlantern/lantern-box/adapter"
 	lbgroups "github.com/getlantern/lantern-box/adapter/groups"
-
 	"github.com/getlantern/radiance/common/settings"
 	"github.com/getlantern/radiance/internal/testutil"
 	"github.com/getlantern/radiance/servers"
@@ -38,7 +37,7 @@ func TestConnection(t *testing.T) {
 		dataPath: tmp,
 	}
 
-	require.NoError(t, tun.start(optsStr, nil), "failed to establish connection")
+	require.NoError(t, tun.start(t.Context(), optsStr, nil), "failed to establish connection")
 	t.Cleanup(func() {
 		tun.close()
 	})
@@ -153,7 +152,7 @@ func testConnection(t *testing.T, opts sbO.Options) *tunnel {
 	}
 
 	options, _ := json.Marshal(opts)
-	err := tun.start(string(options), nil)
+	err := tun.start(t.Context(), string(options), nil)
 	require.NoError(t, err, "failed to establish connection")
 	t.Cleanup(func() {
 		tun.close()


### PR DESCRIPTION
Fixes https://github.com/getlantern/engineering/issues/3299.

## Context

Freshdesk [#173696](https://lantern.freshdesk.com/a/tickets/173696): user toggled Smart Routing, VPN restart stalled for 13s of user-visible outage, and DNS was broken for another ~28s after. Log confirms \`sing-box started ( 10.11 s )\`.

SigNoz \`/service/start\` distribution across all clients (24h):

| Percentile | Duration |
|---|---|
| p50 | 135 ms |
| p95 | 535 ms |
| p99 | 2.38 s |
| Max | **11.25 s** |

1 of 170 (0.6%) exceeded 10s, matching the Freshdesk case exactly. But the 11.25s span has **no child spans** — can't tell whether the 10s lives in \`libbox.Setup\`, \`libbox.NewServiceWithContext\`, \`BoxService.Start\`, or \`newMutableGroupManager\`.

Separately, settings-toggle restart (\`maybeRestartVPN\` → \`ipc.RestartService\`) has the handler traced at p99=4.37ms but no span around the actual restart logic. When a 10s restart happens, it's invisible.

## What this changes

- \`TunnelService.Restart\` — new span with \`path=direct|platform_ifce\` attribute
- \`tunnel.start\` — new span (\`options_size\`, \`platform\` attributes); propagates ctx through to init/connect
- \`tunnel.init\` — new span with child spans around:
  - \`libbox.Setup\`
  - \`libbox.NewServiceWithContext\`
  - \`loadURLTestHistory\`
- \`tunnel.connect\` — new span with child spans around:
  - \`libbox.BoxService.Start\`
  - \`newMutableGroupManager\`

Sing-box-minimal itself is untouched — it's a close-to-upstream fork with no OTEL deps. All instrumentation lives in radiance's wrapper layer, which already calls each sing-box entry point individually.

## Expected span hierarchy (after merge)

```
ipc.Server.StartService       (existing, was opaque)
  └─ tunnel.start             (new)
      ├─ tunnel.init          (new)
      │   ├─ libbox.Setup                    (new)
      │   ├─ libbox.NewServiceWithContext    (new)
      │   └─ loadURLTestHistory              (new)
      └─ tunnel.connect       (new)
          ├─ libbox.BoxService.Start         (new) ← prime suspect
          └─ newMutableGroupManager          (new)
```

And for the restart path:

```
ipc.Server.restartServiceHandler   (existing)
  └─ TunnelService.Restart         (new)
      └─ tunnel.start              (new, same tree as above)
```

## Follow-up

Once this lands on staging, wait ~24h for enough traffic and then re-query SigNoz to attribute the tail. The instrumentation is cheap (6 extra spans per restart) and can stay permanently — this path runs only on connect/disconnect/settings-toggle, not in the hot data path.

## Test plan

- [x] \`go build ./...\` on darwin/arm64
- [x] \`go vet ./vpn/...\`
- [x] \`go test -timeout 60s -run 'TestConnection|TestUpdateServers|TestTunnelClose' ./vpn/\`
- [ ] Observe child spans appear in SigNoz staging after dogfood connect/disconnect cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)