### PR TITLE
fix(backend): treat empty tag as AutoSelect in LocalBackend.SelectServer

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -697,6 +697,15 @@ func (r *LocalBackend) RestartVPN() error {
 }
 
 func (r *LocalBackend) SelectServer(tag string) error {
+	// Normalize up-front so the post-vpnClient settings branch below picks the
+	// auto path instead of falling through to the manual-tag srvManager lookup
+	// (which would reject "" with "no server found with tag"). Mirrors the
+	// same normalization in LocalBackend.ConnectVPN above. VPNClient.SelectServer
+	// already treats "" as AutoSelectTag internally (fac9089); this aligns the
+	// outer wrapper with that behavior so callers can use either spelling.
+	if tag == "" {
+		tag = vpn.AutoSelectTag
+	}
 	if err := r.vpnClient.SelectServer(tag); err != nil {
 		return fmt.Errorf("failed to select server: %w", err)
 	}


### PR DESCRIPTION
## Summary

Follow-up to `fac9089`. That fix normalized the `""` → `AutoSelectTag` convention in `VPNClient.SelectServer` (`vpn/vpn.go:295`), but `LocalBackend.SelectServer` — which wraps `vpnClient.SelectServer` and then does its own settings update + server-tag lookup — still compares against `AutoSelectTag` directly. With `tag == ""` the inner vpnClient call succeeds (fac9089 handles it), then the outer wrapper's own tag check falls through to `srvManager.GetServerByTag("")`, which isn't found, producing `"no server found with tag "` (trailing space).

Reproduced on Lantern 9.0.30 (internal tester, Freshdesk #173773). Smart-from-connected now surfaces as `"start service failed: ipc: status 500: no server found with tag "` in the Dart snackbar.

## Call path

```mermaid
sequenceDiagram
    autonumber
    participant Caller as Lantern client<br/>vpn_tunnel.ConnectToServer<br/>(on live tunnel)
    participant LB as LocalBackend<br/>backend/radiance.go
    participant VC as VPNClient<br/>vpn/vpn.go

    Caller->>LB: POST /server/selected {Tag: ""}
    Note over LB: backend/radiance.go:699 SelectServer(tag="")

    rect rgba(200, 255, 200, 0.3)
        Note over LB: ✅ this PR: line 706<br/>if tag == "" { tag = vpn.AutoSelectTag }<br/>(mirrors LocalBackend.ConnectVPN:642)
    end

    LB->>VC: r.vpnClient.SelectServer("auto")
    VC->>VC: vpn/vpn.go:295 ✅ fac9089<br/>tag == AutoSelectTag \|\| tag == ""<br/>→ tunnel.selectMode(AutoSelectTag)
    VC-->>LB: nil
    LB->>LB: line 712: tag == AutoSelectTag ✅<br/>settings.Patch(AutoConnect: true) → return nil

    rect rgba(255, 200, 200, 0.3)
        Note over LB: 🐛 Without this PR: tag stays "".<br/>line 712 tag == AutoSelectTag → false<br/>line 723 srvManager.GetServerByTag("") → not found<br/>line 725 return "no server found with tag " → HTTP 500
    end

    LB-->>Caller: 200 OK
```

## Change

One block at the top of `LocalBackend.SelectServer`, mirroring `LocalBackend.ConnectVPN:642`:

```go
func (r *LocalBackend) SelectServer(tag string) error {
    if tag == "" {
        tag = vpn.AutoSelectTag
    }
    if err := r.vpnClient.SelectServer(tag); err != nil {
        ...
    }
    if tag == vpn.AutoSelectTag {   // now correctly matches the "" case too
        ...
    }
    ...
}
```

With this, both radiance primitives handle `""` uniformly, and the Dart convention of sending `""` for Smart-auto works end-to-end regardless of whether the caller hits `ConnectVPN` or `SelectServer`.

## Test plan

- [x] `go build ./backend/...` clean
- [x] `go vet ./backend/...` clean
- [x] `go test ./backend/...` clean
- [x] `gofmt -l` clean
- [ ] Smoke: from Lantern's refactor tip (pinned to this commit once bumped), Smart-from-connected should succeed — no snackbar, Clash mode flips to auto, settings persist with `AutoConnectKey=true`.

Pre-existing note: `cmd/lantern/lantern.go:78` has an unrelated build error (`ipc.NewClient` signature mismatch) on `origin/refactor` — not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)