### PR TITLE
backend: stop logging ErrTunnelAlreadyConnected as an error after config update

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -277,7 +277,14 @@ func (r *LocalBackend) Start() {
 		if err := r.setServers(list, true); err != nil {
 			slog.Error("setting servers in manager", "error", err)
 		}
-		if err := r.RunOfflineURLTests(); err != nil {
+		if err := r.RunOfflineURLTests(); err != nil && !errors.Is(err, vpn.ErrTunnelAlreadyConnected) {
+			// ErrTunnelAlreadyConnected is the expected, non-error case while
+			// the VPN is up: setServers above already pushed the new outbounds
+			// (and any bandit URL overrides) into the running tunnel, and
+			// addOutbounds triggers an immediate URL test cycle for them via
+			// MutableURLTest.CheckOutbounds. The "offline" pre-warm path here
+			// is for the not-yet-connected case only — running both would
+			// duplicate work and conflict with the live URLTest selector.
 			slog.Error("Failed to run offline URL tests after config update", "error", err)
 		}
 	})


### PR DESCRIPTION
Cosmetic fix to a misleading log line that's been showing up on every \`/v1/config-new\` refresh while the VPN is connected.

## What's happening

When a fresh config arrives **while the VPN is up**, two things run from the \`NewConfigEvent\` listener in \`backend/radiance.go\`:

1. \`setServers(list, true)\` — pushes the new outbounds + bandit URL overrides into the *running* sing-box via \`UpdateOutbounds\` → \`tunnel.updateOutbounds\` → \`tunnel.addOutbounds\`. Among other things, \`addOutbounds\` calls \`mutGrpMgr.SetURLOverrides(AutoSelectTag, ...)\` and, if any overrides were present, synchronously triggers an immediate URL test cycle via \`mutGrpMgr.CheckOutbounds(AutoSelectTag)\` (\`vpn/tunnel.go:436-450\`, the \`Triggered immediate URL test for bandit callbacks\` log line).

2. \`RunOfflineURLTests()\` — gated by \`if c.tunnel != nil\` in \`vpn/vpn.go:462\`, so when the tunnel is up it returns \`ErrTunnelAlreadyConnected\` immediately and does nothing else.

The skip in step 2 is **correct**: running offline URL tests while the live tunnel is also probing the same outbounds (continuously, every \`urlTestInterval\` = 3 min, plus the immediate post-config trigger in step 1) would duplicate work and conflict with the live URLTest selector. The offline pre-warm is for the not-yet-connected case.

But we were logging the expected sentinel at \`level=ERROR\`:

\`\`\`
level=ERROR pkg=radiance source.func=(*LocalBackend).Start.func3 source.file=radiance.go:288
  msg=\"Failed to run offline URL tests after config update\" error=\"tunnel already connected\"
\`\`\`

…which makes it look like URL tests aren't running after a config update. They are — just via the in-tunnel path, not the offline path.

## Fix

Skip the log line when the error is \`vpn.ErrTunnelAlreadyConnected\`. Keep it for any other error (e.g. \`offline tests already running\`, real misconfiguration, etc.). Adds a comment explaining why this is the expected case while connected.

\`\`\`go
if err := r.RunOfflineURLTests(); err != nil && !errors.Is(err, vpn.ErrTunnelAlreadyConnected) {
    // ErrTunnelAlreadyConnected is the expected, non-error case while
    // the VPN is up: setServers above already pushed the new outbounds
    // (and any bandit URL overrides) into the running tunnel, and
    // addOutbounds triggers an immediate URL test cycle for them via
    // MutableURLTest.CheckOutbounds. The "offline" pre-warm path here
    // is for the not-yet-connected case only — running both would
    // duplicate work and conflict with the live URLTest selector.
    slog.Error(\"Failed to run offline URL tests after config update\", \"error\", err)
}
\`\`\`

## Test plan

- [ ] Connect VPN, observe a fresh config event in the logs (e.g. via the 3-min poll cycle), confirm there's no \`Failed to run offline URL tests after config update\` line. The \`Triggered immediate URL test for bandit callbacks\` line should still appear.
- [ ] Disconnect VPN, observe a fresh config event, confirm \`Performing offline URL tests\` runs (no behavior change for the disconnected case).
- [ ] If \`RunOfflineURLTests\` returns \`offline tests already running\` (e.g. two configs landing back-to-back while disconnected), confirm that one still logs at ERROR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)