### PR TITLE
vpn: instrument tunnel.start phases + VPNClient.Restart

### DIFF
--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -14,21 +14,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	lsync "github.com/getlantern/common/sync"
-	box "github.com/getlantern/lantern-box"
-
-	lbA "github.com/getlantern/lantern-box/adapter"
-	"github.com/getlantern/lantern-box/adapter/groups"
-	lblog "github.com/getlantern/lantern-box/log"
-	"github.com/getlantern/lantern-box/tracker/clientcontext"
-
-	"github.com/getlantern/radiance/common"
-	"github.com/getlantern/radiance/common/settings"
-	"github.com/getlantern/radiance/events"
-	"github.com/getlantern/radiance/kindling"
-	rlog "github.com/getlantern/radiance/log"
-	"github.com/getlantern/radiance/servers"
-
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/common/conntrack"
 	"github.com/sagernet/sing-box/common/urltest"
@@ -38,6 +23,23 @@ import (
 	O "github.com/sagernet/sing-box/option"
 	"github.com/sagernet/sing/common/json"
 	"github.com/sagernet/sing/service"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	lsync "github.com/getlantern/common/sync"
+	box "github.com/getlantern/lantern-box"
+	lbA "github.com/getlantern/lantern-box/adapter"
+	"github.com/getlantern/lantern-box/adapter/groups"
+	lblog "github.com/getlantern/lantern-box/log"
+	"github.com/getlantern/lantern-box/tracker/clientcontext"
+	"github.com/getlantern/radiance/common"
+	"github.com/getlantern/radiance/common/settings"
+	"github.com/getlantern/radiance/events"
+	"github.com/getlantern/radiance/kindling"
+	rlog "github.com/getlantern/radiance/log"
+	"github.com/getlantern/radiance/servers"
 )
 
 type tunnel struct {
@@ -62,8 +64,17 @@ type tunnel struct {
 	closers []io.Closer
 }
 
-func (t *tunnel) start(options string, platformIfce libbox.PlatformInterface) (err error) {
-	if t.status.Load() != Restarting {
+func (t *tunnel) start(ctx context.Context, options string, platformIfce libbox.PlatformInterface) (err error) {
+	isRestart := t.status.Load() == Restarting
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "tunnel.start",
+		trace.WithAttributes(
+			attribute.Int("options_size", len(options)),
+			attribute.String("platform", common.Platform),
+			attribute.Bool("is_restart", isRestart),
+		))
+	defer span.End()
+
+	if !isRestart {
 		t.setStatus(Connecting, nil)
 	}
 	// Unbounded signaling must dial freddie outside the VPN tunnel or it
@@ -77,13 +88,13 @@ func (t *tunnel) start(options string, platformIfce libbox.PlatformInterface) (e
 		}
 	}()
 
-	if err := t.init(options, platformIfce); err != nil {
+	if err := t.init(ctx, options, platformIfce); err != nil {
 		t.close()
 		slog.Error("Failed to initialize tunnel", "error", err)
 		return fmt.Errorf("initializing tunnel: %w", err)
 	}
 
-	if err := t.connect(); err != nil {
+	if err := t.connect(ctx); err != nil {
 		t.close()
 		slog.Error("Failed to connect tunnel", "error", err)
 		return fmt.Errorf("connecting tunnel: %w", err)
@@ -93,7 +104,23 @@ func (t *tunnel) start(options string, platformIfce libbox.PlatformInterface) (e
 	return nil
 }
 
-func (t *tunnel) init(options string, platformIfce libbox.PlatformInterface) error {
+// traceSpan wraps fn in a child span of the caller's context and records any
+// error on the child span so failures show up per-phase in the trace.
+func traceSpan(ctx context.Context, name string, fn func() error) error {
+	_, span := otel.Tracer(tracerName).Start(ctx, name)
+	defer span.End()
+	err := fn()
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	return err
+}
+
+func (t *tunnel) init(ctx context.Context, options string, platformIfce libbox.PlatformInterface) error {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "tunnel.init")
+	defer span.End()
+
 	slog.Log(nil, rlog.LevelTrace, "Initializing tunnel")
 
 	// setup libbox service
@@ -110,7 +137,9 @@ func (t *tunnel) init(options string, platformIfce libbox.PlatformInterface) err
 	}
 
 	slog.Log(nil, rlog.LevelTrace, "Setting up libbox", "setup_options", setupOpts)
-	if err := libbox.Setup(setupOpts); err != nil {
+	if err := traceSpan(ctx, "libbox.Setup", func() error {
+		return libbox.Setup(setupOpts)
+	}); err != nil {
 		return fmt.Errorf("setup libbox: %w", err)
 	}
 
@@ -124,8 +153,12 @@ func (t *tunnel) init(options string, platformIfce libbox.PlatformInterface) err
 	}
 
 	slog.Log(nil, rlog.LevelTrace, "Creating libbox service")
-	lb, err := libbox.NewServiceWithContext(t.ctx, options, platformIfce)
-	if err != nil {
+	var lb *libbox.BoxService
+	if err := traceSpan(ctx, "libbox.NewServiceWithContext", func() error {
+		var err error
+		lb, err = libbox.NewServiceWithContext(t.ctx, options, platformIfce)
+		return err
+	}); err != nil {
 		return fmt.Errorf("create libbox service: %w", err)
 	}
 
@@ -192,7 +225,10 @@ func newMutableGroupManager(
 	return groups.NewMutableGroupManager(logger, oMgr, epMgr, connMgr, mutGroups), nil
 }
 
-func (t *tunnel) connect() (err error) {
+func (t *tunnel) connect(ctx context.Context) (err error) {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "tunnel.connect")
+	defer span.End()
+
 	slog.Log(nil, rlog.LevelTrace, "Starting libbox service")
 
 	defer func() {
@@ -201,7 +237,9 @@ func (t *tunnel) connect() (err error) {
 			err = fmt.Errorf("panic starting libbox service: %v", r)
 		}
 	}()
-	if err := t.lbService.Start(); err != nil {
+	if err := traceSpan(ctx, "libbox.BoxService.Start", func() error {
+		return t.lbService.Start()
+	}); err != nil {
 		slog.Error("Failed to start libbox service", "error", err)
 		return fmt.Errorf("starting libbox service: %w", err)
 	}
@@ -210,10 +248,14 @@ func (t *tunnel) connect() (err error) {
 	t.clashServer = service.FromContext[adapter.ClashServer](t.ctx).(*clashapi.Server)
 	t.outboundMgr = service.FromContext[adapter.OutboundManager](t.ctx)
 
-	mutGrpMgr, err := newMutableGroupManager(
-		t.ctx, t.logFactory.NewLogger("groupsManager"), t.clashServer.TrafficManager(),
-	)
-	if err != nil {
+	var mutGrpMgr *groups.MutableGroupManager
+	if err := traceSpan(ctx, "newMutableGroupManager", func() error {
+		var err error
+		mutGrpMgr, err = newMutableGroupManager(
+			t.ctx, t.logFactory.NewLogger("groupsManager"), t.clashServer.TrafficManager(),
+		)
+		return err
+	}); err != nil {
 		t.close()
 		return fmt.Errorf("creating mutable group manager: %w", err)
 	}

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -64,8 +64,7 @@ type tunnel struct {
 	closers []io.Closer
 }
 
-func (t *tunnel) start(ctx context.Context, options string, platformIfce libbox.PlatformInterface) (err error) {
-	isRestart := t.status.Load() == Restarting
+func (t *tunnel) start(ctx context.Context, options string, platformIfce libbox.PlatformInterface, isRestart bool) (err error) {
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "tunnel.start",
 		trace.WithAttributes(
 			attribute.Int("options_size", len(options)),
@@ -117,9 +116,15 @@ func traceSpan(ctx context.Context, name string, fn func() error) error {
 	return err
 }
 
-func (t *tunnel) init(ctx context.Context, options string, platformIfce libbox.PlatformInterface) error {
+func (t *tunnel) init(ctx context.Context, options string, platformIfce libbox.PlatformInterface) (err error) {
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "tunnel.init")
-	defer span.End()
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
 
 	slog.Log(nil, rlog.LevelTrace, "Initializing tunnel")
 
@@ -227,7 +232,13 @@ func newMutableGroupManager(
 
 func (t *tunnel) connect(ctx context.Context) (err error) {
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "tunnel.connect")
-	defer span.End()
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
 
 	slog.Log(nil, rlog.LevelTrace, "Starting libbox service")
 

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -134,15 +134,15 @@ func (c *VPNClient) Connect(boxOptions BoxOptions) error {
 	if err != nil {
 		return traces.RecordError(ctx, fmt.Errorf("failed to marshal options: %w", err))
 	}
-	return traces.RecordError(ctx, c.start(ctx, boxOptions.BasePath, string(opts)))
+	return traces.RecordError(ctx, c.start(ctx, boxOptions.BasePath, string(opts), false))
 }
 
-func (c *VPNClient) start(ctx context.Context, path, options string) error {
+func (c *VPNClient) start(ctx context.Context, path, options string, isRestart bool) error {
 	c.logger.Debug("Starting tunnel", "options", options)
 	t := tunnel{
 		dataPath: path,
 	}
-	if err := t.start(ctx, options, c.platformIfce); err != nil {
+	if err := t.start(ctx, options, c.platformIfce, isRestart); err != nil {
 		return fmt.Errorf("failed to start tunnel: %w", err)
 	}
 	c.tunnel = &t
@@ -219,7 +219,7 @@ func (c *VPNClient) Restart(boxOptions BoxOptions) error {
 	if err != nil {
 		return traces.RecordError(ctx, fmt.Errorf("failed to marshal options: %w", err))
 	}
-	if err := c.start(ctx, boxOptions.BasePath, string(opts)); err != nil {
+	if err := c.start(ctx, boxOptions.BasePath, string(opts), true); err != nil {
 		c.logger.Error("starting tunnel", "error", err)
 		return traces.RecordError(ctx, fmt.Errorf("starting tunnel: %w", err))
 	}

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -28,7 +28,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	box "github.com/getlantern/lantern-box"
-
 	"github.com/getlantern/radiance/events"
 	"github.com/getlantern/radiance/log"
 	"github.com/getlantern/radiance/servers"
@@ -135,15 +134,15 @@ func (c *VPNClient) Connect(boxOptions BoxOptions) error {
 	if err != nil {
 		return traces.RecordError(ctx, fmt.Errorf("failed to marshal options: %w", err))
 	}
-	return traces.RecordError(ctx, c.start(boxOptions.BasePath, string(opts)))
+	return traces.RecordError(ctx, c.start(ctx, boxOptions.BasePath, string(opts)))
 }
 
-func (c *VPNClient) start(path, options string) error {
+func (c *VPNClient) start(ctx context.Context, path, options string) error {
 	c.logger.Debug("Starting tunnel", "options", options)
 	t := tunnel{
 		dataPath: path,
 	}
-	if err := t.start(options, c.platformIfce); err != nil {
+	if err := t.start(ctx, options, c.platformIfce); err != nil {
 		return fmt.Errorf("failed to start tunnel: %w", err)
 	}
 	c.tunnel = &t
@@ -182,6 +181,9 @@ func (c *VPNClient) close() error {
 // Restart closes and restarts the tunnel if it is currently running. Returns an error if the tunnel
 // is not running or restart fails.
 func (c *VPNClient) Restart(boxOptions BoxOptions) error {
+	ctx, span := otel.Tracer(tracerName).Start(context.Background(), "VPNClient.Restart")
+	defer span.End()
+
 	c.mu.Lock()
 	if c.tunnel == nil || c.tunnel.Status() != Connected {
 		c.mu.Unlock()
@@ -192,32 +194,34 @@ func (c *VPNClient) Restart(boxOptions BoxOptions) error {
 	c.logger.Info("Restarting tunnel")
 	t.setStatus(Restarting, nil)
 	if c.platformIfce != nil {
+		span.SetAttributes(attribute.String("path", "platform_ifce"))
 		c.mu.Unlock()
 		if err := c.platformIfce.RestartService(); err != nil {
 			c.logger.Error("Failed to restart tunnel via platform interface", "error", err)
 			err = fmt.Errorf("platform interface restart failed: %w", err)
 			t.setStatus(ErrorStatus, err)
-			return err
+			return traces.RecordError(ctx, err)
 		}
 		c.logger.Info("Tunnel restarted successfully")
 		return nil
 	}
+	span.SetAttributes(attribute.String("path", "direct"))
 
 	defer c.mu.Unlock()
 	if err := c.close(); err != nil {
-		return fmt.Errorf("closing tunnel: %w", err)
+		return traces.RecordError(ctx, fmt.Errorf("closing tunnel: %w", err))
 	}
 	options, err := buildOptions(boxOptions)
 	if err != nil {
-		return fmt.Errorf("failed to build options: %w", err)
+		return traces.RecordError(ctx, fmt.Errorf("failed to build options: %w", err))
 	}
 	opts, err := sbjson.Marshal(options)
 	if err != nil {
-		return fmt.Errorf("failed to marshal options: %w", err)
+		return traces.RecordError(ctx, fmt.Errorf("failed to marshal options: %w", err))
 	}
-	if err := c.start(boxOptions.BasePath, string(opts)); err != nil {
+	if err := c.start(ctx, boxOptions.BasePath, string(opts)); err != nil {
 		c.logger.Error("starting tunnel", "error", err)
-		return fmt.Errorf("starting tunnel: %w", err)
+		return traces.RecordError(ctx, fmt.Errorf("starting tunnel: %w", err))
 	}
 	c.logger.Info("Tunnel restarted successfully")
 	return nil


### PR DESCRIPTION
Fixes https://github.com/getlantern/engineering/issues/3299.

Port of #442 (merged into \`main\`) onto the \`refactor\` branch.

## Why this branch needs its own copy

\`refactor\` has a different VPN architecture than \`main\`: it keeps the tunnel in-process via \`VPNClient\` instead of splitting it across \`TunnelService\` + IPC. The instrumentation names match #442 so any SigNoz dashboards we build against \`main\` keep working here, but the glue is different:

- \`main\`: spans attached to \`TunnelService.Restart\` (IPC-side)
- \`refactor\`: spans attached to \`VPNClient.Restart\` (in-process)

## What this changes

- \`VPNClient.Restart\` span (new) — the whole settings-toggle restart path was invisible in SigNoz on this branch too
- \`tunnel.start\` span with \`options_size\`, \`platform\`, \`is_restart\` attributes
- \`tunnel.init\` / \`tunnel.connect\` spans
- Child spans: \`libbox.Setup\`, \`libbox.NewServiceWithContext\`, \`libbox.BoxService.Start\`, \`newMutableGroupManager\`

Note: this branch has no \`loadURLTestHistory\` call (urltest history is pulled from context via \`service.FromContext\`, not from disk), so that phase is absent compared to \`main\`. Everything else matches.

## Test plan

- [x] \`go build ./vpn/...\` on darwin/arm64
- [x] \`go vet ./vpn/...\`
- [x] \`go test -timeout 60s -run 'TestConnection|TestUpdateServers|TestTunnelClose' ./vpn/\`
- [ ] Observe child spans appear in SigNoz after dogfood connect/disconnect cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)