### PR TITLE
trace: log VPN status hop timestamps (Freshdesk #174072)

### DIFF
--- a/ipc/client_nonmobile.go
+++ b/ipc/client_nonmobile.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	rlog "github.com/getlantern/radiance/log"
 )
@@ -101,6 +103,13 @@ func (c *Client) sseStream(ctx context.Context, endpoint string, handler func([]
 		if data, ok := strings.CutPrefix(line, "data: "); ok {
 			data = strings.TrimSpace(data)
 			if data != "" {
+				// [vpn-state-trace] hop=sse_parsed — moment the client side
+				// got a full SSE event from the named pipe. The gap to
+				// ssehandler_flushed measures pipe-transit + bufio.Scanner
+				// buffering on Windows.
+				if endpoint == vpnStatusEventsEndpoint {
+					slog.Info("[vpn-state-trace]", "hop", "sse_parsed", "data", string(data), "ts_ms", time.Now().UnixMilli())
+				}
 				handler([]byte(data))
 			}
 		}

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -407,6 +407,7 @@ func (s *localapi) vpnStatusEventsHandler(w http.ResponseWriter, r *http.Request
 		if data, err := json.Marshal(vpn.StatusUpdateEvent{Status: cur}); err == nil {
 			fmt.Fprintf(w, "data: %s\n\n", data)
 			flusher.Flush()
+			slog.Info("[vpn-state-trace]", "hop", "ssehandler_flushed_replay", "data", string(data), "ts_ms", time.Now().UnixMilli())
 		}
 	}
 
@@ -415,6 +416,11 @@ func (s *localapi) vpnStatusEventsHandler(w http.ResponseWriter, r *http.Request
 		case data := <-ch:
 			fmt.Fprintf(w, "data: %s\n\n", data)
 			flusher.Flush()
+			// [vpn-state-trace] hop=ssehandler_flushed — bytes handed to the
+			// HTTP response after Flush. Pairs with daemon_setstatus upstream
+			// and sse_parsed downstream to bracket transit through the
+			// (winio) named pipe on Windows.
+			slog.Info("[vpn-state-trace]", "hop", "ssehandler_flushed", "data", string(data), "ts_ms", time.Now().UnixMilli())
 		case <-r.Context().Done():
 			return
 		}

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -263,6 +263,10 @@ func (c *VPNClient) setStatus(s VPNStatus, err error) {
 		return
 	}
 	c.status.Store(s)
+	// [vpn-state-trace] hop=daemon_setstatus — start of the status delivery chain.
+	// Pair this timestamp with hop=ssehandler_flushed / hop=ffi_to_port / hop=dart_applied
+	// to localize where Connecting/Disconnecting transitions stall on Windows.
+	slog.Info("[vpn-state-trace]", "hop", "daemon_setstatus", "status", s, "ts_ms", time.Now().UnixMilli())
 	evt := StatusUpdateEvent{Status: s}
 	if err != nil {
 		evt.Error = err.Error()

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -266,7 +266,9 @@ func (c *VPNClient) setStatus(s VPNStatus, err error) {
 	// [vpn-state-trace] hop=daemon_setstatus — start of the status delivery chain.
 	// Pair this timestamp with hop=ssehandler_flushed / hop=ffi_to_port / hop=dart_applied
 	// to localize where Connecting/Disconnecting transitions stall on Windows.
-	slog.Info("[vpn-state-trace]", "hop", "daemon_setstatus", "status", s, "ts_ms", time.Now().UnixMilli())
+	// Use c.logger (not slog.Info) so this respects the VPNClient's configured
+	// logger — important for tests that pass NoOpLogger via WithLogger.
+	c.logger.Info("[vpn-state-trace]", "hop", "daemon_setstatus", "status", s, "ts_ms", time.Now().UnixMilli())
 	evt := StatusUpdateEvent{Status: s}
 	if err != nil {
 		evt.Error = err.Error()


### PR DESCRIPTION
## Summary

Adds three diagnostic log lines on the path \`setStatus → SSE flush → SSE parse\` so a Windows disconnect run produces a timeline that pinpoints where the Connecting/Disconnecting transitions get held.

| Hop | File | Where |
|---|---|---|
| \`daemon_setstatus\` | \`vpn/vpn.go\` | Inside \`setStatus\`, just before \`events.Emit\` |
| \`ssehandler_flushed\` | \`ipc/server.go\` | After \`flusher.Flush()\` per event (and on the replay path) |
| \`sse_parsed\` | \`ipc/client_nonmobile.go\` | When the client-side \`bufio.Scanner\` returns a parsed event |

The lantern repo carries the matching pair (\`ffi_to_port\` and \`dart_applied\`) so a single \`vpn-state-trace\` grep across both surfaces gives a five-row timeline per status change.

## Why

Freshdesk #174072 — Windows users report the VPN toggle never visibly enters Connecting/Disconnecting. PR #447's replay-on-subscribe ruled out the first-attach race; the residual gap appears to be in the SSE delivery path on Windows (winio named pipe + bufio scanner). My analysis offered three plausible sources but I can't pin one without timestamps from a real Windows disconnect — hence this trace.

## Cleanup

Remove all three lines (and the \`log/slog\`/\`time\` imports added to \`client_nonmobile.go\`) once we know the buggy hop and ship the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
