### PR TITLE
ipc: replay current VPN status on SSE subscribe (fixes Windows missing Connecting state)

### DIFF
--- a/ipc/server.go
+++ b/ipc/server.go
@@ -400,6 +400,20 @@ func (s *localapi) vpnStatusEventsHandler(w http.ResponseWriter, r *http.Request
 		}
 	})
 	defer sub.Unsubscribe()
+
+	// events.Subscribe is forward-only; enqueue the current status so a
+	// subscriber that attaches between two setStatus calls still observes the
+	// prior state. ch is the single ordering path: a direct write could land
+	// after an earlier event already queued by a concurrent emit.
+	if cur := s.backend(r.Context()).VPNStatus(); cur != "" {
+		if data, err := json.Marshal(vpn.StatusUpdateEvent{Status: cur}); err == nil {
+			select {
+			case ch <- data:
+			default:
+			}
+		}
+	}
+
 	for {
 		select {
 		case data := <-ch:

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -401,16 +401,17 @@ func (s *localapi) vpnStatusEventsHandler(w http.ResponseWriter, r *http.Request
 	})
 	defer sub.Unsubscribe()
 
-	// events.Subscribe is forward-only; enqueue the current status so a
-	// subscriber that attaches between two setStatus calls still observes the
-	// prior state. ch is the single ordering path: a direct write could land
-	// after an earlier event already queued by a concurrent emit.
+	// events.Subscribe is forward-only; write the current status directly
+	// to the wire so a subscriber that attaches between two setStatus calls
+	// still observes the prior state. Writing direct (rather than via ch)
+	// guarantees the snapshot is the first event the client sees and can't
+	// be dropped by ch backpressure: any concurrent emit that happens after
+	// VPNStatus() returns goes through ch and is delivered after this
+	// snapshot, preserving forward ordering.
 	if cur := s.backend(r.Context()).VPNStatus(); cur != "" {
 		if data, err := json.Marshal(vpn.StatusUpdateEvent{Status: cur}); err == nil {
-			select {
-			case ch <- data:
-			default:
-			}
+			fmt.Fprintf(w, "data: %s\n\n", data)
+			flusher.Flush()
 		}
 	}
 

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -402,12 +402,7 @@ func (s *localapi) vpnStatusEventsHandler(w http.ResponseWriter, r *http.Request
 	defer sub.Unsubscribe()
 
 	// events.Subscribe is forward-only; write the current status directly
-	// to the wire so a subscriber that attaches between two setStatus calls
-	// still observes the prior state. Writing direct (rather than via ch)
-	// guarantees the snapshot is the first event the client sees and can't
-	// be dropped by ch backpressure: any concurrent emit that happens after
-	// VPNStatus() returns goes through ch and is delivered after this
-	// snapshot, preserving forward ordering.
+	// so a subscriber that attaches between setStatus calls still sees it.
 	if cur := s.backend(r.Context()).VPNStatus(); cur != "" {
 		if data, err := json.Marshal(vpn.StatusUpdateEvent{Status: cur}); err == nil {
 			fmt.Fprintf(w, "data: %s\n\n", data)


### PR DESCRIPTION
## Summary
- The lantern UI on Windows reportedly skips the **Connecting** state on the VPN toggle — the button jumps straight from off to on. This PR fixes the root cause: a subscribe-after-emit race in the `/vpn/status/events` SSE handler.

## Root cause

```mermaid
sequenceDiagram
    autonumber
    participant Dart as Flutter UI<br/>vpn_switch.dart
    participant FFI as lantern-core FFI<br/>ffi.go (UI process)
    participant SSE as SSE subscriber<br/>ffi.go:445 startStatusListener
    participant Pipe as Named pipe<br/>(Windows IPC)
    participant Daemon as radiance daemon<br/>(LanternSvc service)

    Dart->>FFI: tap → startVPN()
    FFI->>SSE: startStatusListener(c) [sync.Once goroutine]
    Note over SSE: schedules goroutine ⚠️
    FFI->>Pipe: c.ConnectVPN("")
    Pipe->>Daemon: POST /vpn/connect
    rect rgba(255, 200, 200, 0.3)
        Daemon->>Daemon: vpn.go:166<br/>setStatus(Connecting) → events.Emit ⚠️
        Note over SSE: SSE GET / handshake still in flight 🐛
        Daemon->>Daemon: tunnel.start (slow)
        Daemon->>Daemon: vpn.go:173<br/>setStatus(Connected) → events.Emit
    end
    SSE-->>Pipe: GET /vpn/status/events (NOW connected)
    Pipe-->>SSE: SSE stream open — but Connecting already missed
    Daemon-->>SSE: (next event only — Connected)
    SSE->>Dart: status=Connected
    Note over Dart: UI: off → on (no Connecting ever rendered)
```

The two layered bugs:

1. **`lantern-core/ffi/ffi.go:519-538`** (in the lantern repo) — `startVPN()` calls `startStatusListener(c)` (which kicks off a `sync.Once` goroutine that has to dial the named pipe + finish an SSE handshake), then immediately calls `c.ConnectVPN("")`. On Windows the named-pipe dial + HTTP setup is slow on first use, so `Connecting` regularly fires before the SSE stream is open.
2. **`ipc/server.go` `vpnStatusEventsHandler`** (this PR) — calls `events.Subscribe(...)` and forwards *future* events only. There is no replay of the current status, so any event emitted before the subscriber attaches is silently dropped (the buffered chan even has a non-blocking `default` case).

`Connecting` IS emitted by the daemon (`vpn/vpn.go:164-174`) and the Dart UI does observe `connecting` correctly (`lib/features/vpn/vpn_switch.dart:44-58`). The bug is purely event delivery.

Why **Windows-only**: Android/iOS/macOS either run the daemon in-process or set up the SSE subscriber during app init, well before the user taps. Windows is the only platform where the daemon is a separate Windows service process *and* the SSE subscription opens on first button tap.

## Fix

Replay the current status to new subscribers before entering the event loop. Receivers (`lantern-core/ffi/ffi.go:437-441` `statusListenerLast`) already dedup, so a redundant `Connected` after reconnect is harmless.

```mermaid
sequenceDiagram
    autonumber
    participant Sub as Subscriber<br/>(lantern UI / lantern-core FFI)
    participant H as vpnStatusEventsHandler<br/>ipc/server.go
    participant Bus as events bus
    participant V as vpnClient.status

    Sub->>H: GET /vpn/status/events
    H->>Bus: events.Subscribe (future events buffered)
    H->>V: VPNStatus()
    V-->>H: cur (e.g. Connecting)
    H->>Sub: data: {"status":"connecting"} 🟢
    Note over H: now enter event loop
    Bus->>H: Connected (future event)
    H->>Sub: data: {"status":"connected"}
```

Edge: if the status changes between Subscribe and `VPNStatus()`, the receiver gets both — the freshly-read state plus the queued event from the channel. Dedup absorbs the redundancy.

## Test plan
- [ ] Build a Windows nightly that pulls this radiance and verify the toggle now shows the spinner during connect (`vpn_switch.dart:44-58` renders `CircularProgressIndicator` for `VPNStatus.connecting`).
- [ ] Sanity check that disconnect still goes through Disconnecting → Disconnected (the same dedup path applies).
- [ ] Sanity check macOS/Android/iOS — they should be unchanged (their listener is established before any user action so the replay is just a redundant first event that dedups out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)