### PR TITLE
fix: disconnect VPN on backend close

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -294,6 +294,9 @@ func (r *LocalBackend) Start() {
 func (r *LocalBackend) Close() {
 	r.closeOnce.Do(func() {
 		slog.Debug("Closing Radiance")
+		if err := r.DisconnectVPN(); err != nil {
+			slog.Error("Failed to disconnect VPN on shutdown", "error", err)
+		}
 		r.cancel() // cancels context, unsubscribes all event listeners and stops child goroutines
 		close(r.stopChan)
 		for _, shutdown := range r.shutdownFuncs {


### PR DESCRIPTION
Disconnect the VPN in `LocalBackend.Close` to prevent network from entering an error state if VPN was connected.