### PR TITLE
Read x-lantern-client-country header from RADIANCE_COUNTRY env, not settings

### DIFF
--- a/config/fetcher.go
+++ b/config/fetcher.go
@@ -154,12 +154,6 @@ func (f *fetcher) send(ctx context.Context, body io.Reader) ([]byte, error) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Cache-Control", "no-cache")
 
-	// x-lantern-client-country is a developer/test-only override that forces
-	// the server to apply diversion rules for a specific country. It MUST NOT
-	// be set from settings.CountryCodeKey (which is auto-populated from the
-	// server's first config response and is intended for issue reports), or
-	// the server's MaxMind ASN lookup short-circuits and returns ASN=0,
-	// breaking per-ASN bandit learning. See engineering #3398.
 	if val := env.GetString(env.Country); val != "" {
 		slog.Info("Setting x-lantern-client-country header", "country", val)
 		req.Header.Set("x-lantern-client-country", val)

--- a/config/fetcher.go
+++ b/config/fetcher.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/getlantern/radiance/account"
 	"github.com/getlantern/radiance/common"
+	"github.com/getlantern/radiance/common/env"
 	"github.com/getlantern/radiance/common/settings"
 	"github.com/getlantern/radiance/log"
 	"github.com/getlantern/radiance/traces"
@@ -153,7 +154,13 @@ func (f *fetcher) send(ctx context.Context, body io.Reader) ([]byte, error) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Cache-Control", "no-cache")
 
-	if val := settings.GetString(settings.CountryCodeKey); val != "" {
+	// x-lantern-client-country is a developer/test-only override that forces
+	// the server to apply diversion rules for a specific country. It MUST NOT
+	// be set from settings.CountryCodeKey (which is auto-populated from the
+	// server's first config response and is intended for issue reports), or
+	// the server's MaxMind ASN lookup short-circuits and returns ASN=0,
+	// breaking per-ASN bandit learning. See engineering #3398.
+	if val := env.GetString(env.Country); val != "" {
 		slog.Info("Setting x-lantern-client-country header", "country", val)
 		req.Header.Set("x-lantern-client-country", val)
 	}


### PR DESCRIPTION
## Summary

The `x-lantern-client-country` header is a developer/test-only override that forces the server to apply diversion rules for a specific country. [#370](https://github.com/getlantern/radiance/pull/370) (LocalBackend refactor) changed the read source from `os.LookupEnv("RADIANCE_COUNTRY")` to `settings.GetString(settings.CountryCodeKey)` — but `CountryCodeKey` is **auto-populated from the server's first config response** (intended for issue reports per the comment in `backend/radiance.go:212`), so every production client started sending the header on every subsequent `/config-new` request.

## Server impact

`lantern-cloud`'s `maxmind.LookupCountryASNState` short-circuits when this header is present and returns `ASN=0` without calling MaxMind. SigNoz data:

- **~21.6% of all `/config-new` responses landed with `bandit.asn=0` in the last 24h**
- **~82% of those caused by this header** (36k of 44k warns)
- **CN: ~100% impact** — every Chinese client is broken at per-ASN bandit level
- **Rising 6× week-over-week** as #370 rolled out

Per-ASN EXP3.S learning has been silently broken in our largest market. Refs [engineering#3398](https://github.com/getlantern/engineering/issues/3398).

## Fix

Switches the read back to `env.GetString(env.Country)` — the same env-var source the code had pre-#370 (`RADIANCE_COUNTRY`), using the existing `env` helper for consistency with `backend/radiance.go:214`. `settings.CountryCodeKey` continues to be populated from config responses for issue reports; it just no longer feeds the request header.

```go
// before (broken — auto-populated from server response)
if val := settings.GetString(settings.CountryCodeKey); val != "" { ... }

// after (dev-only env override)
if val := env.GetString(env.Country); val != "" { ... }
```

## Test plan

- [x] `go build ./config/...` clean
- [x] `go vet ./config/...` clean
- [x] `go test ./config/...` clean
- [ ] CI green
- [ ] After merge: SigNoz `"ASN resolved to 0"` rate should drop ~80% within minutes of clients picking up the new build (most rapidly in CN where impact is ~100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)