### PR TITLE
cmd/lanternd: grant Built-in Users start/stop on LanternSvc

### DIFF
--- a/cmd/lanternd/lanternd_windows.go
+++ b/cmd/lanternd/lanternd_windows.go
@@ -19,6 +19,16 @@ import (
 const (
 	serviceName = "LanternSvc"
 	binPath     = "C:\\Program Files\\Lantern\\" + serviceName + ".exe"
+
+	// LanternSvc must be controllable from the non-elevated UI session; the SCM
+	// default DACL grants SERVICE_START to Administrators only, which makes
+	// OpenService return ERROR_ACCESS_DENIED for every standard-user start
+	// attempt. SY/BA keep their default full access; BU (Built-in Users) is
+	// granted query, start, stop, and interrogate.
+	serviceSDDL = "D:" +
+		"(A;;CCLCSWRPWPDTLOCRRC;;;SY)" +
+		"(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)" +
+		"(A;;CCLCSWRPWPLOCRRC;;;BU)"
 )
 
 var isWindowsService bool
@@ -88,12 +98,34 @@ func install(dataPath, logPath, logLevel string) error {
 	if err != nil {
 		return fmt.Errorf("failed to set service recovery actions: %w", err)
 	}
+
+	if err := setServiceDACL(); err != nil {
+		return fmt.Errorf("failed to set service DACL: %w", err)
+	}
+
 	if err := service.Start(); err != nil {
 		return fmt.Errorf("failed to start service: %w", err)
 	}
 
 	slog.Info("Windows service installed successfully")
 	return nil
+}
+
+func setServiceDACL() error {
+	sd, err := windows.SecurityDescriptorFromString(serviceSDDL)
+	if err != nil {
+		return fmt.Errorf("parse SDDL: %w", err)
+	}
+	dacl, _, err := sd.DACL()
+	if err != nil {
+		return fmt.Errorf("read DACL from SD: %w", err)
+	}
+	return windows.SetNamedSecurityInfo(
+		serviceName,
+		windows.SE_SERVICE,
+		windows.DACL_SECURITY_INFORMATION,
+		nil, nil, dacl, nil,
+	)
 }
 
 func uninstall() error {

--- a/cmd/lanternd/lanternd_windows.go
+++ b/cmd/lanternd/lanternd_windows.go
@@ -86,6 +86,23 @@ func install(dataPath, logPath, logLevel string) error {
 	}
 	defer service.Close()
 
+	// A half-installed service (registered without recovery actions or with the
+	// default admin-only DACL) would block the non-elevated start this path is
+	// meant to enable, so any failure before installed=true rolls the install
+	// back.
+	installed := false
+	defer func() {
+		if installed {
+			return
+		}
+		if delErr := service.Delete(); delErr != nil {
+			slog.Warn("install rollback: failed to delete service", "error", delErr)
+		}
+		if rmErr := os.Remove(binPath); rmErr != nil && !os.IsNotExist(rmErr) {
+			slog.Warn("install rollback: failed to remove binary", "error", rmErr)
+		}
+	}()
+
 	err = service.SetRecoveryActions([]mgr.RecoveryAction{
 		{Type: mgr.ServiceRestart, Delay: 1 * time.Second},
 		{Type: mgr.ServiceRestart, Delay: 2 * time.Second},
@@ -107,6 +124,7 @@ func install(dataPath, logPath, logLevel string) error {
 		return fmt.Errorf("failed to start service: %w", err)
 	}
 
+	installed = true
 	slog.Info("Windows service installed successfully")
 	return nil
 }


### PR DESCRIPTION
## Summary

Two related changes to `cmd/lanternd/lanternd_windows.go`:

1. **Widen the DACL on `LanternSvc`** so Built-in Users can `query | start | stop | interrogate`. The SCM default DACL grants `SERVICE_START` to Administrators only.
2. **Make `install()` atomic across post-`CreateService` failures.** A defer-based rollback (delete service + remove copied binary, gated on `installed = true` set at the end) replaces the prior pattern of returning with a half-installed service if `SetRecoveryActions`, `setServiceDACL`, or `service.Start` failed.

## Origin and scope clarification

This PR was originally drafted in response to [Freshdesk #173802](https://lantern.freshdesk.com/a/tickets/173802) — a v9.0.26-beta user on Windows 10 hitting "The Windows VPN service is unavailable: LanternSvc could not start." On further investigation, **the primary fix for that ticket is the radiance daemon refactor itself, already merged** (lantern #8578 + radiance #370). Pre-refactor, the Dart UI's `_prepareWindowsService` / `_startWindowsServiceWarmup` (`lantern_ffi_service.dart:284, 436, 541`) called `sc start LanternSvc` from a non-elevated process — that's the call the auto-diagnose flagged with `OpenService: error 5`. The refactor deleted that whole code path. On post-refactor main, `grep -rln 'OpenService\|StartService\|sc start' lib/ lantern-core/ ipc/ cmd/` (both repos) returns only `cmd/lanternd/lanternd_windows.go` itself (the install path) and dev-only PowerShell scripts.

So in steady-state post-refactor flow:
- `StartType: mgr.StartAutomatic` + 7 recovery actions keep the service running.
- The UI just connects to `\\.\pipe\LanternService`. No SCM call.
- A non-admin user works fine **as long as the service is running**.

This PR is **defense in depth**, not the ticket's primary fix. Worth landing because:
- VPN client services that are user-controllable by design should ship with an explicit DACL — relying on auto-start to mask the missing DACL is fragile.
- Any future UI code adding a "service ready?" probe with start-fallback works for non-admin users too.
- Without it, a user whose service ends up in `STOPPED` (manual stop, recovery exhaustion, install bug) can't recover without admin elevation.
- The install-atomicity fix is independently valuable and was prompted by the Copilot review on this PR.

## SDDL

```
D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)
  (A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)
  (A;;CCLCSWRPWPLOCRRC;;;BU)
```

| ACE | Trustee | Mask |
|---|---|---|
| 1 | `SY` LocalSystem | query/start/stop/pause/interrogate/user-defined/read-control (matches default) |
| 2 | `BA` Built-in Admins | full control (matches default) |
| 3 | `BU` Built-in Users | query-config/query-status/enumerate-dependents/start/stop/interrogate/user-defined/read-control. **No** `change-config`, `write-DAC`, `delete`, or `write-owner`. |

## Verification status

- **Cross-build** (`GOOS=windows go build ./cmd/lanternd/`): ✓ clean.
- **`go vet`**: ✓ clean.
- **Manual Windows testing: NOT YET DONE.** Hard prereq before merge:
  - [ ] Install on a Windows VM as Administrator. Run `sc sdshow LanternSvc` and confirm the new ACE for `BU` is present in the persisted DACL.
  - [ ] Switch to a non-admin user. Verify `sc start LanternSvc` and `sc stop LanternSvc` succeed (not `OpenService FAILED 5: Access is denied.`).
  - [ ] Verify install rollback by injecting a forced failure (e.g. invalid SDDL constant, invalid recovery actions) → `sc query LanternSvc` should return service-not-found and `C:\Program Files\Lantern\LanternSvc.exe` should be absent.
  - [ ] Upgrade test: machine with old (admin-only DACL) LanternSvc → run installer with this build → confirm `sc sdshow` shows new DACL after upgrade.

## What this does not do

- Does **not** fix the ticket for users on 9.0.26-beta directly. They'll get fixed when they upgrade to a build that includes the lantern refactor (which already removed the failing `sc start` call from the UI).
- Does **not** add a "service ready?" probe with SCM fallback in the UI. That would be a separate change in lantern, and may not be needed at all post-refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
