### PR TITLE
Wire peer.Client into LocalBackend (Share My Connection PR 2/4)

### DIFF
--- a/backend/peer_share.go
+++ b/backend/peer_share.go
@@ -1,0 +1,121 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/getlantern/radiance/common"
+	"github.com/getlantern/radiance/common/settings"
+	"github.com/getlantern/radiance/kindling"
+	"github.com/getlantern/radiance/peer"
+)
+
+// peerController is the subset of *peer.Client that LocalBackend needs.
+// Defined as an interface so tests can swap in a fake without standing up
+// real UPnP / sing-box / lantern-cloud dependencies.
+type peerController interface {
+	Start(ctx context.Context) error
+	Stop(ctx context.Context) error
+	IsActive() bool
+	CurrentStatus() peer.Status
+}
+
+// peerToggleTimeout caps blocking time on a slow router; UPnP M-SEARCH +
+// /v1/peer/register normally complete in single-digit seconds. Also used as
+// the deadline for Stop on backend close so a stalled deregister can't hang
+// shutdown.
+const peerToggleTimeout = 30 * time.Second
+
+// newPeerClient constructs the production peer.Client wired against the
+// shared kindling HTTP client and the platform device ID. Pulled out of
+// NewLocalBackend so the construction site is a one-liner.
+func newPeerClient(platformDeviceID string) (*peer.Client, error) {
+	api := peer.NewAPI(kindling.HTTPClient(), common.GetBaseURL(), platformDeviceID)
+	client, err := peer.NewClient(peer.Config{API: api})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create peer client: %w", err)
+	}
+	return client, nil
+}
+
+// applyPeerShare drives peerClient to match the toggle. On Start failure the
+// persisted setting is rolled back so reads of PeerShareEnabledKey reflect
+// runtime state. Stop errors are logged because a partial teardown shouldn't
+// keep the toggle on.
+//
+// peerToggleMu serializes concurrent toggles: without it, a fast off→on→off
+// sequence could see the second call's "already active" rollback racing the
+// third call's Stop.
+func (r *LocalBackend) applyPeerShare(enabled bool) error {
+	r.peerToggleMu.Lock()
+	defer r.peerToggleMu.Unlock()
+	toggleCtx, cancel := context.WithTimeout(r.ctx, peerToggleTimeout)
+	defer cancel()
+	if enabled {
+		if err := r.peerClient.Start(toggleCtx); err != nil {
+			if rbErr := settings.Patch(settings.Settings{settings.PeerShareEnabledKey: false}); rbErr != nil {
+				slog.Error("peer share rollback failed after Start error",
+					"start_err", err, "rollback_err", rbErr)
+			}
+			return fmt.Errorf("start peer share: %w", err)
+		}
+		return nil
+	}
+	if err := r.peerClient.Stop(toggleCtx); err != nil {
+		slog.Warn("peer share stop returned error (toggle still off)", "err", err)
+	}
+	return nil
+}
+
+// resumePeerShareIfEnabled re-Starts the peer client if the user left the
+// toggle on across restarts. Runs in a goroutine because UPnP discovery and
+// registration can take several seconds and Start() must return promptly.
+// peerWG ensures Close waits for an in-flight resume to settle before
+// teardown, so we never leave a registered route or a running box behind.
+func (r *LocalBackend) resumePeerShareIfEnabled() {
+	if !settings.GetBool(settings.PeerShareEnabledKey) {
+		return
+	}
+	r.peerWG.Add(1)
+	go func() {
+		defer r.peerWG.Done()
+		if r.ctx.Err() != nil {
+			return
+		}
+		if err := r.applyPeerShare(true); err != nil {
+			slog.Warn("peer share auto-resume failed", "err", err)
+		}
+	}()
+}
+
+// closePeerClient runs at backend shutdown. It waits for any in-flight
+// auto-resume Start to finish (so we don't tear down ctx while it's still
+// setting things up — that would leave a registered route + open box
+// behind) and then stops the peer client with a fresh ctx so Deregister
+// and UnmapPort have a live HTTP deadline even though r.ctx is about to
+// cancel.
+//
+// No-op when peerClient is nil (peer-focused unit tests that construct
+// partial LocalBackends).
+func (r *LocalBackend) closePeerClient() {
+	if r.peerClient == nil {
+		return
+	}
+	r.peerWG.Wait()
+	if !r.peerClient.IsActive() {
+		return
+	}
+	stopCtx, cancel := context.WithTimeout(context.Background(), peerToggleTimeout)
+	defer cancel()
+	if err := r.peerClient.Stop(stopCtx); err != nil {
+		slog.Warn("peer share stop on backend close returned error", "err", err)
+	}
+}
+
+// PeerStatus returns the current peer-share session state for the IPC
+// /peer/status endpoint.
+func (r *LocalBackend) PeerStatus() peer.Status {
+	return r.peerClient.CurrentStatus()
+}

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -35,6 +35,7 @@ import (
 	"github.com/getlantern/radiance/issue"
 	"github.com/getlantern/radiance/kindling"
 	"github.com/getlantern/radiance/log"
+	"github.com/getlantern/radiance/peer"
 	"github.com/getlantern/radiance/servers"
 	"github.com/getlantern/radiance/telemetry"
 	"github.com/getlantern/radiance/traces"
@@ -45,6 +46,13 @@ import (
 )
 
 const tracerName = "github.com/getlantern/radiance/backend"
+
+type peerController interface {
+	Start(ctx context.Context) error
+	Stop(ctx context.Context) error
+	IsActive() bool
+	CurrentStatus() peer.Status
+}
 
 // LocalBackend ties all the core functionality of Radiance together. It manages the configuration,
 // servers, VPN connection, account management, issue reporting, and telemetry for the application.
@@ -59,6 +67,9 @@ type LocalBackend struct {
 	srvManager     *servers.Manager
 	vpnClient      *vpn.VPNClient
 	splitTunnelMgr *vpn.SplitTunnel
+	peerClient     peerController
+	peerToggleMu   sync.Mutex
+	peerWG         sync.WaitGroup
 
 	shutdownFuncs []func() error
 	closeOnce     sync.Once
@@ -155,6 +166,13 @@ func NewLocalBackend(ctx context.Context, opts Options) (*LocalBackend, error) {
 	}
 
 	vpnClient := vpn.NewVPNClient(dataDir, slog.Default().With("service", "vpn"), opts.PlatformInterface)
+
+	peerAPI := peer.NewAPI(kindling.HTTPClient(), common.GetBaseURL(), platformDeviceID)
+	peerClient, err := peer.NewClient(peer.Config{API: peerAPI})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create peer client: %w", err)
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 	cOpts := config.Options{
 		DataPath:      dataDir,
@@ -172,6 +190,7 @@ func NewLocalBackend(ctx context.Context, opts Options) (*LocalBackend, error) {
 		srvManager:     svrMgr,
 		vpnClient:      vpnClient,
 		splitTunnelMgr: splitTunnelMgr,
+		peerClient:     peerClient,
 		shutdownFuncs: []func() error{
 			telemetry.Close, kindling.Close,
 		},
@@ -208,6 +227,8 @@ func (r *LocalBackend) Start() {
 	}
 	r.startVPNStatusListeners()
 	r.startAutoSelectedListener()
+
+	r.resumePeerShareIfEnabled()
 
 	// set country code in settings when new config is received so it can be included in issue reports
 	events.SubscribeOnce(func(evt config.NewConfigEvent) {
@@ -294,6 +315,20 @@ func (r *LocalBackend) Start() {
 func (r *LocalBackend) Close() {
 	r.closeOnce.Do(func() {
 		slog.Debug("Closing Radiance")
+		// Wait for an in-flight peer auto-resume so we don't tear down ctx
+		// while it's mid-Start (which would leave a registered route + open
+		// box behind). Then stop with a fresh ctx so Deregister has a live
+		// HTTP deadline even though r.ctx is about to cancel.
+		if r.peerClient != nil {
+			r.peerWG.Wait()
+			if r.peerClient.IsActive() {
+				stopCtx, cancel := context.WithTimeout(context.Background(), peerStartTimeout)
+				if err := r.peerClient.Stop(stopCtx); err != nil {
+					slog.Warn("peer share stop on backend close returned error", "err", err)
+				}
+				cancel()
+			}
+		}
 		r.cancel() // cancels context, unsubscribes all event listeners and stops child goroutines
 		close(r.stopChan)
 		for _, shutdown := range r.shutdownFuncs {
@@ -437,8 +472,73 @@ func (r *LocalBackend) PatchSettings(updates settings.Settings) error {
 	}
 	r.maybeRestartVPN(diff)
 
+	if _, ok := diff[settings.PeerShareEnabledKey]; ok {
+		if err := r.applyPeerShare(settings.GetBool(settings.PeerShareEnabledKey)); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
+
+// applyPeerShare drives peerClient to match the toggle. On Start failure the
+// persisted setting is rolled back so reads of PeerShareEnabledKey reflect
+// runtime state. Stop errors are logged because a partial teardown shouldn't
+// keep the toggle on.
+//
+// peerToggleMu serializes concurrent toggles: without it, a fast off→on→off
+// sequence could see the second call's "already active" rollback racing the
+// third call's Stop.
+//
+// peerStartTimeout caps blocking time on a slow router; UPnP M-SEARCH +
+// /v1/peer/register normally complete in single-digit seconds.
+func (r *LocalBackend) applyPeerShare(enabled bool) error {
+	r.peerToggleMu.Lock()
+	defer r.peerToggleMu.Unlock()
+	if enabled {
+		startCtx, cancel := context.WithTimeout(r.ctx, peerStartTimeout)
+		defer cancel()
+		if err := r.peerClient.Start(startCtx); err != nil {
+			if rbErr := settings.Patch(settings.Settings{settings.PeerShareEnabledKey: false}); rbErr != nil {
+				slog.Error("peer share rollback failed after Start error",
+					"start_err", err, "rollback_err", rbErr)
+			}
+			return fmt.Errorf("start peer share: %w", err)
+		}
+		return nil
+	}
+	if err := r.peerClient.Stop(r.ctx); err != nil {
+		slog.Warn("peer share stop returned error (toggle still off)", "err", err)
+	}
+	return nil
+}
+
+// resumePeerShareIfEnabled re-Starts the peer client if the user left the
+// toggle on across restarts. Runs in a goroutine because UPnP discovery and
+// registration can take several seconds and Start() must return promptly.
+// peerWG ensures Close waits for an in-flight resume to settle before
+// teardown, so we never leave a registered route or a running box behind.
+func (r *LocalBackend) resumePeerShareIfEnabled() {
+	if !settings.GetBool(settings.PeerShareEnabledKey) {
+		return
+	}
+	r.peerWG.Add(1)
+	go func() {
+		defer r.peerWG.Done()
+		if r.ctx.Err() != nil {
+			return
+		}
+		if err := r.applyPeerShare(true); err != nil {
+			slog.Warn("peer share auto-resume failed", "err", err)
+		}
+	}()
+}
+
+func (r *LocalBackend) PeerStatus() peer.Status {
+	return r.peerClient.CurrentStatus()
+}
+
+const peerStartTimeout = 30 * time.Second
 
 // maybeRestartVPN restarts the VPN connection if either the ad block or smart routing settings
 // were changed and the VPN is currently connected.

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -322,7 +322,7 @@ func (r *LocalBackend) Close() {
 		if r.peerClient != nil {
 			r.peerWG.Wait()
 			if r.peerClient.IsActive() {
-				stopCtx, cancel := context.WithTimeout(context.Background(), peerStartTimeout)
+				stopCtx, cancel := context.WithTimeout(context.Background(), peerToggleTimeout)
 				if err := r.peerClient.Stop(stopCtx); err != nil {
 					slog.Warn("peer share stop on backend close returned error", "err", err)
 				}
@@ -490,15 +490,15 @@ func (r *LocalBackend) PatchSettings(updates settings.Settings) error {
 // sequence could see the second call's "already active" rollback racing the
 // third call's Stop.
 //
-// peerStartTimeout caps blocking time on a slow router; UPnP M-SEARCH +
+// peerToggleTimeout caps blocking time on a slow router; UPnP M-SEARCH +
 // /v1/peer/register normally complete in single-digit seconds.
 func (r *LocalBackend) applyPeerShare(enabled bool) error {
 	r.peerToggleMu.Lock()
 	defer r.peerToggleMu.Unlock()
+	toggleCtx, cancel := context.WithTimeout(r.ctx, peerToggleTimeout)
+	defer cancel()
 	if enabled {
-		startCtx, cancel := context.WithTimeout(r.ctx, peerStartTimeout)
-		defer cancel()
-		if err := r.peerClient.Start(startCtx); err != nil {
+		if err := r.peerClient.Start(toggleCtx); err != nil {
 			if rbErr := settings.Patch(settings.Settings{settings.PeerShareEnabledKey: false}); rbErr != nil {
 				slog.Error("peer share rollback failed after Start error",
 					"start_err", err, "rollback_err", rbErr)
@@ -507,7 +507,7 @@ func (r *LocalBackend) applyPeerShare(enabled bool) error {
 		}
 		return nil
 	}
-	if err := r.peerClient.Stop(r.ctx); err != nil {
+	if err := r.peerClient.Stop(toggleCtx); err != nil {
 		slog.Warn("peer share stop returned error (toggle still off)", "err", err)
 	}
 	return nil
@@ -538,7 +538,7 @@ func (r *LocalBackend) PeerStatus() peer.Status {
 	return r.peerClient.CurrentStatus()
 }
 
-const peerStartTimeout = 30 * time.Second
+const peerToggleTimeout = 30 * time.Second
 
 // maybeRestartVPN restarts the VPN connection if either the ad block or smart routing settings
 // were changed and the VPN is currently connected.

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -35,7 +35,6 @@ import (
 	"github.com/getlantern/radiance/issue"
 	"github.com/getlantern/radiance/kindling"
 	"github.com/getlantern/radiance/log"
-	"github.com/getlantern/radiance/peer"
 	"github.com/getlantern/radiance/servers"
 	"github.com/getlantern/radiance/telemetry"
 	"github.com/getlantern/radiance/traces"
@@ -46,13 +45,6 @@ import (
 )
 
 const tracerName = "github.com/getlantern/radiance/backend"
-
-type peerController interface {
-	Start(ctx context.Context) error
-	Stop(ctx context.Context) error
-	IsActive() bool
-	CurrentStatus() peer.Status
-}
 
 // LocalBackend ties all the core functionality of Radiance together. It manages the configuration,
 // servers, VPN connection, account management, issue reporting, and telemetry for the application.
@@ -169,10 +161,9 @@ func NewLocalBackend(ctx context.Context, opts Options) (*LocalBackend, error) {
 
 	vpnClient := vpn.NewVPNClient(dataDir, slog.Default().With("service", "vpn"), opts.PlatformInterface)
 
-	peerAPI := peer.NewAPI(kindling.HTTPClient(), common.GetBaseURL(), platformDeviceID)
-	peerClient, err := peer.NewClient(peer.Config{API: peerAPI})
+	peerClient, err := newPeerClient(platformDeviceID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create peer client: %w", err)
+		return nil, err
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -322,20 +313,7 @@ func (r *LocalBackend) Start() {
 func (r *LocalBackend) Close() {
 	r.closeOnce.Do(func() {
 		slog.Debug("Closing Radiance")
-		// Wait for an in-flight peer auto-resume so we don't tear down ctx
-		// while it's mid-Start (which would leave a registered route + open
-		// box behind). Then stop with a fresh ctx so Deregister has a live
-		// HTTP deadline even though r.ctx is about to cancel.
-		if r.peerClient != nil {
-			r.peerWG.Wait()
-			if r.peerClient.IsActive() {
-				stopCtx, cancel := context.WithTimeout(context.Background(), peerToggleTimeout)
-				if err := r.peerClient.Stop(stopCtx); err != nil {
-					slog.Warn("peer share stop on backend close returned error", "err", err)
-				}
-				cancel()
-			}
-		}
+		r.closePeerClient()
 		// vpnClient is always set in production via NewLocalBackend, but
 		// peer-focused unit tests construct partial LocalBackends without
 		// one. Guard the call so Close stays robust under those paths
@@ -522,65 +500,6 @@ func (r *LocalBackend) PatchSettings(updates settings.Settings) error {
 
 	return nil
 }
-
-// applyPeerShare drives peerClient to match the toggle. On Start failure the
-// persisted setting is rolled back so reads of PeerShareEnabledKey reflect
-// runtime state. Stop errors are logged because a partial teardown shouldn't
-// keep the toggle on.
-//
-// peerToggleMu serializes concurrent toggles: without it, a fast off→on→off
-// sequence could see the second call's "already active" rollback racing the
-// third call's Stop.
-//
-// peerToggleTimeout caps blocking time on a slow router; UPnP M-SEARCH +
-// /v1/peer/register normally complete in single-digit seconds.
-func (r *LocalBackend) applyPeerShare(enabled bool) error {
-	r.peerToggleMu.Lock()
-	defer r.peerToggleMu.Unlock()
-	toggleCtx, cancel := context.WithTimeout(r.ctx, peerToggleTimeout)
-	defer cancel()
-	if enabled {
-		if err := r.peerClient.Start(toggleCtx); err != nil {
-			if rbErr := settings.Patch(settings.Settings{settings.PeerShareEnabledKey: false}); rbErr != nil {
-				slog.Error("peer share rollback failed after Start error",
-					"start_err", err, "rollback_err", rbErr)
-			}
-			return fmt.Errorf("start peer share: %w", err)
-		}
-		return nil
-	}
-	if err := r.peerClient.Stop(toggleCtx); err != nil {
-		slog.Warn("peer share stop returned error (toggle still off)", "err", err)
-	}
-	return nil
-}
-
-// resumePeerShareIfEnabled re-Starts the peer client if the user left the
-// toggle on across restarts. Runs in a goroutine because UPnP discovery and
-// registration can take several seconds and Start() must return promptly.
-// peerWG ensures Close waits for an in-flight resume to settle before
-// teardown, so we never leave a registered route or a running box behind.
-func (r *LocalBackend) resumePeerShareIfEnabled() {
-	if !settings.GetBool(settings.PeerShareEnabledKey) {
-		return
-	}
-	r.peerWG.Add(1)
-	go func() {
-		defer r.peerWG.Done()
-		if r.ctx.Err() != nil {
-			return
-		}
-		if err := r.applyPeerShare(true); err != nil {
-			slog.Warn("peer share auto-resume failed", "err", err)
-		}
-	}()
-}
-
-func (r *LocalBackend) PeerStatus() peer.Status {
-	return r.peerClient.CurrentStatus()
-}
-
-const peerToggleTimeout = 30 * time.Second
 
 // maybeRestartVPN restarts the VPN connection if either the ad block or smart routing settings
 // were changed and the VPN is currently connected. Returns an error if the VPN restart fails;

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -336,8 +336,14 @@ func (r *LocalBackend) Close() {
 				cancel()
 			}
 		}
-		if err := r.DisconnectVPN(); err != nil {
-			slog.Error("Failed to disconnect VPN on shutdown", "error", err)
+		// vpnClient is always set in production via NewLocalBackend, but
+		// peer-focused unit tests construct partial LocalBackends without
+		// one. Guard the call so Close stays robust under those paths
+		// rather than panicking in DisconnectVPN.
+		if r.vpnClient != nil {
+			if err := r.DisconnectVPN(); err != nil {
+				slog.Error("Failed to disconnect VPN on shutdown", "error", err)
+			}
 		}
 		r.cancel() // cancels context, unsubscribes all event listeners and stops child goroutines
 		close(r.stopChan)

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -329,7 +329,7 @@ func (r *LocalBackend) Close() {
 		if r.peerClient != nil {
 			r.peerWG.Wait()
 			if r.peerClient.IsActive() {
-				stopCtx, cancel := context.WithTimeout(context.Background(), peerStartTimeout)
+				stopCtx, cancel := context.WithTimeout(context.Background(), peerToggleTimeout)
 				if err := r.peerClient.Stop(stopCtx); err != nil {
 					slog.Warn("peer share stop on backend close returned error", "err", err)
 				}
@@ -526,15 +526,15 @@ func (r *LocalBackend) PatchSettings(updates settings.Settings) error {
 // sequence could see the second call's "already active" rollback racing the
 // third call's Stop.
 //
-// peerStartTimeout caps blocking time on a slow router; UPnP M-SEARCH +
+// peerToggleTimeout caps blocking time on a slow router; UPnP M-SEARCH +
 // /v1/peer/register normally complete in single-digit seconds.
 func (r *LocalBackend) applyPeerShare(enabled bool) error {
 	r.peerToggleMu.Lock()
 	defer r.peerToggleMu.Unlock()
+	toggleCtx, cancel := context.WithTimeout(r.ctx, peerToggleTimeout)
+	defer cancel()
 	if enabled {
-		startCtx, cancel := context.WithTimeout(r.ctx, peerStartTimeout)
-		defer cancel()
-		if err := r.peerClient.Start(startCtx); err != nil {
+		if err := r.peerClient.Start(toggleCtx); err != nil {
 			if rbErr := settings.Patch(settings.Settings{settings.PeerShareEnabledKey: false}); rbErr != nil {
 				slog.Error("peer share rollback failed after Start error",
 					"start_err", err, "rollback_err", rbErr)
@@ -543,7 +543,7 @@ func (r *LocalBackend) applyPeerShare(enabled bool) error {
 		}
 		return nil
 	}
-	if err := r.peerClient.Stop(r.ctx); err != nil {
+	if err := r.peerClient.Stop(toggleCtx); err != nil {
 		slog.Warn("peer share stop returned error (toggle still off)", "err", err)
 	}
 	return nil
@@ -574,7 +574,7 @@ func (r *LocalBackend) PeerStatus() peer.Status {
 	return r.peerClient.CurrentStatus()
 }
 
-const peerStartTimeout = 30 * time.Second
+const peerToggleTimeout = 30 * time.Second
 
 // maybeRestartVPN restarts the VPN connection if either the ad block or smart routing settings
 // were changed and the VPN is currently connected. Returns an error if the VPN restart fails;

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -35,6 +35,7 @@ import (
 	"github.com/getlantern/radiance/issue"
 	"github.com/getlantern/radiance/kindling"
 	"github.com/getlantern/radiance/log"
+	"github.com/getlantern/radiance/peer"
 	"github.com/getlantern/radiance/servers"
 	"github.com/getlantern/radiance/telemetry"
 	"github.com/getlantern/radiance/traces"
@@ -45,6 +46,13 @@ import (
 )
 
 const tracerName = "github.com/getlantern/radiance/backend"
+
+type peerController interface {
+	Start(ctx context.Context) error
+	Stop(ctx context.Context) error
+	IsActive() bool
+	CurrentStatus() peer.Status
+}
 
 // LocalBackend ties all the core functionality of Radiance together. It manages the configuration,
 // servers, VPN connection, account management, issue reporting, and telemetry for the application.
@@ -60,6 +68,10 @@ type LocalBackend struct {
 	vpnClient      *vpn.VPNClient
 	splitTunnelMgr *vpn.SplitTunnel
 	sessionHistory *vpn.SessionHistory
+
+	peerClient   peerController
+	peerToggleMu sync.Mutex
+	peerWG       sync.WaitGroup
 
 	shutdownFuncs []func() error
 	closeOnce     sync.Once
@@ -156,6 +168,13 @@ func NewLocalBackend(ctx context.Context, opts Options) (*LocalBackend, error) {
 	}
 
 	vpnClient := vpn.NewVPNClient(dataDir, slog.Default().With("service", "vpn"), opts.PlatformInterface)
+
+	peerAPI := peer.NewAPI(kindling.HTTPClient(), common.GetBaseURL(), platformDeviceID)
+	peerClient, err := peer.NewClient(peer.Config{API: peerAPI})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create peer client: %w", err)
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 	cOpts := config.Options{
 		DataPath:      dataDir,
@@ -173,6 +192,7 @@ func NewLocalBackend(ctx context.Context, opts Options) (*LocalBackend, error) {
 		srvManager:     svrMgr,
 		vpnClient:      vpnClient,
 		splitTunnelMgr: splitTunnelMgr,
+		peerClient:     peerClient,
 		shutdownFuncs: []func() error{
 			telemetry.Close, kindling.Close,
 		},
@@ -214,6 +234,8 @@ func (r *LocalBackend) Start() {
 	r.startVPNStatusListeners()
 	r.startAutoSelectedListener()
 	r.startSessionAutoSelectListener()
+
+	r.resumePeerShareIfEnabled()
 
 	// set country code in settings when new config is received so it can be included in issue reports
 	events.SubscribeOnce(func(evt config.NewConfigEvent) {
@@ -300,6 +322,20 @@ func (r *LocalBackend) Start() {
 func (r *LocalBackend) Close() {
 	r.closeOnce.Do(func() {
 		slog.Debug("Closing Radiance")
+		// Wait for an in-flight peer auto-resume so we don't tear down ctx
+		// while it's mid-Start (which would leave a registered route + open
+		// box behind). Then stop with a fresh ctx so Deregister has a live
+		// HTTP deadline even though r.ctx is about to cancel.
+		if r.peerClient != nil {
+			r.peerWG.Wait()
+			if r.peerClient.IsActive() {
+				stopCtx, cancel := context.WithTimeout(context.Background(), peerStartTimeout)
+				if err := r.peerClient.Stop(stopCtx); err != nil {
+					slog.Warn("peer share stop on backend close returned error", "err", err)
+				}
+				cancel()
+			}
+		}
 		if err := r.DisconnectVPN(); err != nil {
 			slog.Error("Failed to disconnect VPN on shutdown", "error", err)
 		}
@@ -468,8 +504,77 @@ func (r *LocalBackend) PatchSettings(updates settings.Settings) error {
 	if _, ok := diff[k]; ok {
 		r.splitTunnelMgr.SetEnabled(settings.GetBool(k))
 	}
-	return r.maybeRestartVPN(diff)
+	if err := r.maybeRestartVPN(diff); err != nil {
+		return err
+	}
+
+	if _, ok := diff[settings.PeerShareEnabledKey]; ok {
+		if err := r.applyPeerShare(settings.GetBool(settings.PeerShareEnabledKey)); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
+
+// applyPeerShare drives peerClient to match the toggle. On Start failure the
+// persisted setting is rolled back so reads of PeerShareEnabledKey reflect
+// runtime state. Stop errors are logged because a partial teardown shouldn't
+// keep the toggle on.
+//
+// peerToggleMu serializes concurrent toggles: without it, a fast off→on→off
+// sequence could see the second call's "already active" rollback racing the
+// third call's Stop.
+//
+// peerStartTimeout caps blocking time on a slow router; UPnP M-SEARCH +
+// /v1/peer/register normally complete in single-digit seconds.
+func (r *LocalBackend) applyPeerShare(enabled bool) error {
+	r.peerToggleMu.Lock()
+	defer r.peerToggleMu.Unlock()
+	if enabled {
+		startCtx, cancel := context.WithTimeout(r.ctx, peerStartTimeout)
+		defer cancel()
+		if err := r.peerClient.Start(startCtx); err != nil {
+			if rbErr := settings.Patch(settings.Settings{settings.PeerShareEnabledKey: false}); rbErr != nil {
+				slog.Error("peer share rollback failed after Start error",
+					"start_err", err, "rollback_err", rbErr)
+			}
+			return fmt.Errorf("start peer share: %w", err)
+		}
+		return nil
+	}
+	if err := r.peerClient.Stop(r.ctx); err != nil {
+		slog.Warn("peer share stop returned error (toggle still off)", "err", err)
+	}
+	return nil
+}
+
+// resumePeerShareIfEnabled re-Starts the peer client if the user left the
+// toggle on across restarts. Runs in a goroutine because UPnP discovery and
+// registration can take several seconds and Start() must return promptly.
+// peerWG ensures Close waits for an in-flight resume to settle before
+// teardown, so we never leave a registered route or a running box behind.
+func (r *LocalBackend) resumePeerShareIfEnabled() {
+	if !settings.GetBool(settings.PeerShareEnabledKey) {
+		return
+	}
+	r.peerWG.Add(1)
+	go func() {
+		defer r.peerWG.Done()
+		if r.ctx.Err() != nil {
+			return
+		}
+		if err := r.applyPeerShare(true); err != nil {
+			slog.Warn("peer share auto-resume failed", "err", err)
+		}
+	}()
+}
+
+func (r *LocalBackend) PeerStatus() peer.Status {
+	return r.peerClient.CurrentStatus()
+}
+
+const peerStartTimeout = 30 * time.Second
 
 // maybeRestartVPN restarts the VPN connection if either the ad block or smart routing settings
 // were changed and the VPN is currently connected. Returns an error if the VPN restart fails;

--- a/backend/radiance_test.go
+++ b/backend/radiance_test.go
@@ -1,8 +1,218 @@
 package backend
 
 import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/getlantern/radiance/common/settings"
+	"github.com/getlantern/radiance/peer"
 )
 
-func TestBackend(t *testing.T) {
+func TestBackend(t *testing.T) {}
+
+type fakePeerController struct {
+	startCalls atomic.Int64
+	stopCalls  atomic.Int64
+	startErr   error
+	active     atomic.Bool
+}
+
+func (f *fakePeerController) Start(_ context.Context) error {
+	f.startCalls.Add(1)
+	if f.startErr != nil {
+		return f.startErr
+	}
+	f.active.Store(true)
+	return nil
+}
+
+func (f *fakePeerController) Stop(_ context.Context) error {
+	f.stopCalls.Add(1)
+	f.active.Store(false)
+	return nil
+}
+
+func (f *fakePeerController) IsActive() bool          { return f.active.Load() }
+func (f *fakePeerController) CurrentStatus() peer.Status { return peer.Status{Active: f.active.Load()} }
+
+// newPeerTestBackend wires a minimal LocalBackend with only the fields
+// applyPeerShare touches. settings is initialized to a fresh tempdir per test
+// so the rollback path doesn't leak across runs.
+func newPeerTestBackend(t *testing.T, fake *fakePeerController) *LocalBackend {
+	t.Helper()
+	require.NoError(t, settings.InitSettings(t.TempDir()))
+	t.Cleanup(settings.Reset)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return &LocalBackend{ctx: ctx, peerClient: fake}
+}
+
+func TestApplyPeerShare_StartsOnEnable(t *testing.T) {
+	fake := &fakePeerController{}
+	r := newPeerTestBackend(t, fake)
+
+	require.NoError(t, r.applyPeerShare(true))
+	assert.Equal(t, int64(1), fake.startCalls.Load())
+	assert.Equal(t, int64(0), fake.stopCalls.Load())
+	assert.True(t, fake.IsActive())
+}
+
+func TestApplyPeerShare_StopsOnDisable(t *testing.T) {
+	fake := &fakePeerController{}
+	r := newPeerTestBackend(t, fake)
+	fake.active.Store(true)
+
+	require.NoError(t, r.applyPeerShare(false))
+	assert.Equal(t, int64(0), fake.startCalls.Load())
+	assert.Equal(t, int64(1), fake.stopCalls.Load())
+	assert.False(t, fake.IsActive())
+}
+
+// On a Start failure we surface the error so the Dart side can roll back
+// its UI, AND we flip the persisted setting back to false so the user-visible
+// state matches reality on the next read.
+func TestApplyPeerShare_StartFailureRollsBackSetting(t *testing.T) {
+	fake := &fakePeerController{startErr: errors.New("no upnp")}
+	r := newPeerTestBackend(t, fake)
+
+	require.NoError(t, settings.Patch(settings.Settings{settings.PeerShareEnabledKey: true}))
+	require.True(t, settings.GetBool(settings.PeerShareEnabledKey))
+
+	err := r.applyPeerShare(true)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "no upnp")
+	assert.False(t, settings.GetBool(settings.PeerShareEnabledKey),
+		"setting must roll back to false after a Start failure")
+	assert.False(t, fake.IsActive())
+}
+
+func TestPeerStatus_Accessor(t *testing.T) {
+	fake := &fakePeerController{}
+	r := newPeerTestBackend(t, fake)
+	fake.active.Store(true)
+
+	got := r.PeerStatus()
+	assert.True(t, got.Active)
+}
+
+func TestResumePeerShare_NoopWhenSettingOff(t *testing.T) {
+	fake := &fakePeerController{}
+	r := newPeerTestBackend(t, fake)
+
+	r.resumePeerShareIfEnabled()
+	r.peerWG.Wait()
+	assert.Equal(t, int64(0), fake.startCalls.Load())
+}
+
+func TestResumePeerShare_StartsWhenSettingOn(t *testing.T) {
+	fake := &fakePeerController{}
+	r := newPeerTestBackend(t, fake)
+	require.NoError(t, settings.Patch(settings.Settings{settings.PeerShareEnabledKey: true}))
+
+	r.resumePeerShareIfEnabled()
+	r.peerWG.Wait()
+	assert.Equal(t, int64(1), fake.startCalls.Load())
+	assert.True(t, fake.IsActive())
+}
+
+// Close must wait for an in-flight auto-resume Start before tearing down,
+// then call Stop on the active session — otherwise we leave a registered
+// route + open box behind on shutdown.
+func TestClose_WaitsForResumeAndStopsActivePeer(t *testing.T) {
+	startGate := make(chan struct{})
+	fake := &slowStartFake{gate: startGate}
+	r := newCloseableTestBackend(t, fake)
+	require.NoError(t, settings.Patch(settings.Settings{settings.PeerShareEnabledKey: true}))
+
+	r.resumePeerShareIfEnabled()
+
+	closeReturned := make(chan struct{})
+	go func() {
+		r.Close()
+		close(closeReturned)
+	}()
+
+	// Close must NOT return while the resume goroutine is still in Start.
+	select {
+	case <-closeReturned:
+		t.Fatal("Close returned before in-flight resume Start completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Release Start. It returns nil → peer becomes active. Close must then
+	// observe IsActive() and call Stop.
+	close(startGate)
+	select {
+	case <-closeReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not return after resume Start unblocked")
+	}
+	assert.Equal(t, int64(1), fake.startCalls.Load())
+	assert.Equal(t, int64(1), fake.stopCalls.Load())
+}
+
+// slowStartFake blocks on gate until the test releases it, simulating a
+// long UPnP discovery so we can race Close against Start.
+type slowStartFake struct {
+	startCalls atomic.Int64
+	stopCalls  atomic.Int64
+	active     atomic.Bool
+	gate       chan struct{}
+}
+
+func (f *slowStartFake) Start(ctx context.Context) error {
+	f.startCalls.Add(1)
+	select {
+	case <-f.gate:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	f.active.Store(true)
+	return nil
+}
+func (f *slowStartFake) Stop(_ context.Context) error {
+	f.stopCalls.Add(1)
+	f.active.Store(false)
+	return nil
+}
+func (f *slowStartFake) IsActive() bool             { return f.active.Load() }
+func (f *slowStartFake) CurrentStatus() peer.Status { return peer.Status{Active: f.active.Load()} }
+
+// newCloseableTestBackend mirrors newPeerTestBackend but provides the fields
+// Close needs (closeOnce, stopChan, cancel) so we can exercise the shutdown
+// path end-to-end.
+func newCloseableTestBackend(t *testing.T, fake peerController) *LocalBackend {
+	t.Helper()
+	require.NoError(t, settings.InitSettings(t.TempDir()))
+	t.Cleanup(settings.Reset)
+	ctx, cancel := context.WithCancel(context.Background())
+	return &LocalBackend{
+		ctx:        ctx,
+		cancel:     cancel,
+		peerClient: fake,
+		stopChan:   make(chan struct{}),
+		closeOnce:  sync.Once{},
+	}
+}
+
+// Verify the PatchSettings dispatch actually routes PeerShareEnabledKey to
+// applyPeerShare. A typo on the diff key would silently break the toggle.
+func TestPatchSettings_PeerShareDispatches(t *testing.T) {
+	fake := &fakePeerController{}
+	r := newPeerTestBackend(t, fake)
+
+	require.NoError(t, r.PatchSettings(settings.Settings{settings.PeerShareEnabledKey: true}))
+	assert.Equal(t, int64(1), fake.startCalls.Load())
+	assert.True(t, fake.IsActive())
+
+	require.NoError(t, r.PatchSettings(settings.Settings{settings.PeerShareEnabledKey: false}))
+	assert.Equal(t, int64(1), fake.stopCalls.Load())
+	assert.False(t, fake.IsActive())
 }

--- a/common/settings/settings.go
+++ b/common/settings/settings.go
@@ -50,11 +50,12 @@ const (
 	OAuthProviderKey _key = "oauth_provider" // string (e.g. "google", "apple", "email")
 
 	// VPN related keys.
-	SmartRoutingKey   _key = "smart_routing"   // bool
-	SplitTunnelKey    _key = "split_tunnel"    // bool
-	AdBlockKey        _key = "ad_block"        // bool
-	AutoConnectKey    _key = "auto_connect"    // bool
-	SelectedServerKey _key = "selected_server" // [servers.Server] Server.Options is not stored
+	SmartRoutingKey     _key = "smart_routing"      // bool
+	SplitTunnelKey      _key = "split_tunnel"       // bool
+	AdBlockKey          _key = "ad_block"           // bool
+	AutoConnectKey      _key = "auto_connect"       // bool
+	PeerShareEnabledKey _key = "peer_share_enabled" // bool
+	SelectedServerKey   _key = "selected_server"    // [servers.Server] Server.Options is not stored
 
 	PreferredLocationKey _key = "preferred_location" // [common.PreferredLocation]
 

--- a/common/settings/settings.go
+++ b/common/settings/settings.go
@@ -51,11 +51,12 @@ const (
 	OAuthProviderKey _key = "oauth_provider" // string (e.g. "google", "apple", "email")
 
 	// VPN related keys.
-	SmartRoutingKey   _key = "smart_routing"   // bool
-	SplitTunnelKey    _key = "split_tunnel"    // bool
-	AdBlockKey        _key = "ad_block"        // bool
-	AutoConnectKey    _key = "auto_connect"    // bool
-	SelectedServerKey _key = "selected_server" // [servers.Server] Server.Options is not stored
+	SmartRoutingKey     _key = "smart_routing"      // bool
+	SplitTunnelKey      _key = "split_tunnel"       // bool
+	AdBlockKey          _key = "ad_block"           // bool
+	AutoConnectKey      _key = "auto_connect"       // bool
+	PeerShareEnabledKey _key = "peer_share_enabled" // bool
+	SelectedServerKey   _key = "selected_server"    // [servers.Server] Server.Options is not stored
 
 	PreferredLocationKey _key = "preferred_location" // [common.PreferredLocation]
 

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -445,37 +445,40 @@ func (s *localapi) peerStatusHandler(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, s.backend(r.Context()).PeerStatus())
 }
 
-// peerStatusEventsHandler streams peer.StatusEvent over SSE. Replays the
-// current snapshot first so a subscriber attaching between events still sees
-// the live state.
+// peerStatusEventsHandler streams peer.StatusEvent over SSE. The wire
+// payload is always the live snapshot from PeerStatus(), not the event's
+// captured value: events.Emit dispatches each callback on its own goroutine
+// so a quick start→stop pair can land out of order, and we'd send a stale
+// "active" after a "inactive". Reading the live snapshot when the trigger
+// fires guarantees the SSE consumer's last message reflects current state.
 func (s *localapi) peerStatusEventsHandler(w http.ResponseWriter, r *http.Request) {
 	flusher := sseWriter(w)
 	if flusher == nil {
 		return
 	}
-	ch := make(chan []byte, 16)
-	sub := events.Subscribe(func(evt peer.StatusEvent) {
-		data, err := json.Marshal(evt)
-		if err != nil {
-			return
-		}
+	trigger := make(chan struct{}, 1)
+	sub := events.Subscribe(func(_ peer.StatusEvent) {
 		select {
-		case ch <- data:
+		case trigger <- struct{}{}:
 		default:
 		}
 	})
 	defer sub.Unsubscribe()
 
-	if data, err := json.Marshal(peer.StatusEvent{Status: s.backend(r.Context()).PeerStatus()}); err == nil {
+	send := func() {
+		data, err := json.Marshal(peer.StatusEvent{Status: s.backend(r.Context()).PeerStatus()})
+		if err != nil {
+			return
+		}
 		_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
 		flusher.Flush()
 	}
+	send() // replay current snapshot for subscribers attaching between events
 
 	for {
 		select {
-		case data := <-ch:
-			_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
-			flusher.Flush()
+		case <-trigger:
+			send()
 		case <-r.Context().Done():
 			return
 		}

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/getlantern/radiance/config"
 	"github.com/getlantern/radiance/events"
 	rlog "github.com/getlantern/radiance/log"
+	"github.com/getlantern/radiance/peer"
 	"github.com/getlantern/radiance/vpn"
 
 	sjson "github.com/sagernet/sing/common/json"
@@ -59,6 +60,10 @@ const (
 	// Settings endpoints
 	featuresEndpoint = "/settings/features"
 	settingsEndpoint = "/settings"
+
+	// Peer-share ("Share My Connection") endpoints
+	peerStatusEndpoint       = "/peer/status"
+	peerStatusEventsEndpoint = "/peer/status/events"
 
 	// Split tunnel endpoint
 	splitTunnelEndpoint = "/split-tunnel"
@@ -218,6 +223,11 @@ func newLocalAPI(b *backend.LocalBackend, withAuth bool) *localapi {
 	// Settings
 	mux.HandleFunc("GET "+featuresEndpoint, traced(s.featuresHandler))
 	mux.HandleFunc(settingsEndpoint, traced(s.settingsHandler))
+
+	// Peer share
+	mux.HandleFunc("GET "+peerStatusEndpoint, traced(s.peerStatusHandler))
+	// SSE skips the tracer middleware since it buffers the entire response body.
+	mux.HandleFunc("GET "+peerStatusEventsEndpoint, s.peerStatusEventsHandler)
 
 	// Split tunnel
 	mux.HandleFunc(splitTunnelEndpoint, traced(s.splitTunnelHandler))
@@ -421,6 +431,51 @@ func (s *localapi) vpnStatusEventsHandler(w http.ResponseWriter, r *http.Request
 			// and sse_parsed downstream to bracket transit through the
 			// (winio) named pipe on Windows.
 			slog.Info("[vpn-state-trace]", "hop", "ssehandler_flushed", "data", string(data), "ts_ms", time.Now().UnixMilli())
+		case <-r.Context().Done():
+			return
+		}
+	}
+}
+
+/////////////////
+//  Peer share //
+/////////////////
+
+func (s *localapi) peerStatusHandler(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, s.backend(r.Context()).PeerStatus())
+}
+
+// peerStatusEventsHandler streams peer.StatusEvent over SSE. Replays the
+// current snapshot first so a subscriber attaching between events still sees
+// the live state.
+func (s *localapi) peerStatusEventsHandler(w http.ResponseWriter, r *http.Request) {
+	flusher := sseWriter(w)
+	if flusher == nil {
+		return
+	}
+	ch := make(chan []byte, 16)
+	sub := events.Subscribe(func(evt peer.StatusEvent) {
+		data, err := json.Marshal(evt)
+		if err != nil {
+			return
+		}
+		select {
+		case ch <- data:
+		default:
+		}
+	})
+	defer sub.Unsubscribe()
+
+	if data, err := json.Marshal(peer.StatusEvent{Status: s.backend(r.Context()).PeerStatus()}); err == nil {
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
+		flusher.Flush()
+	}
+
+	for {
+		select {
+		case data := <-ch:
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
+			flusher.Flush()
 		case <-r.Context().Done():
 			return
 		}

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/getlantern/radiance/config"
 	"github.com/getlantern/radiance/events"
 	rlog "github.com/getlantern/radiance/log"
+	"github.com/getlantern/radiance/peer"
 	"github.com/getlantern/radiance/vpn"
 
 	sjson "github.com/sagernet/sing/common/json"
@@ -62,6 +63,10 @@ const (
 	// Settings endpoints
 	featuresEndpoint = "/settings/features"
 	settingsEndpoint = "/settings"
+
+	// Peer-share ("Share My Connection") endpoints
+	peerStatusEndpoint       = "/peer/status"
+	peerStatusEventsEndpoint = "/peer/status/events"
 
 	// Split tunnel endpoint
 	splitTunnelEndpoint = "/split-tunnel"
@@ -224,6 +229,11 @@ func newLocalAPI(b *backend.LocalBackend, withAuth bool) *localapi {
 	// Settings
 	mux.HandleFunc("GET "+featuresEndpoint, traced(s.featuresHandler))
 	mux.HandleFunc(settingsEndpoint, traced(s.settingsHandler))
+
+	// Peer share
+	mux.HandleFunc("GET "+peerStatusEndpoint, traced(s.peerStatusHandler))
+	// SSE skips the tracer middleware since it buffers the entire response body.
+	mux.HandleFunc("GET "+peerStatusEventsEndpoint, s.peerStatusEventsHandler)
 
 	// Split tunnel
 	mux.HandleFunc(splitTunnelEndpoint, traced(s.splitTunnelHandler))
@@ -452,6 +462,51 @@ func (s *localapi) vpnStatusEventsHandler(w http.ResponseWriter, r *http.Request
 			// and sse_parsed downstream to bracket transit through the
 			// (winio) named pipe on Windows.
 			slog.Info("[vpn-state-trace]", "hop", "ssehandler_flushed", "data", string(data), "ts_ms", time.Now().UnixMilli())
+		case <-r.Context().Done():
+			return
+		}
+	}
+}
+
+/////////////////
+//  Peer share //
+/////////////////
+
+func (s *localapi) peerStatusHandler(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, s.backend(r.Context()).PeerStatus())
+}
+
+// peerStatusEventsHandler streams peer.StatusEvent over SSE. Replays the
+// current snapshot first so a subscriber attaching between events still sees
+// the live state.
+func (s *localapi) peerStatusEventsHandler(w http.ResponseWriter, r *http.Request) {
+	flusher := sseWriter(w)
+	if flusher == nil {
+		return
+	}
+	ch := make(chan []byte, 16)
+	sub := events.Subscribe(func(evt peer.StatusEvent) {
+		data, err := json.Marshal(evt)
+		if err != nil {
+			return
+		}
+		select {
+		case ch <- data:
+		default:
+		}
+	})
+	defer sub.Unsubscribe()
+
+	if data, err := json.Marshal(peer.StatusEvent{Status: s.backend(r.Context()).PeerStatus()}); err == nil {
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
+		flusher.Flush()
+	}
+
+	for {
+		select {
+		case data := <-ch:
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
+			flusher.Flush()
 		case <-r.Context().Done():
 			return
 		}

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -476,37 +476,40 @@ func (s *localapi) peerStatusHandler(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, s.backend(r.Context()).PeerStatus())
 }
 
-// peerStatusEventsHandler streams peer.StatusEvent over SSE. Replays the
-// current snapshot first so a subscriber attaching between events still sees
-// the live state.
+// peerStatusEventsHandler streams peer.StatusEvent over SSE. The wire
+// payload is always the live snapshot from PeerStatus(), not the event's
+// captured value: events.Emit dispatches each callback on its own goroutine
+// so a quick start→stop pair can land out of order, and we'd send a stale
+// "active" after a "inactive". Reading the live snapshot when the trigger
+// fires guarantees the SSE consumer's last message reflects current state.
 func (s *localapi) peerStatusEventsHandler(w http.ResponseWriter, r *http.Request) {
 	flusher := sseWriter(w)
 	if flusher == nil {
 		return
 	}
-	ch := make(chan []byte, 16)
-	sub := events.Subscribe(func(evt peer.StatusEvent) {
-		data, err := json.Marshal(evt)
-		if err != nil {
-			return
-		}
+	trigger := make(chan struct{}, 1)
+	sub := events.Subscribe(func(_ peer.StatusEvent) {
 		select {
-		case ch <- data:
+		case trigger <- struct{}{}:
 		default:
 		}
 	})
 	defer sub.Unsubscribe()
 
-	if data, err := json.Marshal(peer.StatusEvent{Status: s.backend(r.Context()).PeerStatus()}); err == nil {
+	send := func() {
+		data, err := json.Marshal(peer.StatusEvent{Status: s.backend(r.Context()).PeerStatus()})
+		if err != nil {
+			return
+		}
 		_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
 		flusher.Flush()
 	}
+	send() // replay current snapshot for subscribers attaching between events
 
 	for {
 		select {
-		case data := <-ch:
-			_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
-			flusher.Flush()
+		case <-trigger:
+			send()
 		case <-r.Context().Done():
 			return
 		}

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -12,8 +12,16 @@ import (
 
 	"github.com/sagernet/sing-box/experimental/libbox"
 
+	"github.com/getlantern/radiance/events"
 	"github.com/getlantern/radiance/portforward"
 )
+
+// StatusEvent fires whenever the Client's session state changes — successful
+// Start, user Stop, or auto-Stop on a 404 heartbeat.
+type StatusEvent struct {
+	events.Event
+	Status Status `json:"status"`
+}
 
 // Lower bound avoids well-known/registered ports; upper bound stays below the
 // typical OS ephemeral range so the OS isn't likely to assign the same port
@@ -223,6 +231,7 @@ func (c *Client) Start(ctx context.Context) error {
 		ExternalPort: mapping.ExternalPort,
 		RouteID:      regResp.RouteID,
 	}
+	statusSnapshot := c.status
 	c.mu.Unlock()
 
 	fwd.StartRenewal(runCtx)
@@ -237,6 +246,7 @@ func (c *Client) Start(ctx context.Context) error {
 		"heartbeat", heartbeat,
 	)
 	success = true
+	events.Emit(StatusEvent{Status: statusSnapshot})
 	return nil
 }
 
@@ -283,6 +293,7 @@ func (c *Client) Stop(ctx context.Context) error {
 		slog.Warn("peer client unmap port failed", "err", err)
 	}
 	slog.Info("peer client stopped", "route_id", routeID)
+	events.Emit(StatusEvent{Status: Status{}})
 	return firstErr
 }
 

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -101,7 +101,18 @@ func NewClient(cfg Config) (*Client, error) {
 	}
 	if cfg.NewForwarder == nil {
 		cfg.NewForwarder = func(ctx context.Context) (portForwarder, error) {
-			return portforward.NewForwarder(ctx)
+			// Explicitly return a nil interface on error — `return
+			// portforward.NewForwarder(ctx)` collapses the (*Forwarder, error)
+			// pair into a typed-nil interface on failure, which then panics
+			// inside the deferred cleanup's `if fwd != nil { fwd.UnmapPort... }`
+			// because the nil-check passes (interface has a type) but the
+			// receiver is nil. Surfacing the underlying error here lets the
+			// caller see ErrNoPortForwarding instead of a runtime panic.
+			fwd, err := portforward.NewForwarder(ctx)
+			if err != nil {
+				return nil, err
+			}
+			return fwd, nil
 		}
 	}
 	if cfg.BuildBoxService == nil {

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -111,7 +111,18 @@ func NewClient(cfg Config) (*Client, error) {
 	}
 	if cfg.NewForwarder == nil {
 		cfg.NewForwarder = func(ctx context.Context) (portForwarder, error) {
-			return portforward.NewForwarder(ctx)
+			// Explicitly return a nil interface on error — `return
+			// portforward.NewForwarder(ctx)` collapses the (*Forwarder, error)
+			// pair into a typed-nil interface on failure, which then panics
+			// inside the deferred cleanup's `if fwd != nil { fwd.UnmapPort... }`
+			// because the nil-check passes (interface has a type) but the
+			// receiver is nil. Surfacing the underlying error here lets the
+			// caller see ErrNoPortForwarding instead of a runtime panic.
+			fwd, err := portforward.NewForwarder(ctx)
+			if err != nil {
+				return nil, err
+			}
+			return fwd, nil
 		}
 	}
 	if cfg.BuildBoxService == nil {

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -12,8 +12,16 @@ import (
 
 	"github.com/sagernet/sing-box/experimental/libbox"
 
+	"github.com/getlantern/radiance/events"
 	"github.com/getlantern/radiance/portforward"
 )
+
+// StatusEvent fires whenever the Client's session state changes — successful
+// Start, user Stop, or auto-Stop on a 404 heartbeat.
+type StatusEvent struct {
+	events.Event
+	Status Status `json:"status"`
+}
 
 // Port range chosen to minimize collision risk on the typical home network,
 // not to guarantee one. 30000–50000 sits above the well-known/system range
@@ -243,6 +251,7 @@ func (c *Client) Start(ctx context.Context) error {
 		ExternalPort: mapping.ExternalPort,
 		RouteID:      regResp.RouteID,
 	}
+	statusSnapshot := c.status
 	c.mu.Unlock()
 
 	fwd.StartRenewal(runCtx)
@@ -257,6 +266,7 @@ func (c *Client) Start(ctx context.Context) error {
 		"heartbeat", heartbeat,
 	)
 	success = true
+	events.Emit(StatusEvent{Status: statusSnapshot})
 	return nil
 }
 
@@ -320,6 +330,7 @@ func (c *Client) Stop(ctx context.Context) error {
 		slog.Warn("peer client unmap port failed", "err", err)
 	}
 	slog.Info("peer client stopped", "route_id", routeID)
+	events.Emit(StatusEvent{Status: Status{}})
 	return firstErr
 }
 

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/getlantern/radiance/events"
 	"github.com/getlantern/radiance/portforward"
 )
 
@@ -506,6 +507,38 @@ func TestAPIError_StringFormat(t *testing.T) {
 	e := &APIError{Status: 422, Body: "could not connect to peer port"}
 	assert.Contains(t, e.Error(), "422")
 	assert.Contains(t, e.Error(), "could not connect")
+}
+
+// Subscribers (the IPC SSE handler in production) need both edges so the UI
+// can render fresh state without polling.
+func TestClient_StatusEventEmittedOnStartAndStop(t *testing.T) {
+	fwd := &fakeForwarder{}
+	box := &fakeBoxService{}
+	srv := newStubServer(t)
+	c := newTestClient(t, fwd, box, srv)
+
+	got := make(chan StatusEvent, 4)
+	sub := events.Subscribe(func(evt StatusEvent) {
+		got <- evt
+	})
+	defer sub.Unsubscribe()
+
+	require.NoError(t, c.Start(context.Background()))
+	select {
+	case evt := <-got:
+		assert.True(t, evt.Status.Active)
+		assert.NotEmpty(t, evt.Status.RouteID)
+	case <-time.After(time.Second):
+		t.Fatal("no Start status event within 1s")
+	}
+
+	require.NoError(t, c.Stop(context.Background()))
+	select {
+	case evt := <-got:
+		assert.False(t, evt.Status.Active)
+	case <-time.After(time.Second):
+		t.Fatal("no Stop status event within 1s")
+	}
 }
 
 var _ portForwarder = (*fakeForwarder)(nil)

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/getlantern/radiance/events"
 	"github.com/getlantern/radiance/portforward"
 )
 
@@ -573,6 +574,38 @@ func TestAPIError_StringFormat(t *testing.T) {
 	e := &APIError{Status: 422, Body: "could not connect to peer port"}
 	assert.Contains(t, e.Error(), "422")
 	assert.Contains(t, e.Error(), "could not connect")
+}
+
+// Subscribers (the IPC SSE handler in production) need both edges so the UI
+// can render fresh state without polling.
+func TestClient_StatusEventEmittedOnStartAndStop(t *testing.T) {
+	fwd := &fakeForwarder{}
+	box := &fakeBoxService{}
+	srv := newStubServer(t)
+	c := newTestClient(t, fwd, box, srv)
+
+	got := make(chan StatusEvent, 4)
+	sub := events.Subscribe(func(evt StatusEvent) {
+		got <- evt
+	})
+	defer sub.Unsubscribe()
+
+	require.NoError(t, c.Start(context.Background()))
+	select {
+	case evt := <-got:
+		assert.True(t, evt.Status.Active)
+		assert.NotEmpty(t, evt.Status.RouteID)
+	case <-time.After(time.Second):
+		t.Fatal("no Start status event within 1s")
+	}
+
+	require.NoError(t, c.Stop(context.Background()))
+	select {
+	case evt := <-got:
+		assert.False(t, evt.Status.Active)
+	case <-time.After(time.Second):
+		t.Fatal("no Stop status event within 1s")
+	}
 }
 
 var _ portForwarder = (*fakeForwarder)(nil)

--- a/portforward/portforward.go
+++ b/portforward/portforward.go
@@ -113,6 +113,14 @@ func (f *Forwarder) MapPort(ctx context.Context, internalPort uint16, descriptio
 // about a router rule that's actually still live and the user would have
 // to wait for the UPnP lease to expire.
 func (f *Forwarder) UnmapPort(ctx context.Context) error {
+	// Defensive: callers that pass a *Forwarder through an interface (see
+	// peer.Client's portForwarder shim) can land here with f == nil if a
+	// failed construction collapsed `(*Forwarder)(nil), err` into a
+	// non-nil-but-typed-nil interface. A bare `f.mu.Lock()` would panic;
+	// this guard makes the cleanup path idempotent against that race.
+	if f == nil {
+		return nil
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.cancel != nil {

--- a/portforward/portforward.go
+++ b/portforward/portforward.go
@@ -130,6 +130,14 @@ func (f *Forwarder) MapPort(ctx context.Context, internalPort uint16, descriptio
 // about a router rule that's actually still live and the user would have
 // to wait for the UPnP lease to expire.
 func (f *Forwarder) UnmapPort(ctx context.Context) error {
+	// Defensive: callers that pass a *Forwarder through an interface (see
+	// peer.Client's portForwarder shim) can land here with f == nil if a
+	// failed construction collapsed `(*Forwarder)(nil), err` into a
+	// non-nil-but-typed-nil interface. A bare `f.mu.Lock()` would panic;
+	// this guard makes the cleanup path idempotent against that race.
+	if f == nil {
+		return nil
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.cancel != nil {


### PR DESCRIPTION
Stacks on **#458** (peer module + portforward). Targets `fisk/peer-module`; rebase onto `main` when #458 merges.

## What's wired up

```
Dart toggle → FFI (PR 3) → backend.PatchSettings({PeerShareEnabledKey: true})
                                                          │
                                                          ▼
                                                  applyPeerShare(true)
                                                          │
                          ┌───────────────────────────────┼────────────────────────┐
                          ▼                               ▼                        ▼
                  peer.Client.Start             rollback setting            emit peer.StatusEvent
                   (UPnP → register             on Start failure           (subscribed by IPC SSE)
                    → sing-box → hb)
```

* `common/settings`: `PeerShareEnabledKey` (bool).
* `peer.Client`: emits `peer.StatusEvent` on Start success and Stop completion.
* `backend.LocalBackend`:
  - new `peerController` interface seam (so tests can inject a fake)
  - constructed in `NewLocalBackend` with `kindling.HTTPClient()` + `common.GetBaseURL()` + the device ID
  - new `applyPeerShare` helper, called from `PatchSettings` dispatch
  - new `PeerStatus()` accessor for the IPC handler
* `ipc`: `GET /peer/status` (snapshot) + `GET /peer/status/events` (SSE).

## Three subtle behaviors worth flagging

1. **Toggle calls are serialized** by `peerToggleMu`. Without it, a fast `off→on→off` could see the second call's `"already active"` rollback racing the third call's `Stop`, and the persisted setting could end up disagreeing with runtime state.
2. **Start runs under a 30s deadline**. UPnP discovery + register + box build is normally single-digit seconds; the deadline caps the worst case so a hung router can't block the IPC toggle response indefinitely.
3. **Auto-resume + Close synchronize via `peerWG`**. If the user left the toggle on across restarts, `LocalBackend.Start()` resumes the session in a goroutine. Without the WG, a `Close()` racing the resume could cancel `r.ctx` mid-Start, leaving a registered route + open box behind on the cloud side.

## Rollback semantics

Mirroring `setBlockAds`: write the setting, try the side effect, on failure roll the setting back AND return the error so the Dart toggle can re-render to "off" with a user-facing error. `Stop` errors are logged but not surfaced — the user wants the session off, and a partial teardown shouldn't keep the toggle on.

## Test coverage

- `TestApplyPeerShare_StartsOnEnable` / `_StopsOnDisable` / `_StartFailureRollsBackSetting`
- `TestResumePeerShare_NoopWhenSettingOff` / `_StartsWhenSettingOn`
- `TestClose_WaitsForResumeAndStopsActivePeer` — exercises the WG race using a `slowStartFake` that blocks Start on a gate channel; asserts Close cannot return until the gate is released
- `TestPatchSettings_PeerShareDispatches` — PatchSettings({PeerShareEnabledKey: true}) → fake.startCalls == 1 (catches a typo'd dispatch key)
- `TestClient_StatusEventEmittedOnStartAndStop` in `peer/` — Subscribe and assert both edges fire with the expected `Status`

`go test -race ./peer/... ./backend/... ./common/settings/... ./ipc/...` and `golangci-lint run --new-from-rev=origin/main` are both clean.

## Out of scope (PR 3-4)

- PR 3 (lantern-core): `setPeerProxyEnabled` FFI export + ffigen regen.
- PR 4 (lantern): Dart `setPeerProxy` rewrite mirroring `setBlockAds`, optional status indicator using the new SSE.

## Test plan

- [x] `go test -race ./peer/... ./backend/... ./common/settings/... ./ipc/...`
- [x] `golangci-lint run --new-from-rev=origin/main`
- [ ] Manual end-to-end deferred until PR 4 (when the Dart toggle lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)