### PR TITLE
Revert signup url and guard check for the sign up request.

### DIFF
--- a/account/user.go
+++ b/account/user.go
@@ -156,7 +156,6 @@ func (a *Client) SignUp(ctx context.Context, email, password string) ([]byte, *p
 
 	proToken := settings.GetString(settings.TokenKey)
 	userID := settings.GetString(settings.UserIDKey)
-	slog.Debug("Signing up user", "email", email, "proTokenSet", proToken)
 	if proToken == "" || userID == "" {
 		return nil, nil, traces.RecordError(ctx, errors.New("signup requires the pro token and user ID to continue"))
 	}

--- a/account/user.go
+++ b/account/user.go
@@ -153,9 +153,20 @@ func (a *Client) SignUp(ctx context.Context, email, password string) ([]byte, *p
 		// If new user faces any issue while sign up user can sign up again
 		Temp: true,
 	}
-	// Signup endpoint need to include device ID, user ID and pro token
-	// if not api wil create new user instead of linking to existing user which cause issue
-	resp, err := a.sendProRequest(ctx, "POST", "/users/signup", nil, nil, data)
+
+	proToken := settings.GetString(settings.TokenKey)
+	userID := settings.GetString(settings.UserIDKey)
+	slog.Debug("Signing up user", "email", email, "proTokenSet", proToken)
+	if proToken == "" || userID == "" {
+		return nil, nil, traces.RecordError(ctx, errors.New("signup requires the pro token and user ID to continue"))
+	}
+	headers := map[string]string{
+		common.DeviceIDHeader: settings.GetString(settings.DeviceIDKey),
+		common.ProTokenHeader: proToken,
+		common.UserIDHeader:   userID,
+	}
+
+	resp, err := a.sendRequest(ctx, "POST", "/users/signup", nil, headers, data)
 	if err != nil {
 		return nil, nil, traces.RecordError(ctx, err)
 	}

--- a/account/user_test.go
+++ b/account/user_test.go
@@ -249,6 +249,8 @@ func newTestClientWithSRP(t *testing.T, email, password string) (*Client, *testS
 
 func TestSignUp(t *testing.T) {
 	ac, _ := newTestClient(t)
+	settings.Set(settings.TokenKey, "test-token")
+	settings.Set(settings.UserIDKey, "123")
 	salt, signupResponse, err := ac.SignUp(context.Background(), "test@example.com", "password")
 	assert.NoError(t, err)
 	assert.NotNil(t, salt)


### PR DESCRIPTION
This pull request updates the user sign-up logic in `account/user.go` to enforce that both a pro token and user ID are present before proceeding. It also ensures these values, along with the device ID, are sent as headers with the sign-up request, improving user account linking and error handling.

**Sign-up flow improvements:**

* The sign-up process now checks that both the pro token and user ID are set in `settings`; if either is missing, it returns an error and halts the operation.
* The sign-up request now includes the device ID, pro token, and user ID as headers, ensuring the backend can correctly link the sign-up to an existing user when appropriate.
* The code now uses `sendRequest` instead of `sendProRequest` to make the sign-up API call, reflecting the updated requirements for headers.