### PR TITLE
bump lantern-box to v0.0.77 (unbounded dial watchdog)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/getlantern/domainfront v0.0.0-20260419161617-0bff0b2169f4
 	github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694
 	github.com/getlantern/kindling v0.0.0-20260428171407-6143132aaf40
-	github.com/getlantern/lantern-box v0.0.76
+	github.com/getlantern/lantern-box v0.0.77
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694 h1:iLWm6S/4
 github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260428171407-6143132aaf40 h1:P5pkaBGxWOGBn7bKzjzdln/ro+ShG1RUbOuy+7pSzXE=
 github.com/getlantern/kindling v0.0.0-20260428171407-6143132aaf40/go.mod h1:TGTxpoNVwc8Be4qkBNtf5oj2psJaEIZEq47GOPS7zkA=
-github.com/getlantern/lantern-box v0.0.76 h1:SkSfkoYfZIXIyzte1+PXGX9PzdlNBKKwFt+fnCGkNAw=
-github.com/getlantern/lantern-box v0.0.76/go.mod h1:YV6+5bOdvw9rmc0cJoOTP7UaFt/6XWVOierv7KcfAkY=
+github.com/getlantern/lantern-box v0.0.77 h1:2b2TyrPXYHzIx1aPUvpE//AxoW0TMl/EF/bQHaZyfqw=
+github.com/getlantern/lantern-box v0.0.77/go.mod h1:YV6+5bOdvw9rmc0cJoOTP7UaFt/6XWVOierv7KcfAkY=
 github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90 h1:P9JX1yAu2uq3b5YiT0sLtHkTrkZuttV8gPZh81nUuag=
 github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90/go.mod h1:3JpJgwi4KEI6rS9loOAvcBp+F2jP65d0tTg2GQcTPBU=
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 h1:3BwvWj0JZzFEvNNiMhCu4bf60nqcIuQpTYb00Ezm1ag=


### PR DESCRIPTION
## Summary

Bumps `github.com/getlantern/lantern-box` from `v0.0.76` to `v0.0.77` to pick up [getlantern/lantern-box#252](https://github.com/getlantern/lantern-box/pull/252) — a passive dial watchdog inside the unbounded outbound.

## What this gets us

- Observes successful dial elapsed times per outbound and flags pairings that look pathologically slow.
- Trip rule: rolling 10-dial window has zero dials under 1s **and** the most recent 5 are each over 5s. Region-agnostic by construction (medium-band consistent dials don't trip; fast dials anywhere in the window save the pairing).
- Emits `slog.WarnContext` with structured fields when a pairing flips to unhealthy, and `slog.InfoContext` when a fast dial after a trip clears the state.
- Purely observational in this version; no action is taken on the broflake state machine. We need to see the rate of "unbounded peer flagged unhealthy" in production logs before adding a soft-reset action (which requires a re-pairing API in broflake's `clientcore` — separate PR).

## Test plan

- [x] `go mod tidy` clean
- [x] `go build ./...` clean for everything except the pre-existing `cmd/lantern/lantern.go:78` build error (unrelated to this bump — same error reproduces on `main` before the change)
- [x] `go vet ./...` likewise clean outside the pre-existing breakage
- [ ] After this lands and ships in a Lantern build, grep `lantern.log` for `unbounded peer flagged unhealthy` to confirm the symptom is being detected. Reasonable rate is the green light to start phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)