### PR TITLE
feat(cli): add monitor TUI, throughput, and session history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,19 +2,37 @@
 
 ## Code Comments
 
-**Default: no comment.** Only add one if a specific *why* is load-bearing — invariant, concurrency guarantee, error condition, zero-value behavior, non-obvious caller contract, or a constraint that would surprise the reader. Aesthetic "this section is well-documented" comments are noise.
+**Language doc conventions take precedence.** When writing a doc comment that the language's tooling formats or renders (Go's `// Foo ...`, Python docstrings, JSDoc, rustdoc, etc.), follow that convention even if it conflicts with the "lead with the *why*" guidance — for Go that means start with the identifier's name. The *why* still belongs in the comment, just in the body after the conventional opening.
 
-Before writing any comment, run this checklist on the proposed text. If any answer is yes, delete or rewrite:
+- **Default: no comment.** Only comment when necessary to explain a non-obvious contract, invariant, rationale, or surprising behavior.
+- Comments must answer *why* something is done a particular way, not *what* is being done (which should be clear from the code and naming).
+- Before adding a comment, ask:
+  - Is this information not obvious from the code or naming?
+  - Does it document a constraint, invariant, concurrency guarantee, or error condition that would surprise a reader?
+  - Is it essential for future maintainers to understand the reasoning or risk behind this code?
+- **Do not add comments that:**
+  - Restate the identifier name (in-line only).
+  - Narrate the next line of code.
+  - Reference tickets, coworkers, or code locations (these belong in commit messages).
+  - Describe the mechanism instead of the contract.
+  - Are aesthetic or redundant ("well-documented").
+- Prefer documenting contracts at the declaration site. Use inline comments only for truly non-obvious lines.
+- Remove or update obsolete comments promptly.
+- **TODOs:** Must state both what needs to be done and why it isn’t done now. Remove or resolve unclear TODOs.
 
-1. Does it restate the identifier name or signature? (`// Foo does foo`, `// updateX manages X across Y`)
-2. Does it narrate what the visible next line does? (`// Cancel any existing listener` immediately above `cancel()`)
-3. Does it open with a generic lifecycle/management preamble before getting to the point? (`// manages the lifecycle of...`, `// handles the X for Y`)
-4. Does it reference tickets, coworkers, sibling files, commit SHAs, or other code locations? Those belong in the commit message / PR description — they rot in source.
-5. Does it describe the mechanism instead of the contract? (`authenticates via peer credentials over a Unix socket` vs. `authenticates each connection`)
+**Examples:**
 
-Lead with the *why*, not a summary of the function. If the only thing you can write is a summary, the comment isn't needed.
+```go
+// BAD: Restates what the code does
+// Cancel any in-flight requests.
+cancelRequests()
 
-Examples:
+// GOOD: Explains why this is necessary
+// Must cancel in-flight requests to avoid leaking goroutines on shutdown.
+cancelRequests()
+```
+
+---
 
 ```go
 // BAD — restates name, generic preamble, narrates the code
@@ -50,18 +68,60 @@ c.offlineTestCancel()
 // access is released before disk I/O so a slow write can't starve readers.
 ```
 
+```go
+// BAD — doc block enumerates every branch; only one branch has hidden why,
+// the rest restate cases the code already shows
+// mapStatusEvent maps a radiance VPN status event to the wire value sent
+// to Dart. Three cases deviate from a direct pass-through:
+//   - vpn.Restarting collapses into vpn.Connecting so the UI shows a
+//     transitional state during a tunnel restart.
+//   - A non-empty evt.Error always maps to vpn.ErrorStatus.
+//   - An unrecognized status falls back to Disconnected.
+func mapStatusEvent(evt vpn.StatusUpdateEvent) (vpn.VPNStatus, string) { ... }
+
+// GOOD — no doc block; inline comment on the only branch with hidden context
+func mapStatusEvent(evt vpn.StatusUpdateEvent) (vpn.VPNStatus, string) {
+	if evt.Error != "" {
+		return vpn.ErrorStatus, evt.Error
+	}
+	switch evt.Status {
+	case vpn.Connected, vpn.Connecting, vpn.Disconnecting, vpn.Disconnected, vpn.ErrorStatus:
+		return evt.Status, ""
+	case vpn.Restarting:
+		// Map to Connecting; Dart's parser falls back to Disconnected otherwise.
+		return vpn.Connecting, ""
+	default:
+		return vpn.Disconnected, ""
+	}
+}
+```
+
 Before writing an inline comment, consider whether a doc comment on the enclosing function or type would make it unnecessary. Prefer documenting contracts at the declaration over explaining implementation details inline.
 
+Conversely, before writing a multi-bullet doc block that enumerates branches or cases, check each bullet against the line that implements it. If only one bullet carries hidden *why* and the rest restate visible branches, drop the doc block and put a single inline comment on the surprising branch. Doc blocks belong on contracts that surprise as a whole, not on functions where one corner of the implementation is non-obvious. The bar is higher for unexported helpers: the Go doc convention targets exported API, and unexported functions should default to no comment unless the contract genuinely surprises.
+
 TODO comments must state *what* needs to happen and *why* it isn't done now. `TODO: ???` is not actionable — either resolve it or remove it.
+
+## Go Doc Comments
+
+- Use Go doc comments (`// Foo ...`) for exported identifiers and any unexported ones with non-obvious contracts.
+- Start with the identifier’s name and a concise summary: `// Foo does X.` The first sentence is shown by `go doc` and pkg.go.dev.
+- Follow with additional context or rationale as needed, especially if the *why* is not obvious.
+- Place the comment immediately above the declaration, with no blank line.
+- For package comments, place one above the `package` clause (typically in `doc.go`), starting with `// Package foo ...`.
+- Formatting:
+  - Use blank lines for paragraphs.
+  - Indent code blocks.
+  - Use lists and headings as supported by Go doc formatting.
+  - Avoid HTML and manual line wrapping; let gofmt handle formatting.
+- Use `// Deprecated: ...` on its own paragraph for deprecated identifiers.
+- Prefer `ExampleFoo` functions in `_test.go` for usage examples; these are rendered and tested by Go tooling.
+- Review doc comments regularly to keep them accurate and relevant.
+
+**Reference:** [Go doc comment guidelines](https://go.dev/doc/comment)
 
 ## Comment Verification
 
 After any edit that adds or modifies a comment, you MUST spawn a code-reviewer subagent with the diff before declaring the task done. The subagent applies the Code Comments checklist above and reports violations. Fix the violations and re-spawn until the subagent reports none.
 
 You MUST NOT skip this by self-reviewing the diff. The point of the subagent is to review without the generation bias of the Claude that wrote the comment — a self-review by the writer is a known failure mode and does not satisfy this step.
-
-## Go Doc Comments
-
-- When a doc comment is warranted on an exported identifier, start it with the identifier's name and use complete sentences: `// Foo does X.` The first sentence is the summary shown by `go doc` and pkg.go.dev.
-- Package comments: one per package, above the `package` clause (conventionally in `doc.go` for larger packages), starting with `// Package foo ...`.
-- Formatting (gofmt-aware since Go 1.19): blank lines separate paragraphs; indented lines render as code blocks; lines starting with `-`, `*`, or `1.` render as lists; `[Name]` links to other symbols; `# Heading` renders as a heading. Avoid HTML and manual wrapping.

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -59,6 +59,7 @@ type LocalBackend struct {
 	srvManager     *servers.Manager
 	vpnClient      *vpn.VPNClient
 	splitTunnelMgr *vpn.SplitTunnel
+	sessionHistory *vpn.SessionHistory
 
 	shutdownFuncs []func() error
 	closeOnce     sync.Once
@@ -180,6 +181,8 @@ func NewLocalBackend(ctx context.Context, opts Options) (*LocalBackend, error) {
 		deviceID:  platformDeviceID,
 		dataCapCh: make(chan *account.DataCapInfo, 1),
 	}
+	r.sessionHistory = vpn.NewSessionHistory(slog.Default().With("service", "session_history"), r.sessionInfo())
+	r.shutdownFuncs = append(r.shutdownFuncs, func() error { r.sessionHistory.Close(); return nil })
 	return r, nil
 }
 
@@ -208,6 +211,7 @@ func (r *LocalBackend) Start() {
 	}
 	r.startVPNStatusListeners()
 	r.startAutoSelectedListener()
+	r.startSessionAutoSelectListener()
 
 	// set country code in settings when new config is received so it can be included in issue reports
 	events.SubscribeOnce(func(evt config.NewConfigEvent) {
@@ -294,6 +298,9 @@ func (r *LocalBackend) Start() {
 func (r *LocalBackend) Close() {
 	r.closeOnce.Do(func() {
 		slog.Debug("Closing Radiance")
+		if err := r.DisconnectVPN(); err != nil {
+			slog.Error("Failed to disconnect VPN on shutdown", "error", err)
+		}
 		r.cancel() // cancels context, unsubscribes all event listeners and stops child goroutines
 		close(r.stopChan)
 		for _, shutdown := range r.shutdownFuncs {
@@ -315,6 +322,24 @@ func (r *LocalBackend) startVPNStatusListeners() {
 	events.SubscribeContext(r.ctx, func(evt vpn.StatusUpdateEvent) {
 		r.updateURLTestListener(evt.Status)
 	})
+}
+
+func (r *LocalBackend) sessionInfo() vpn.SessionInfo {
+	return vpn.SessionInfo{
+		Status: r.vpnClient.Status,
+		SelectedServer: func() (tag, city, country string) {
+			server, _, err := r.SelectedServer()
+			if err != nil || server == nil {
+				return "", "", ""
+			}
+			return server.Tag, server.Location.City, server.Location.Country
+		},
+		Bytes: r.vpnClient.Bytes,
+	}
+}
+
+func (r *LocalBackend) Sessions(limit int) []vpn.Session {
+	return r.sessionHistory.Sessions(limit)
 }
 
 //////////////////
@@ -742,8 +767,7 @@ func (r *LocalBackend) RestartVPN() error {
 	return r.vpnClient.Restart(bOptions)
 }
 
-// SelectServer selects the server identified by tag. The empty string is
-// treated as [vpn.AutoSelectTag].
+// SelectServer selects the server identified by tag. The empty string is treated as [vpn.AutoSelectTag].
 func (r *LocalBackend) SelectServer(tag string) error {
 	if tag == "" {
 		tag = vpn.AutoSelectTag
@@ -752,6 +776,11 @@ func (r *LocalBackend) SelectServer(tag string) error {
 		return fmt.Errorf("failed to select server: %w", err)
 	}
 	r.persistSelection(tag)
+	if r.vpnClient.Status() == vpn.Connected {
+		if sel, _, err := r.SelectedServer(); err == nil && sel != nil {
+			r.sessionHistory.HandleServerChange(sel.Tag, sel.Location.City, sel.Location.Country)
+		}
+	}
 	return nil
 }
 
@@ -787,6 +816,10 @@ func (r *LocalBackend) persistSelection(tag string) {
 // connections and the tunnel is open, an empty slice is returned without an error.
 func (r *LocalBackend) VPNConnections() ([]vpn.Connection, error) {
 	return r.vpnClient.Connections()
+}
+
+func (r *LocalBackend) VPNThroughput() (vpn.ThroughputSnapshot, error) {
+	return r.vpnClient.Throughput()
 }
 
 // ActiveVPNConnections returns a list of currently active connections, ordered from newest to oldest.
@@ -840,6 +873,20 @@ func (r *LocalBackend) SelectedServer() (*servers.Server, bool, error) {
 // VPN client.
 func (r *LocalBackend) CurrentAutoSelectedServer() (string, error) {
 	return r.vpnClient.CurrentAutoSelectedServer()
+}
+
+func (r *LocalBackend) startSessionAutoSelectListener() {
+	events.SubscribeContext(r.ctx, func(evt vpn.AutoSelectedEvent) {
+		if evt.Selected == "" || r.vpnClient.Status() != vpn.Connected {
+			return
+		}
+		var city, country string
+		if server, found := r.srvManager.GetServerByTag(evt.Selected); found {
+			city = server.Location.City
+			country = server.Location.Country
+		}
+		r.sessionHistory.HandleServerChange(evt.Selected, city, country)
+	})
 }
 
 func (r *LocalBackend) startAutoSelectedListener() {

--- a/cmd/lantern/format.go
+++ b/cmd/lantern/format.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+func formatBytes(b int64) string {
+	const (
+		kib = 1024
+		mib = kib * 1024
+		gib = mib * 1024
+	)
+	switch {
+	case b >= gib:
+		return fmt.Sprintf("%6.2f GiB", float64(b)/gib)
+	case b >= mib:
+		return fmt.Sprintf("%6.2f MiB", float64(b)/mib)
+	case b >= kib:
+		return fmt.Sprintf("%6.2f KiB", float64(b)/kib)
+	default:
+		return fmt.Sprintf("%6d B  ", b)
+	}
+}
+
+func joinNonEmpty(sep string, parts ...string) string {
+	out := slices.DeleteFunc(parts, func(p string) bool { return p == "" })
+	return strings.Join(out, sep)
+}

--- a/cmd/lantern/ip.go
+++ b/cmd/lantern/ip.go
@@ -33,14 +33,21 @@ func init() {
 	}
 }
 
-type IPCmd struct{}
+type IPCmd struct {
+	JSON bool `arg:"--json" help:"output JSON"`
+}
 
-func runIP(ctx context.Context) error {
+func runIP(ctx context.Context, cmd *IPCmd) error {
 	tctx, tcancel := context.WithTimeout(ctx, 10*time.Second)
 	defer tcancel()
 	ip, err := getPublicIP(tctx)
 	if err != nil {
 		return err
+	}
+	if cmd.JSON {
+		return printJSON(struct {
+			IP string `json:"ip"`
+		}{IP: ip})
 	}
 	fmt.Println(ip)
 	return nil

--- a/cmd/lantern/lantern.go
+++ b/cmd/lantern/lantern.go
@@ -2,10 +2,15 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
+	"regexp"
+	"strings"
 	"syscall"
+	"time"
 
 	"context"
 
@@ -22,15 +27,17 @@ type args struct {
 	Disconnect   *DisconnectCmd   `arg:"subcommand:disconnect" help:"disconnect VPN"`
 	Status       *StatusCmd       `arg:"subcommand:status" help:"show VPN status"`
 	Servers      *ServersCmd      `arg:"subcommand:servers" help:"manage servers"`
-	Features     *FeaturesCmd     `arg:"subcommand:features" help:"list available features and their status"`
 	Set          *SetCmd          `arg:"subcommand:set" help:"update one or more settings"`
 	Get          *GetCmd          `arg:"subcommand:get" help:"show one or all settings"`
-	UpdateConfig *UpdateConfigCmd `arg:"subcommand:update-config" help:"force an immediate config fetch"`
 	SplitTunnel  *SplitTunnelCmd  `arg:"subcommand:split-tunnel" help:"split-tunnel filter management"`
+	Features     *FeaturesCmd     `arg:"subcommand:features" help:"list available features and their status"`
 	Account      *AccountCmd      `arg:"subcommand:account" help:"login, signup, user data, devices, recovery"`
 	Subscription *SubscriptionCmd `arg:"subcommand:subscription" help:"plans, payments, and billing"`
 	ReportIssue  *ReportIssueCmd  `arg:"subcommand:report-issue" help:"report an issue"`
-	Logs         *LogsCmd         `arg:"subcommand:logs" help:"tail daemon logs"`
+	Throughput   *ThroughputCmd   `arg:"subcommand:throughput" help:"show throughput, globally and per outbound"`
+	Monitor      *MonitorCmd      `arg:"subcommand:monitor" help:"watch status, throughput, settings, recent history and errors; press q or Ctrl-C to quit"`
+	Logs         *LogsCmd         `arg:"subcommand:logs" help:"tail daemon logs; press q or Ctrl-C to quit"`
+	UpdateConfig *UpdateConfigCmd `arg:"subcommand:update-config" help:"force an immediate config fetch"`
 	IP           *IPCmd           `arg:"subcommand:ip" help:"show public IP address"`
 	Version      *VersionCmd      `arg:"subcommand:version" help:"print version"`
 }
@@ -49,22 +56,106 @@ func runReportIssue(ctx context.Context, c *ipc.Client, cmd *ReportIssueCmd) err
 	return c.ReportIssue(ctx, issue.IssueType(cmd.Type), cmd.Description, cmd.Email, nil)
 }
 
-type LogsCmd struct{}
+type LogsCmd struct {
+	Level            string        `arg:"--level" help:"only show entries at this level or higher (trace|debug|info|warn|error|fatal|panic)"`
+	Grep             string        `arg:"--grep" help:"regex; only show entries that match"`
+	ReconnectTimeout time.Duration `arg:"--reconnect-timeout" default:"60s" help:"retry the daemon for this long after it goes away (0 disables retry)"`
+}
 
-func tailLogs(ctx context.Context, c *ipc.Client) error {
-	err := c.TailLogs(ctx, func(entry rlog.LogEntry) {
-		fmt.Println(entry)
-	})
-	if ctx.Err() != nil {
-		fmt.Fprintln(os.Stderr, "\nStopped tailing logs.")
-		return nil
+// tailLogs streams log entries from the daemon, with optional filtering and reconnect logic.
+func tailLogs(ctx context.Context, c *ipc.Client, cmd *LogsCmd) error {
+	ctx, cleanup := quitOnKey(ctx)
+	defer cleanup()
+
+	var levelMin slog.Level
+	levelSet := false
+	if cmd.Level != "" {
+		lvl, err := rlog.ParseLogLevel(cmd.Level)
+		if err != nil {
+			return err
+		}
+		levelMin = lvl
+		levelSet = true
 	}
-	return err
+	var grepRE *regexp.Regexp
+	if cmd.Grep != "" {
+		re, err := regexp.Compile(cmd.Grep)
+		if err != nil {
+			return fmt.Errorf("invalid --grep regex: %w", err)
+		}
+		grepRE = re
+	}
+
+	st := newReconnect(cmd.ReconnectTimeout)
+	handler := func(entry rlog.LogEntry) {
+		st.onSuccess()
+		if levelSet && !logEntryMeetsLevel(entry, levelMin) {
+			return
+		}
+		if grepRE != nil && !grepRE.MatchString(entry) {
+			return
+		}
+		fmt.Printf("%s\r\n", entry)
+	}
+
+	for {
+		err := c.TailLogs(ctx, handler)
+		if ctx.Err() != nil {
+			st.abandon()
+			fmt.Fprint(os.Stderr, "\r\nStopped tailing logs.\r\n")
+			return nil
+		}
+		if err == nil {
+			// We connected even if no entries arrived, so the reconnect window has to reset
+			// before we map nil → ErrIPCNotRunning to drive the next retry.
+			st.onSuccess()
+			err = ipc.ErrIPCNotRunning
+		}
+		if !errors.Is(err, ipc.ErrIPCNotRunning) {
+			st.abandon()
+			return err
+		}
+		wait := st.onError()
+		if wait <= 0 {
+			st.abandon()
+			return fmt.Errorf("daemon unreachable: %w", err)
+		}
+		if err := st.waitForRetry(ctx, wait); err != nil {
+			st.abandon()
+			fmt.Fprint(os.Stderr, "\r\nStopped tailing logs.\r\n")
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+	}
+}
+
+// logEntryMeetsLevel checks whether the log entry has a level at least as high as the specified
+// minimum. Lines without a parseable level=... attr are passed through, not filtered out. Callers
+// should not assume `false` means "below min".
+func logEntryMeetsLevel(entry string, min slog.Level) bool {
+	_, rest, fnd := strings.Cut(entry, "level=")
+	if !fnd {
+		return true
+	}
+	end := strings.IndexAny(rest, " \t")
+	if end < 0 {
+		end = len(rest)
+	}
+	lvlStr := rest[:end]
+	lvl, err := rlog.ParseLogLevel(lvlStr)
+	return err != nil || lvl >= min
 }
 
 type VersionCmd struct{}
 
 func main() {
+	// Watch-mode TUI frames are corrupted by stray library slog output on stderr.
+	slog.SetDefault(slog.New(slog.DiscardHandler))
+
 	var a args
 	p := arg.MustParse(&a)
 	if p.Subcommand() == nil {
@@ -92,7 +183,9 @@ func run(ctx context.Context, c *ipc.Client, a *args) error {
 	case a.Disconnect != nil:
 		return c.DisconnectVPN(ctx)
 	case a.Status != nil:
-		return vpnStatus(ctx, c)
+		return vpnStatus(ctx, c, a.Status)
+	case a.Throughput != nil:
+		return vpnThroughput(ctx, c, a.Throughput)
 	case a.Servers != nil:
 		return runServers(ctx, c, a.Servers)
 	case a.Features != nil:
@@ -111,10 +204,12 @@ func run(ctx context.Context, c *ipc.Client, a *args) error {
 		return runSubscription(ctx, c, a.Subscription)
 	case a.ReportIssue != nil:
 		return runReportIssue(ctx, c, a.ReportIssue)
+	case a.Monitor != nil:
+		return runMonitor(ctx, c, a.Monitor)
 	case a.Logs != nil:
-		return tailLogs(ctx, c)
+		return tailLogs(ctx, c, a.Logs)
 	case a.IP != nil:
-		return runIP(ctx)
+		return runIP(ctx, a.IP)
 	case a.Version != nil:
 		fmt.Println(common.Version)
 		return nil

--- a/cmd/lantern/monitor.go
+++ b/cmd/lantern/monitor.go
@@ -1,0 +1,781 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unicode/utf8"
+
+	"golang.org/x/term"
+
+	"github.com/getlantern/radiance/account"
+	"github.com/getlantern/radiance/common"
+	"github.com/getlantern/radiance/common/settings"
+	"github.com/getlantern/radiance/ipc"
+	rlog "github.com/getlantern/radiance/log"
+	"github.com/getlantern/radiance/servers"
+	"github.com/getlantern/radiance/vpn"
+)
+
+const (
+	ansiCursorHome = "\033[H"
+	ansiClearToEOL = "\033[K"
+	ansiClearBelow = "\033[J"
+	ansiHideCursor = "\033[?25l"
+	ansiShowCursor = "\033[?25h"
+	ansiAltScreen  = "\033[?1049h"
+	ansiMainScreen = "\033[?1049l"
+	eol            = ansiClearToEOL + "\r\n"
+)
+
+type MonitorCmd struct {
+	Interval         time.Duration `arg:"-i,--interval" default:"1s" help:"refresh interval"`
+	Pool             int           `arg:"--pool" default:"5" help:"number of fastest servers to list; 0 to omit pool summary"`
+	History          int           `arg:"--history" default:"3" help:"number of recent sessions to include; 0 to omit"`
+	Logs             int           `arg:"--logs" default:"5" help:"number of recent warn/error log entries to display (totals always shown); 0 hides entries"`
+	JSON             bool          `arg:"--json" help:"emit one JSON snapshot per refresh"`
+	ReconnectTimeout time.Duration `arg:"--reconnect-timeout" default:"60s" help:"retry the daemon for this long after it goes away (0 disables retry)"`
+}
+
+type monitorSnapshot struct {
+	Version          string                 `json:"version"`
+	DeviceID         string                 `json:"device_id,omitempty"`
+	UserID           string                 `json:"user_id,omitempty"`
+	Pro              bool                   `json:"pro"`
+	Status           statusSnapshot         `json:"status"`
+	Throughput       vpn.ThroughputSnapshot `json:"throughput"`
+	DataCap          *account.DataCapInfo   `json:"data_cap,omitempty"`
+	DataCapStreaming bool                   `json:"data_cap_streaming"`
+	DataCapAgeMs     int64                  `json:"data_cap_age_ms,omitempty"`
+	Settings         map[string]any         `json:"settings"`
+	History          []vpn.Session          `json:"history,omitempty"`
+	ServerPool       *poolSummary           `json:"server_pool,omitempty"`
+	RecentLogs       []logEvent             `json:"recent_logs"`
+	LogCounts        logCounts              `json:"log_counts"`
+}
+
+type logCounts struct {
+	Warn  int `json:"warn"`
+	Error int `json:"error"`
+}
+
+type poolSummary struct {
+	Total   int             `json:"total"`
+	Tested  int             `json:"tested"`
+	Fastest []serverLatency `json:"fastest,omitempty"`
+}
+
+type serverLatency struct {
+	Tag      string    `json:"tag"`
+	Type     string    `json:"type,omitempty"`
+	Location string    `json:"location,omitempty"`
+	DelayMs  uint16    `json:"delay_ms"`
+	TestedAt time.Time `json:"tested_at"`
+}
+
+type logEvent struct {
+	Level string    `json:"level"`
+	Pkg   string    `json:"pkg,omitempty"`
+	Src   string    `json:"src,omitempty"`
+	Msg   string    `json:"msg"`
+	First time.Time `json:"first"`
+	Last  time.Time `json:"last"`
+	Count int       `json:"count"`
+}
+
+func runMonitor(ctx context.Context, c *ipc.Client, cmd *MonitorCmd) error {
+	interval := cmd.Interval
+	if interval <= 0 {
+		interval = time.Second
+	}
+
+	ctx, cleanup := quitOnKey(ctx)
+	defer cleanup()
+
+	tty := !cmd.JSON && stdoutIsTTY()
+	if tty {
+		// Use the alternate screen buffer so we don't mess with the user's scrollback, and hide the
+		// cursor since it would be distracting when refreshing the screen.
+		fmt.Print(ansiAltScreen + ansiHideCursor)
+		defer fmt.Print(ansiShowCursor + ansiMainScreen)
+	}
+
+	state := newMonitorState(cmd.Logs)
+	go state.streamDataCap(ctx, c)
+	go state.tailLogs(ctx, c)
+
+	st := newReconnect(cmd.ReconnectTimeout)
+	refresh := func() error {
+		var snap monitorSnapshot
+		err := callWithReconnect(ctx, st, func() error {
+			return fetchMonitor(ctx, c, cmd, &snap)
+		})
+		if err != nil {
+			return err
+		}
+		state.fillSnapshot(&snap, cmd.Logs)
+		if cmd.JSON {
+			return printJSON(snap)
+		}
+		width, height := 0, 0
+		if tty {
+			if w, h, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
+				width, height = w, h
+			}
+		}
+		var b strings.Builder
+		b.WriteString(ansiCursorHome)
+		renderMonitor(&b, &snap, width)
+		b.WriteString(ansiClearBelow)
+		out := b.String()
+		if height > 0 {
+			out = clipToHeight(out, height, width)
+		}
+		_, _ = io.WriteString(os.Stdout, out)
+		return nil
+	}
+
+	if err := refresh(); err != nil {
+		if ctx.Err() != nil {
+			return nil
+		}
+		return err
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+		if err := refresh(); err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+func fetchMonitor(ctx context.Context, c *ipc.Client, cmd *MonitorCmd, snap *monitorSnapshot) error {
+	snap.Version = common.Version
+
+	s, err := fetchStatus(ctx, c)
+	if err != nil {
+		return err
+	}
+	snap.Status = s
+
+	tp, err := c.VPNThroughput(ctx)
+	if err != nil {
+		return err
+	}
+	snap.Throughput = tp
+
+	cfg, err := c.Settings(ctx)
+	if err != nil {
+		return err
+	}
+	snap.Settings = make(map[string]any, len(settingNames))
+	for _, name := range settingNames {
+		if v, ok := settingValue(name, cfg); ok {
+			snap.Settings[name] = v
+		}
+	}
+	if uid := cfg[settings.UserIDKey]; uid != nil {
+		if v, ok := uid.(float64); ok {
+			snap.UserID = strconv.FormatInt(int64(v), 10)
+		} else {
+			snap.UserID = fmt.Sprintf("%v", uid)
+		}
+	}
+	if did := cfg[settings.DeviceIDKey]; did != nil {
+		snap.DeviceID = fmt.Sprintf("%v", did)
+	}
+	snap.Pro = strings.EqualFold(fmt.Sprintf("%v", cfg[settings.UserLevelKey]), "pro")
+
+	if cmd.History > 0 {
+		h, err := c.VPNSessions(ctx, cmd.History)
+		if err != nil {
+			return err
+		}
+		snap.History = h
+	}
+	if cmd.Pool > 0 {
+		srvs, err := c.Servers(ctx)
+		if err != nil {
+			return err
+		}
+		snap.ServerPool = summarizePool(srvs, cmd.Pool)
+	}
+	return nil
+}
+
+func summarizePool(srvs []*servers.Server, top int) *poolSummary {
+	out := &poolSummary{Total: len(srvs)}
+	tested := make([]serverLatency, 0, len(srvs))
+	for _, s := range srvs {
+		if s == nil || s.URLTestResult == nil {
+			continue
+		}
+		tested = append(tested, serverLatency{
+			Tag:      s.Tag,
+			Type:     s.Type,
+			Location: joinNonEmpty(", ", s.Location.City, s.Location.Country),
+			DelayMs:  s.URLTestResult.Delay,
+			TestedAt: s.URLTestResult.Time,
+		})
+	}
+	out.Tested = len(tested)
+	sort.Slice(tested, func(i, j int) bool { return tested[i].DelayMs < tested[j].DelayMs })
+	if top > len(tested) {
+		top = len(tested)
+	}
+	out.Fastest = tested[:top]
+	return out
+}
+
+func renderMonitor(w io.Writer, snap *monitorSnapshot, width int) {
+	tier := "free"
+	if snap.Pro {
+		tier = "pro"
+	}
+	user := "—"
+	if snap.UserID != "" {
+		user = snap.UserID
+	}
+	fmt.Fprintf(w, "Lantern v%s — user %s (%s)%s", snap.Version, user, tier, eol)
+	if snap.DeviceID != "" {
+		fmt.Fprintf(w, "Device: %s%s", snap.DeviceID, eol)
+	}
+	io.WriteString(w, eol)
+
+	status := string(snap.Status.Status)
+	if status != "" {
+		status = strings.ToUpper(status[:1]) + status[1:]
+	}
+	fmt.Fprintf(w, "Status: %s%s", status, eol)
+	if snap.Status.Server != "" {
+		line := "  Server: " + formatTag(snap.Status.Server)
+		if snap.Status.Location != "" {
+			line += " (" + snap.Status.Location + ")"
+		}
+		if snap.Status.LatencyMs > 0 {
+			line += fmt.Sprintf(" — %dms", snap.Status.LatencyMs)
+		}
+		fmt.Fprintf(w, "%s%s", line, eol)
+	}
+	if snap.Status.IP != "" {
+		fmt.Fprintf(w, "  IP: %s%s", snap.Status.IP, eol)
+	}
+	if cur := currentSession(snap); cur != nil {
+		fmt.Fprintf(w, "  Session: ↓ %s   ↑ %s   (%s)%s",
+			formatBytes(cur.BytesDown), formatBytes(cur.BytesUp),
+			cur.Duration().Truncate(time.Second), eol)
+	}
+	io.WriteString(w, eol)
+
+	renderDataCap(w, snap)
+
+	fmt.Fprintf(w, "Throughput:%s", eol)
+	fmt.Fprintf(w, "  Global  ↓ %s   ↑ %s   (%d active)%s",
+		formatBitsPerSec(snap.Throughput.Global.Down),
+		formatBitsPerSec(snap.Throughput.Global.Up),
+		snap.Throughput.ActiveConnections, eol)
+	tags := outboundTags(snap.Throughput)
+	for _, tag := range tags {
+		sp := snap.Throughput.PerOutbound[tag]
+		name := formatTag(tag)
+		if name == "" {
+			name = "(unrouted)"
+		}
+		fmt.Fprintf(w, "    %-30s ↓ %s   ↑ %s   (%d active)%s",
+			name, formatBitsPerSec(sp.Down), formatBitsPerSec(sp.Up),
+			snap.Throughput.ActivePerOutbound[tag], eol)
+	}
+	io.WriteString(w, eol)
+
+	renderSettings(w, snap.Settings, width)
+
+	renderServerPool(w, snap.ServerPool)
+
+	if len(snap.History) > 0 {
+		fmt.Fprintf(w, "Recent sessions:%s", eol)
+		for _, s := range snap.History {
+			fmt.Fprintf(w, "  %s%s", formatSessionLine(s), eol)
+			if s.Error != "" {
+				fmt.Fprintf(w, "    error: %s%s", s.Error, eol)
+			}
+		}
+		io.WriteString(w, eol)
+	}
+
+	renderRecentLogs(w, snap.RecentLogs, snap.LogCounts)
+
+	fmt.Fprintf(w, "(press q to quit)%s", eol)
+}
+
+func renderDataCap(w io.Writer, snap *monitorSnapshot) {
+	dc := snap.DataCap
+	if dc != nil && dc.Enabled && dc.Usage != nil {
+		used, _ := strconv.ParseInt(dc.Usage.BytesUsed, 10, 64)
+		allotted, _ := strconv.ParseInt(dc.Usage.BytesAllotted, 10, 64)
+		line := fmt.Sprintf("Data cap: %s / %s used", formatBytes(used), formatBytes(allotted))
+		if snap.DataCapStreaming {
+			age := time.Duration(snap.DataCapAgeMs) * time.Millisecond
+			if age > 30*time.Second {
+				line += fmt.Sprintf(" (last update %s ago)", age.Truncate(time.Second))
+			}
+		}
+		fmt.Fprintf(w, "%s%s", line, eol)
+		if t, err := time.Parse(time.RFC3339, dc.Usage.AllotmentEndTime); err == nil {
+			fmt.Fprintf(w, "  resets %s%s", t.Local().Format("2006-01-02 15:04"), eol)
+		}
+	} else {
+		fmt.Fprintf(w, "Data cap: no samples yet%s", eol)
+	}
+	io.WriteString(w, eol)
+}
+
+func renderSettings(w io.Writer, s map[string]any, width int) {
+	if len(s) == 0 {
+		return
+	}
+	keys := make([]string, 0, len(s))
+	for k := range s {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	items := make([]string, len(keys))
+	maxLen := 0
+	for i, k := range keys {
+		items[i] = fmt.Sprintf("%s: %v", k, s[k])
+		if l := len(items[i]); l > maxLen {
+			maxLen = l
+		}
+	}
+	const indent, gap = "  ", "  "
+	cellWidth := maxLen + len(gap)
+	cols := 1
+	if avail := width - len(indent); avail > cellWidth {
+		cols = avail / cellWidth
+	}
+
+	fmt.Fprintf(w, "Settings:%s", eol)
+	for i, item := range items {
+		if i%cols == 0 {
+			io.WriteString(w, indent)
+		}
+		endOfRow := (i+1)%cols == 0 || i == len(items)-1
+		if endOfRow {
+			io.WriteString(w, item)
+			io.WriteString(w, eol)
+		} else {
+			fmt.Fprintf(w, "%-*s", cellWidth, item)
+		}
+	}
+	io.WriteString(w, eol)
+}
+
+func renderServerPool(w io.Writer, p *poolSummary) {
+	if p == nil || p.Total == 0 {
+		return
+	}
+	fmt.Fprintf(w, "Server pool: %d total, %d with recent test%s", p.Total, p.Tested, eol)
+	now := time.Now()
+	for _, s := range p.Fastest {
+		name := formatTag(s.Tag)
+		if s.Location != "" {
+			name = fmt.Sprintf("%s [%s]", name, s.Location)
+		}
+		age := "—"
+		if !s.TestedAt.IsZero() {
+			age = now.Sub(s.TestedAt).Truncate(time.Second).String() + " ago"
+		}
+		fmt.Fprintf(w, "  %5dms  %s  (tested %s)%s", s.DelayMs, name, age, eol)
+	}
+	io.WriteString(w, eol)
+}
+
+func renderRecentLogs(w io.Writer, logs []logEvent, counts logCounts) {
+	fmt.Fprintf(w, "Recent warn/error logs: %d warn, %d error%s", counts.Warn, counts.Error, eol)
+	if len(logs) == 0 {
+		fmt.Fprintf(w, "  (none)%s", eol)
+		io.WriteString(w, eol)
+		return
+	}
+	for _, e := range logs {
+		when := e.Last.Local().Format("15:04:05")
+		count := ""
+		if e.Count > 1 {
+			count = fmt.Sprintf(" (×%d)", e.Count)
+		}
+		src := e.Pkg
+		if e.Src != "" {
+			if src != "" {
+				src += " " + e.Src
+			} else {
+				src = e.Src
+			}
+		}
+		if src != "" {
+			src = " [" + src + "]"
+		}
+		fmt.Fprintf(w, "  %s %-5s%s %s%s%s", when, e.Level, src, e.Msg, count, eol)
+	}
+	io.WriteString(w, eol)
+}
+
+func formatSessionLine(s vpn.Session) string {
+	when := s.ConnectedAt.Local().Format("15:04:05")
+	dur := s.Duration().Truncate(time.Second)
+	status := "ended"
+	if s.DisconnectedAt.IsZero() {
+		status = "active"
+	}
+	srv := formatTag(s.Server.Tag)
+	if srv == "" {
+		srv = "(auto)"
+	}
+	if loc := joinNonEmpty(", ", s.Server.City, s.Server.Country); loc != "" {
+		srv = fmt.Sprintf("%s [%s]", srv, loc)
+	}
+	return fmt.Sprintf("%s  %-9s  %-6s  ↓ %s   ↑ %s   %s",
+		when, dur, status, formatBytes(s.BytesDown), formatBytes(s.BytesUp), srv)
+}
+
+func currentSession(snap *monitorSnapshot) *vpn.Session {
+	if snap.Status.Status != vpn.Connected || len(snap.History) == 0 {
+		return nil
+	}
+	first := snap.History[0]
+	if !first.DisconnectedAt.IsZero() {
+		return nil
+	}
+	return &first
+}
+
+// clipToHeight trims the rendered frame to at most h visual rows so the cursor
+// stays within the viewport. The alt screen has no scrollback, so any line that
+// would push the cursor past the bottom permanently drops the topmost row.
+//
+// Lines wider than width wrap and consume multiple visual rows, so naive newline
+// counting under-counts when wrapping is on (the case here, which we keep so log
+// messages stay readable).
+func clipToHeight(s string, h, width int) string {
+	if h <= 0 {
+		return s
+	}
+	suffix := ""
+	if strings.HasSuffix(s, ansiClearBelow) {
+		s = s[:len(s)-len(ansiClearBelow)]
+		suffix = ansiClearBelow
+	}
+	dropFromLine := func(lineStart int) string {
+		if lineStart == 0 {
+			return suffix
+		}
+		// Drop the \n preceding this line so the cursor lands at the end of the
+		// previous line rather than at the start of an empty next row.
+		return s[:lineStart-1] + suffix
+	}
+	visual := 0
+	lineStart := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] != '\n' {
+			continue
+		}
+		rows := visualRows(s[lineStart:i], width)
+		// Including the trailing \n moves the cursor down one extra row, so the
+		// budget for "line + \n" is h-1 rows total (cursor lands at row h).
+		if visual+rows > h-1 {
+			// If the line content fits without its trailing \n (cursor stops at
+			// end of last wrap row), keep it as the final visible line.
+			if visual+rows <= h {
+				return s[:i] + suffix
+			}
+			return dropFromLine(lineStart)
+		}
+		visual += rows
+		lineStart = i + 1
+	}
+	if lineStart < len(s) {
+		rows := visualRows(s[lineStart:], width)
+		if visual+rows > h {
+			return dropFromLine(lineStart)
+		}
+	}
+	return s + suffix
+}
+
+// visualRows returns the number of terminal rows a line occupies after wrapping
+// at width. width <= 0 disables wrap accounting (one row per line).
+func visualRows(line string, width int) int {
+	if width <= 0 {
+		return 1
+	}
+	n := visualWidth(line)
+	if n == 0 {
+		return 1
+	}
+	return (n + width - 1) / width
+}
+
+// visualWidth returns the rendered column count of line. Each rune counts as
+// one column — close enough for the ASCII + light-Unicode (↓ ↑ — ×) content
+// this dashboard renders; full wcwidth would be overkill.
+func visualWidth(line string) int {
+	n := 0
+	i := 0
+	for i < len(line) {
+		c := line[i]
+		switch {
+		case c == 0x1b && i+1 < len(line) && line[i+1] == '[':
+			i += 2
+			for i < len(line) {
+				t := line[i]
+				i++
+				if t >= 0x40 && t <= 0x7e {
+					break
+				}
+			}
+		case c == '\r':
+			i++
+		case c < 0x80:
+			n++
+			i++
+		default:
+			_, size := utf8.DecodeRuneInString(line[i:])
+			if size <= 0 {
+				size = 1
+			}
+			n++
+			i += size
+		}
+	}
+	return n
+}
+
+var tagUUID = regexp.MustCompile(`([0-9a-f]{8})-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-([0-9a-f]{12})`)
+
+func formatTag(tag string) string {
+	if i := strings.Index(tag, "-out-"); i > 0 {
+		proto := tag[:i]
+		if rest := tag[i+len("-out-"):]; strings.HasPrefix(rest, proto+"-") {
+			tag = rest
+		}
+	}
+	return tagUUID.ReplaceAllString(tag, "$1-...-$2")
+}
+
+func outboundTags(s vpn.ThroughputSnapshot) []string {
+	set := make(map[string]struct{}, len(s.PerOutbound)+len(s.ActivePerOutbound))
+	for tag := range s.PerOutbound {
+		set[tag] = struct{}{}
+	}
+	for tag := range s.ActivePerOutbound {
+		set[tag] = struct{}{}
+	}
+	tags := make([]string, 0, len(set))
+	for tag := range set {
+		tags = append(tags, tag)
+	}
+	sort.Strings(tags)
+	return tags
+}
+
+type monitorState struct {
+	mu          sync.Mutex
+	dataCap     atomic.Pointer[account.DataCapInfo]
+	dataCapAt   atomic.Int64 // unix nanoseconds of last update; 0 if never
+	logCapacity int
+	logs        []logEvent
+	warnTotal   atomic.Int64
+	errorTotal  atomic.Int64
+}
+
+func newMonitorState(logCapacity int) *monitorState {
+	return &monitorState{logCapacity: logCapacity}
+}
+
+func (s *monitorState) setDataCap(info account.DataCapInfo) {
+	cp := info
+	s.dataCap.Store(&cp)
+	s.dataCapAt.Store(time.Now().UnixNano())
+}
+
+func (s *monitorState) fillSnapshot(snap *monitorSnapshot, logLimit int) {
+	snap.DataCap = s.dataCap.Load()
+	if at := s.dataCapAt.Load(); at != 0 {
+		snap.DataCapStreaming = true
+		snap.DataCapAgeMs = time.Since(time.Unix(0, at)).Milliseconds()
+	}
+	snap.LogCounts = logCounts{
+		Warn:  int(s.warnTotal.Load()),
+		Error: int(s.errorTotal.Load()),
+	}
+	if logLimit <= 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.logs) == 0 {
+		return
+	}
+	out := make([]logEvent, len(s.logs))
+	copy(out, s.logs)
+	sort.Slice(out, func(i, j int) bool { return out[i].Last.After(out[j].Last) })
+	if logLimit < len(out) {
+		out = out[:logLimit]
+	}
+	snap.RecentLogs = out
+}
+
+func (s *monitorState) streamDataCap(ctx context.Context, c *ipc.Client) {
+	for ctx.Err() == nil {
+		_ = c.DataCapStream(ctx, s.setDataCap)
+		if ctx.Err() != nil {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+func (s *monitorState) tailLogs(ctx context.Context, c *ipc.Client) {
+	for ctx.Err() == nil {
+		_ = c.TailLogs(ctx, func(entry rlog.LogEntry) {
+			if evt, ok := parseLogEvent(entry); ok {
+				s.recordLog(evt)
+			}
+		})
+		if ctx.Err() != nil {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+func (s *monitorState) recordLog(evt logEvent) {
+	switch evt.Level {
+	case "WARN":
+		s.warnTotal.Add(1)
+	case "ERROR":
+		s.errorTotal.Add(1)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := range s.logs {
+		e := &s.logs[i]
+		if e.Level == evt.Level && e.Pkg == evt.Pkg && e.Msg == evt.Msg {
+			e.Last = evt.Last
+			e.Count++
+			return
+		}
+	}
+	if s.logCapacity > 0 && len(s.logs) >= s.logCapacity*4 {
+		// Cap distinct entries at 4× display so a flood of unique messages
+		// can't grow the slice unbounded.
+		oldestIdx := 0
+		for i := range s.logs {
+			if s.logs[i].Last.Before(s.logs[oldestIdx].Last) {
+				oldestIdx = i
+			}
+		}
+		s.logs = append(s.logs[:oldestIdx], s.logs[oldestIdx+1:]...)
+	}
+	s.logs = append(s.logs, evt)
+}
+
+var (
+	logKeyTimeQuoted = regexp.MustCompile(`time="([^"]+)"`)
+	logKeyTimeBare   = regexp.MustCompile(`(?:^|\s)time=(\S+)`)
+	logKeyLevel      = regexp.MustCompile(`level=(\w+)`)
+	logKeyPkg        = regexp.MustCompile(`pkg=(\S+)`)
+	logKeySrcFile    = regexp.MustCompile(`source\.file=(\S+)`)
+	logKeyMsgQuoted  = regexp.MustCompile(`msg="((?:[^"\\]|\\.)*)"`)
+	logKeyMsgBare    = regexp.MustCompile(`msg=(\S+)`)
+)
+
+func parseLogEvent(line string) (logEvent, bool) {
+	m := logKeyLevel.FindStringSubmatch(line)
+	if m == nil {
+		return logEvent{}, false
+	}
+	level := strings.ToUpper(m[1])
+	if level != "WARN" && level != "WARNING" && level != "ERROR" {
+		return logEvent{}, false
+	}
+	if level == "WARNING" {
+		level = "WARN"
+	}
+	evt := logEvent{Level: level, Count: 1}
+	if m = logKeyMsgQuoted.FindStringSubmatch(line); m != nil {
+		evt.Msg = unescapeQuoted(m[1])
+	} else if m = logKeyMsgBare.FindStringSubmatch(line); m != nil {
+		evt.Msg = m[1]
+	}
+	if m = logKeyPkg.FindStringSubmatch(line); m != nil {
+		evt.Pkg = m[1]
+	}
+	if m = logKeySrcFile.FindStringSubmatch(line); m != nil {
+		evt.Src = m[1]
+	}
+	ts := time.Now()
+	if m = logKeyTimeQuoted.FindStringSubmatch(line); m != nil {
+		if t, ok := parseLogTime(m[1]); ok {
+			ts = t
+		}
+	} else if m = logKeyTimeBare.FindStringSubmatch(line); m != nil {
+		if t, ok := parseLogTime(m[1]); ok {
+			ts = t
+		}
+	}
+	evt.First = ts
+	evt.Last = ts
+	return evt, true
+}
+
+func parseLogTime(s string) (time.Time, bool) {
+	for _, layout := range []string{
+		"2006-01-02 15:04:05.000 MST",
+		"2006-01-02T15:04:05.000Z07:00",
+		time.RFC3339Nano,
+		time.RFC3339,
+	} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func unescapeQuoted(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) {
+			b.WriteByte(s[i+1])
+			i++
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}

--- a/cmd/lantern/servers.go
+++ b/cmd/lantern/servers.go
@@ -13,68 +13,125 @@ import (
 )
 
 type ServersCmd struct {
-	Show           string `arg:"-s,--show" help:"display server by tag"`
-	AddJSON        string `arg:"--add-json" help:"add servers from JSON config"`
-	AddURL         string `arg:"--add-url" help:"add servers from comma-separated URLs"`
-	SkipCertVerify bool   `arg:"--skip-cert-verify" help:"skip cert verification (with --add-url)"`
-	Remove         string `arg:"--remove" help:"comma-separated list of servers to remove"`
-	List           bool   `arg:"-l,--list" help:"list servers"`
-	Latency        bool   `arg:"--latency" help:"include URL test latency results (with --list)"`
+	List          *ServersListCmd    `arg:"subcommand:list" help:"list servers"`
+	Show          *ServersShowCmd    `arg:"subcommand:show" help:"display server by tag"`
+	AddJSON       *ServersAddJSONCmd `arg:"subcommand:add-json" help:"add servers from JSON config"`
+	AddURL        *ServersAddURLCmd  `arg:"subcommand:add-url" help:"add servers from URLs"`
+	Remove        *ServersRemoveCmd  `arg:"subcommand:remove" help:"remove servers by tag"`
+	PrivateServer *PrivateServerCmd  `arg:"subcommand:private" help:"private server operations"`
+}
 
-	PrivateServer *PrivateServerCmd `arg:"subcommand:private" help:"private server operations"`
+type ServersListCmd struct {
+	Latency bool `arg:"--latency" help:"include URL test latency results"`
+	JSON    bool `arg:"--json" help:"output JSON"`
+}
+
+type ServersShowCmd struct {
+	Tag string `arg:"positional,required" help:"server tag"`
+}
+
+type ServersAddJSONCmd struct {
+	Config string `arg:"positional,required" help:"JSON config"`
+}
+
+type ServersAddURLCmd struct {
+	URLs           []string `arg:"positional,required" help:"server URLs"`
+	SkipCertVerify bool     `arg:"--skip-cert-verify" help:"skip cert verification"`
+}
+
+type ServersRemoveCmd struct {
+	Tags []string `arg:"positional,required" help:"server tags to remove"`
+}
+
+// ServerListEntry represents a server in the list output.
+type ServerListEntry struct {
+	Tag           string                 `json:"tag"`
+	Type          string                 `json:"type"`
+	Location      C.ServerLocation       `json:"location,omitempty"`
+	URLTestResult *servers.URLTestResult `json:"urlTestResult,omitempty"`
 }
 
 type PrivateServerCmd struct {
-	Add          string `arg:"-a,--add" help:"add private server with given tag"`
-	Invite       string `arg:"-i,--invite" help:"invite to private server"`
-	RevokeInvite string `arg:"-r,--revoke-invite" help:"revoke invite"`
-	IP           string `arg:"--ip" help:"server IP"`
-	Port         int    `arg:"--port" help:"server port"`
-	Token        string `arg:"--token" help:"access token"`
+	Add          *PrivateServerAddCmd          `arg:"subcommand:add" help:"add a private server"`
+	Invite       *PrivateServerInviteCmd       `arg:"subcommand:invite" help:"create an invite for a private server"`
+	RevokeInvite *PrivateServerRevokeInviteCmd `arg:"subcommand:revoke-invite" help:"revoke a private server invite"`
+}
+
+// PrivateServerConn holds connection parameters for a private server.
+type PrivateServerConn struct {
+	IP    string `arg:"--ip,required" help:"server IP"`
+	Port  int    `arg:"--port,required" help:"server port"`
+	Token string `arg:"--token,required" help:"access token"`
+}
+
+type PrivateServerAddCmd struct {
+	Tag string `arg:"positional,required" help:"tag to assign to the server"`
+	PrivateServerConn
+}
+
+type PrivateServerInviteCmd struct {
+	Name string `arg:"positional,required" help:"invitee name"`
+	PrivateServerConn
+}
+
+type PrivateServerRevokeInviteCmd struct {
+	Name string `arg:"positional,required" help:"invitee name to revoke"`
+	PrivateServerConn
 }
 
 func runServers(ctx context.Context, c *ipc.Client, cmd *ServersCmd) error {
 	switch {
-	case cmd.Show != "":
-		return serversGet(ctx, c, cmd.Show)
-	case cmd.AddJSON != "":
-		return printAddedServers(c.AddServersByJSON(ctx, cmd.AddJSON))
-	case cmd.AddURL != "":
-		urls := strings.Split(cmd.AddURL, ",")
-		return printAddedServers(c.AddServersByURL(ctx, urls, cmd.SkipCertVerify))
-	case cmd.Remove != "":
-		return serversRemove(ctx, c, cmd.Remove)
-	case cmd.List:
-		return serversList(ctx, c, cmd.Latency)
+	case cmd.Show != nil:
+		return serversGet(ctx, c, cmd.Show.Tag)
+	case cmd.AddJSON != nil:
+		return printAddedServers(c.AddServersByJSON(ctx, cmd.AddJSON.Config))
+	case cmd.AddURL != nil:
+		return printAddedServers(c.AddServersByURL(ctx, cmd.AddURL.URLs, cmd.AddURL.SkipCertVerify))
+	case cmd.Remove != nil:
+		return c.RemoveServers(ctx, cmd.Remove.Tags)
 	case cmd.PrivateServer != nil:
 		return runPrivateServer(ctx, c, cmd.PrivateServer)
+	case cmd.List != nil:
+		return serversList(ctx, c, cmd.List.Latency, cmd.List.JSON)
 	default:
-		return fmt.Errorf("must specify one of --get, --add-json, --add-url, --remove, or --list")
+		return serversList(ctx, c, false, false)
 	}
 }
 
 func runPrivateServer(ctx context.Context, c *ipc.Client, cmd *PrivateServerCmd) error {
 	switch {
-	case cmd.Add != "":
-		return c.AddPrivateServer(ctx, cmd.Add, cmd.IP, cmd.Port, cmd.Token)
-	case cmd.Invite != "":
-		code, err := c.InviteToPrivateServer(ctx, cmd.IP, cmd.Port, cmd.Token, cmd.Invite)
+	case cmd.Add != nil:
+		return c.AddPrivateServer(ctx, cmd.Add.Tag, cmd.Add.IP, cmd.Add.Port, cmd.Add.Token)
+	case cmd.Invite != nil:
+		code, err := c.InviteToPrivateServer(ctx, cmd.Invite.IP, cmd.Invite.Port, cmd.Invite.Token, cmd.Invite.Name)
 		if err != nil {
 			return err
 		}
 		fmt.Println(code)
 		return nil
-	case cmd.RevokeInvite != "":
-		return c.RevokePrivateServerInvite(ctx, cmd.IP, cmd.Port, cmd.Token, cmd.RevokeInvite)
+	case cmd.RevokeInvite != nil:
+		return c.RevokePrivateServerInvite(ctx, cmd.RevokeInvite.IP, cmd.RevokeInvite.Port, cmd.RevokeInvite.Token, cmd.RevokeInvite.Name)
 	default:
-		return fmt.Errorf("must specify one of --add, --invite, or --revoke-invite")
+		return fmt.Errorf("must specify one of: add, invite, revoke-invite")
 	}
 }
 
-func serversList(ctx context.Context, c *ipc.Client, showLatency bool) error {
+func serversList(ctx context.Context, c *ipc.Client, showLatency, asJSON bool) error {
 	srvs, err := c.Servers(ctx)
 	if err != nil {
 		return err
+	}
+	if asJSON {
+		out := make([]ServerListEntry, 0, len(srvs))
+		for _, s := range srvs {
+			out = append(out, ServerListEntry{
+				Tag:           s.Tag,
+				Type:          s.Type,
+				Location:      s.Location,
+				URLTestResult: s.URLTestResult,
+			})
+		}
+		return printJSON(out)
 	}
 	if len(srvs) == 0 {
 		fmt.Println("No servers available")
@@ -147,9 +204,4 @@ func printAddedServers(tags []string, err error) error {
 	}
 	fmt.Printf("Added %d server(s): %s\n", len(tags), strings.Join(tags, ", "))
 	return nil
-}
-
-func serversRemove(ctx context.Context, c *ipc.Client, tags string) error {
-	tagList := strings.Split(tags, ",")
-	return c.RemoveServers(ctx, tagList)
 }

--- a/cmd/lantern/tty.go
+++ b/cmd/lantern/tty.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"golang.org/x/term"
+)
+
+// quitOnKey cancels ctx when q, Q, or Ctrl-C is read from stdin.
+// The returned cleanup MUST be deferred: on a TTY it restores terminal
+// state from raw mode. Raw mode also disables \n -> \r\n translation, so
+// callers must emit \r\n explicitly to avoid stairstepping.
+func quitOnKey(ctx context.Context) (context.Context, func()) {
+	ctx, cancel := context.WithCancel(ctx)
+	fd := int(os.Stdin.Fd())
+	if !term.IsTerminal(fd) {
+		return ctx, cancel
+	}
+	oldState, err := term.MakeRaw(fd)
+	if err != nil {
+		return ctx, cancel
+	}
+	go watchKeys(os.Stdin, cancel)
+	return ctx, func() {
+		_ = term.Restore(fd, oldState)
+		cancel()
+	}
+}
+
+func watchKeys(r *os.File, cancel context.CancelFunc) {
+	buf := make([]byte, 1)
+	for {
+		n, err := r.Read(buf)
+		if err != nil || n == 0 {
+			return
+		}
+		switch buf[0] {
+		case 'q', 'Q', 0x03:
+			cancel()
+			return
+		}
+	}
+}

--- a/cmd/lantern/vpn.go
+++ b/cmd/lantern/vpn.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -17,7 +18,13 @@ type ConnectCmd struct {
 
 type DisconnectCmd struct{}
 
-type StatusCmd struct{}
+type StatusCmd struct {
+	JSON bool `arg:"--json" help:"output JSON"`
+}
+
+type ThroughputCmd struct {
+	JSON bool `arg:"--json" help:"output JSON"`
+}
 
 func vpnConnect(ctx context.Context, c *ipc.Client, tag string, wait bool) error {
 	tctx, tcancel := context.WithTimeout(ctx, 5*time.Second)
@@ -79,25 +86,127 @@ func waitForIPChange(ctx context.Context, current string, interval time.Duration
 	}
 }
 
-func vpnStatus(ctx context.Context, c *ipc.Client) error {
-	status, err := c.VPNStatus(ctx)
+func vpnThroughput(ctx context.Context, c *ipc.Client, cmd *ThroughputCmd) error {
+	s, err := c.VPNThroughput(ctx)
 	if err != nil {
 		return err
 	}
-	line := string(status)
-	line = strings.ToUpper(line[:1]) + line[1:] // capitalize first letter
+	if cmd.JSON {
+		return printJSON(s)
+	}
+	printThroughput(s)
+	return nil
+}
+
+func printThroughput(s vpn.ThroughputSnapshot) {
+	fmt.Printf("Global  ↓ %s   ↑ %s   (%d active)\r\n",
+		formatBitsPerSec(s.Global.Down), formatBitsPerSec(s.Global.Up), s.ActiveConnections)
+
+	tagSet := make(map[string]struct{}, len(s.PerOutbound)+len(s.ActivePerOutbound))
+	for tag := range s.PerOutbound {
+		tagSet[tag] = struct{}{}
+	}
+	for tag := range s.ActivePerOutbound {
+		tagSet[tag] = struct{}{}
+	}
+	if len(tagSet) == 0 {
+		return
+	}
+	tags := make([]string, 0, len(tagSet))
+	for tag := range tagSet {
+		tags = append(tags, tag)
+	}
+	sort.Strings(tags)
+	fmt.Print("\r\n")
+	for _, tag := range tags {
+		sp := s.PerOutbound[tag]
+		name := tag
+		if name == "" {
+			name = "(unrouted)"
+		}
+		fmt.Printf("  %-32s ↓ %s   ↑ %s   (%d active)\r\n",
+			name, formatBitsPerSec(sp.Down), formatBitsPerSec(sp.Up), s.ActivePerOutbound[tag])
+	}
+}
+
+func formatBitsPerSec(bps int64) string {
+	const (
+		kbit = 1_000
+		mbit = 1_000_000
+		gbit = 1_000_000_000
+	)
+	switch {
+	case bps >= gbit:
+		return fmt.Sprintf("%6.2f Gbps", float64(bps)/gbit)
+	case bps >= mbit:
+		return fmt.Sprintf("%6.2f Mbps", float64(bps)/mbit)
+	case bps >= kbit:
+		return fmt.Sprintf("%6.2f Kbps", float64(bps)/kbit)
+	default:
+		return fmt.Sprintf("%6d bps ", bps)
+	}
+}
+
+func vpnStatus(ctx context.Context, c *ipc.Client, cmd *StatusCmd) error {
+	snap, err := fetchStatus(ctx, c)
+	if err != nil {
+		return err
+	}
+	return renderStatus(snap, cmd.JSON)
+}
+
+type statusSnapshot struct {
+	Status    vpn.VPNStatus `json:"status"`
+	Server    string        `json:"server,omitempty"`
+	Location  string        `json:"location,omitempty"`
+	LatencyMs uint16        `json:"latency_ms,omitempty"`
+	IP        string        `json:"ip,omitempty"`
+}
+
+func fetchStatus(ctx context.Context, c *ipc.Client) (statusSnapshot, error) {
+	status, err := c.VPNStatus(ctx)
+	if err != nil {
+		return statusSnapshot{}, err
+	}
+	snap := statusSnapshot{Status: status}
 	if status == vpn.Connected {
-		if sel, exists, err := c.SelectedServer(ctx); err == nil && exists {
-			line += "\nServer: " + sel.Tag
-		} else {
-			fmt.Printf("error getting selected server: err=%v, sel=%v, exists=%v\n", err, sel, exists)
+		if sel, exists, err := c.SelectedServer(ctx); err == nil && exists && sel != nil {
+			snap.Server = sel.Tag
+			snap.Location = joinNonEmpty(", ", sel.Location.City, sel.Location.Country)
+			if sel.URLTestResult != nil {
+				snap.LatencyMs = sel.URLTestResult.Delay
+			}
 		}
 	}
 	tctx, tcancel := context.WithTimeout(ctx, 5*time.Second)
 	if ip, err := getPublicIP(tctx); err == nil {
-		line += "\nIP: " + ip
+		snap.IP = ip
 	}
 	tcancel()
-	fmt.Println(line)
+	return snap, nil
+}
+
+func renderStatus(snap statusSnapshot, asJSON bool) error {
+	if asJSON {
+		return printJSON(snap)
+	}
+	s := string(snap.Status)
+	if s != "" {
+		s = strings.ToUpper(s[:1]) + s[1:]
+	}
+	fmt.Println(s)
+	if snap.Server != "" {
+		line := "Server: " + snap.Server
+		if snap.Location != "" {
+			line += " (" + snap.Location + ")"
+		}
+		if snap.LatencyMs > 0 {
+			line += fmt.Sprintf(" — %dms", snap.LatencyMs)
+		}
+		fmt.Println(line)
+	}
+	if snap.IP != "" {
+		fmt.Println("IP: " + snap.IP)
+	}
 	return nil
 }

--- a/cmd/lantern/watch.go
+++ b/cmd/lantern/watch.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"golang.org/x/term"
+
+	"github.com/getlantern/radiance/ipc"
+)
+
+const (
+	defaultReconnectTimeout = 60 * time.Second
+	reconnectInitialBackoff = 500 * time.Millisecond
+	reconnectMaxBackoff     = 5 * time.Second
+
+	reconnectPrefix = "Daemon disconnected; retrying"
+	spinnerFrames   = `|/-\`
+	spinnerInterval = 150 * time.Millisecond
+)
+
+type reconnectState struct {
+	timeout  time.Duration
+	deadline time.Time
+	backoff  time.Duration
+	notified bool
+	spinIdx  int
+}
+
+func newReconnect(timeout time.Duration) *reconnectState {
+	return &reconnectState{timeout: timeout}
+}
+
+func (r *reconnectState) onError() time.Duration {
+	if r.timeout <= 0 {
+		return 0
+	}
+	now := time.Now()
+	if r.deadline.IsZero() {
+		r.deadline = now.Add(r.timeout)
+		r.backoff = reconnectInitialBackoff
+	}
+	if now.After(r.deadline) {
+		return 0
+	}
+	wait := r.backoff
+	r.backoff *= 2
+	r.backoff = min(r.backoff, reconnectMaxBackoff)
+	return wait
+}
+
+func (r *reconnectState) onSuccess() {
+	if r.notified {
+		clearReconnectLine()
+		fmt.Fprint(os.Stderr, "Daemon reconnected.\r\n")
+		r.notified = false
+	}
+	r.deadline = time.Time{}
+	r.backoff = 0
+}
+
+func (r *reconnectState) waitForRetry(ctx context.Context, wait time.Duration) error {
+	if wait <= 0 {
+		return nil
+	}
+	if !stderrIsTTY() {
+		if !r.notified {
+			fmt.Fprintln(os.Stderr, reconnectPrefix+"...")
+			r.notified = true
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(wait):
+			return nil
+		}
+	}
+	deadline := time.Now().Add(wait)
+	for {
+		c := spinnerFrames[r.spinIdx%len(spinnerFrames)]
+		r.spinIdx++
+		fmt.Fprintf(os.Stderr, "\r%s %c ", reconnectPrefix, c)
+		r.notified = true
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nil
+		}
+		sleep := min(remaining, spinnerInterval)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(sleep):
+		}
+	}
+}
+
+func (r *reconnectState) abandon() {
+	if r.notified {
+		clearReconnectLine()
+		r.notified = false
+	}
+}
+
+func stderrIsTTY() bool {
+	return term.IsTerminal(int(os.Stderr.Fd()))
+}
+
+func stdoutIsTTY() bool {
+	return term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+func clearReconnectLine() {
+	if stderrIsTTY() {
+		fmt.Fprint(os.Stderr, "\r\033[K")
+	}
+}
+
+func callWithReconnect(ctx context.Context, st *reconnectState, fn func() error) error {
+	for {
+		err := fn()
+		if err == nil {
+			st.onSuccess()
+			return nil
+		}
+		if !errors.Is(err, ipc.ErrIPCNotRunning) {
+			st.abandon()
+			return err
+		}
+		wait := st.onError()
+		if wait <= 0 {
+			st.abandon()
+			return fmt.Errorf("daemon unreachable: %w", err)
+		}
+		if err := st.waitForRetry(ctx, wait); err != nil {
+			st.abandon()
+			return err
+		}
+	}
+}

--- a/ipc/client.go
+++ b/ipc/client.go
@@ -129,6 +129,25 @@ func (c *Client) ActiveVPNConnections(ctx context.Context) ([]vpn.Connection, er
 	return conns, err
 }
 
+// VPNSessions returns recorded VPN sessions in descending order. A limit value of 0 returns all
+// sessions.
+func (c *Client) VPNSessions(ctx context.Context, limit int) ([]vpn.Session, error) {
+	endpoint := vpnSessionsEndpoint
+	if limit > 0 {
+		endpoint = fmt.Sprintf("%s?limit=%d", endpoint, limit)
+	}
+	var sessions []vpn.Session
+	err := c.doJSON(ctx, http.MethodGet, endpoint, nil, &sessions)
+	return sessions, err
+}
+
+// VPNThroughput returns the most recent global and per-outbound throughput sample.
+func (c *Client) VPNThroughput(ctx context.Context) (vpn.ThroughputSnapshot, error) {
+	var s vpn.ThroughputSnapshot
+	err := c.doJSON(ctx, http.MethodGet, vpnThroughputEndpoint, nil, &s)
+	return s, err
+}
+
 // RunOfflineURLTests runs URL performance tests when offline (VPN disconnected) and caches the
 // results. This enables autoconnect to select the best server for the initial connection.
 func (c *Client) RunOfflineURLTests(ctx context.Context) error {

--- a/ipc/client_nonmobile.go
+++ b/ipc/client_nonmobile.go
@@ -49,6 +49,9 @@ func (c *Client) do(ctx context.Context, method, endpoint string, body any) ([]b
 
 	resp, err := c.http.Do(req)
 	if err != nil {
+		if isConnectionError(err) {
+			return nil, ErrIPCNotRunning
+		}
 		return nil, fmt.Errorf("ipc request %s %s: %w", method, endpoint, err)
 	}
 	defer resp.Body.Close()

--- a/ipc/client_nonmobile.go
+++ b/ipc/client_nonmobile.go
@@ -50,7 +50,7 @@ func (c *Client) do(ctx context.Context, method, endpoint string, body any) ([]b
 	resp, err := c.http.Do(req)
 	if err != nil {
 		if isConnectionError(err) {
-			return nil, ErrIPCNotRunning
+			return nil, fmt.Errorf("ipc request %s %s: %w: %w", method, endpoint, ErrIPCNotRunning, err)
 		}
 		return nil, fmt.Errorf("ipc request %s %s: %w", method, endpoint, err)
 	}
@@ -89,7 +89,7 @@ func (c *Client) sseStream(ctx context.Context, endpoint string, handler func([]
 	resp, err := c.http.Do(req)
 	if err != nil {
 		if isConnectionError(err) {
-			return ErrIPCNotRunning
+			return fmt.Errorf("SSE connect %s: %w: %w", endpoint, ErrIPCNotRunning, err)
 		}
 		return fmt.Errorf("SSE connect %s: %w", endpoint, err)
 	}

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -35,8 +36,10 @@ const (
 	vpnDisconnectEndpoint   = "/vpn/disconnect"
 	vpnRestartEndpoint      = "/vpn/restart"
 	vpnConnectionsEndpoint  = "/vpn/connections"
+	vpnThroughputEndpoint   = "/vpn/throughput"
 	vpnOfflineTestsEndpoint = "/vpn/offline-tests"
 	vpnStatusEventsEndpoint = "/vpn/status/events"
+	vpnSessionsEndpoint     = "/vpn/sessions"
 
 	// Server selection endpoints
 	serverSelectedEndpoint           = "/server/selected"
@@ -194,7 +197,9 @@ func newLocalAPI(b *backend.LocalBackend, withAuth bool) *localapi {
 	mux.HandleFunc("POST "+vpnDisconnectEndpoint, traced(s.vpnDisconnectHandler))
 	mux.HandleFunc("POST "+vpnRestartEndpoint, traced(s.vpnRestartHandler))
 	mux.HandleFunc("GET "+vpnConnectionsEndpoint, traced(s.vpnConnectionsHandler))
+	mux.HandleFunc("GET "+vpnThroughputEndpoint, traced(s.vpnThroughputHandler))
 	mux.HandleFunc("POST "+vpnOfflineTestsEndpoint, traced(s.vpnOfflineTestsHandler))
+	mux.HandleFunc("GET "+vpnSessionsEndpoint, traced(s.vpnSessionsHandler))
 
 	// SSE routes skip the tracer middleware since it buffers the entire response body.
 	mux.HandleFunc("GET "+vpnStatusEventsEndpoint, s.vpnStatusEventsHandler)
@@ -373,6 +378,30 @@ func (s *localapi) vpnConnectionsHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	writeJSON(w, http.StatusOK, conns)
+}
+
+func (s *localapi) vpnThroughputHandler(w http.ResponseWriter, r *http.Request) {
+	tp, err := s.backend(r.Context()).VPNThroughput()
+	if err != nil {
+		// Disconnected has no traffic; a zero snapshot is the correct value, not an error.
+		if errors.Is(err, vpn.ErrTunnelNotConnected) {
+			writeJSON(w, http.StatusOK, vpn.ThroughputSnapshot{})
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, tp)
+}
+
+func (s *localapi) vpnSessionsHandler(w http.ResponseWriter, r *http.Request) {
+	limit := 0
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	writeJSON(w, http.StatusOK, s.backend(r.Context()).Sessions(limit))
 }
 
 func (s *localapi) vpnOfflineTestsHandler(w http.ResponseWriter, r *http.Request) {

--- a/vpn/clash.go
+++ b/vpn/clash.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	N "github.com/sagernet/sing/common/network"
 	"github.com/sagernet/sing/service"
@@ -27,12 +28,17 @@ var _ adapter.ClashServer = (*clashServer)(nil)
 // owned resources beyond what's wired in via the sing-box service context.
 type clashServer struct {
 	ctx       context.Context
+	cancel    context.CancelFunc
+	startOnce sync.Once
+
 	dnsRouter adapter.DNSRouter
 	outbound  adapter.OutboundManager
 	endpoint  adapter.EndpointManager
 
-	urlTestHistory adapter.URLTestHistoryStorage
-	trafficManager *trafficontrol.Manager
+	urlTestHistory    adapter.URLTestHistoryStorage
+	trafficManager    *trafficontrol.Manager
+	throughputTracker *throughputTracker
+	trackerDone       chan struct{}
 
 	mode     string
 	modeList []string
@@ -52,12 +58,17 @@ func newClashServer(ctx context.Context, _ log.ObservableFactory, options option
 		return nil, fmt.Errorf("initial mode %q is not in mode list", initial)
 	}
 
+	runCtx, cancel := context.WithCancel(ctx)
+	trafficManager := trafficontrol.NewManager()
 	return &clashServer{
+		ctx:            runCtx,
+		cancel:         cancel,
 		dnsRouter:      service.FromContext[adapter.DNSRouter](ctx),
 		outbound:       service.FromContext[adapter.OutboundManager](ctx),
 		endpoint:       service.FromContext[adapter.EndpointManager](ctx),
 		urlTestHistory: service.FromContext[adapter.URLTestHistoryStorage](ctx),
-		trafficManager: trafficontrol.NewManager(),
+		trafficManager:    trafficManager,
+		throughputTracker: newThroughputTracker(trafficManager, time.Second),
 		modeList:       modeList,
 		mode:           initial,
 	}, nil
@@ -94,10 +105,21 @@ func (s *clashServer) ModeList() []string {
 }
 
 func (s *clashServer) Start(stage adapter.StartStage) error {
+	s.startOnce.Do(func() {
+		s.trackerDone = make(chan struct{})
+		go func() {
+			defer close(s.trackerDone)
+			s.throughputTracker.Run(s.ctx)
+		}()
+	})
 	return nil
 }
 
 func (s *clashServer) Close() error {
+	s.cancel()
+	if s.trackerDone != nil {
+		<-s.trackerDone
+	}
 	return nil
 }
 
@@ -111,6 +133,10 @@ func (s *clashServer) TrafficManager() *trafficontrol.Manager {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.trafficManager
+}
+
+func (s *clashServer) ThroughputTracker() *throughputTracker {
+	return s.throughputTracker
 }
 
 func (s *clashServer) RoutedConnection(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, matchedRule adapter.Rule, matchOutbound adapter.Outbound) net.Conn {

--- a/vpn/session_history.go
+++ b/vpn/session_history.go
@@ -1,0 +1,327 @@
+package vpn
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/getlantern/radiance/events"
+)
+
+const (
+	maxSessions      = 10
+	sessionPollEvery = time.Second
+	sessionRetention = 15 * time.Minute
+	prunePeriod      = time.Minute
+)
+
+// Session covers a single server selection while connected. A new Session begins on connect and
+// on every server switch; the prior Session is finalized at that boundary. History lives only in
+// the daemon process — sessions are lost when the process exits.
+type Session struct {
+	ConnectedAt    time.Time     `json:"connected_at"`
+	DisconnectedAt time.Time     `json:"disconnected_at,omitempty"`
+	Server         SessionServer `json:"server"`
+	BytesUp        int64         `json:"bytes_up"`
+	BytesDown      int64         `json:"bytes_down"`
+	Error          string        `json:"error,omitempty"`
+}
+
+type SessionServer struct {
+	Tag     string `json:"tag,omitempty"`
+	City    string `json:"city,omitempty"`
+	Country string `json:"country,omitempty"`
+}
+
+// Duration returns the session length.
+func (s Session) Duration() time.Duration {
+	end := s.DisconnectedAt
+	if end.IsZero() {
+		end = time.Now()
+	}
+	return end.Sub(s.ConnectedAt)
+}
+
+// SessionInfo supplies live session metadata to a SessionHistory. Bytes is invoked from a
+// background poll goroutine, so the function must be safe for concurrent use.
+type SessionInfo struct {
+	Status         func() VPNStatus
+	SelectedServer func() (tag, city, country string)
+	Bytes          func() (up, down int64, ok bool)
+}
+
+// SessionHistory keeps an in-memory ring of recent VPN sessions, retaining the most recent
+// maxSessions entries. A session covers a single server selection while connected; a server
+// switch finalizes the current session and starts a new one.
+type SessionHistory struct {
+	logger    *slog.Logger
+	info      SessionInfo
+	sub       *events.Subscription[StatusUpdateEvent]
+	closeOnce sync.Once
+
+	// A tunnel restart resets the underlying traffic-manager counters mid-session; baseline
+	// absorbs the prior tally so cumulative bytes stay monotonic across restarts.
+	bytesMu        sync.Mutex
+	startUp        int64
+	startDown      int64
+	baselineUp     int64
+	baselineDown   int64
+	livePolledUp   int64
+	livePolledDown int64
+
+	mu           sync.Mutex
+	current      *Session
+	stored       []Session
+	pollCancel   context.CancelFunc
+	pollDone     chan struct{}
+	pruneCancel  context.CancelFunc
+	pruneDone    chan struct{}
+}
+
+// NewSessionHistory creates a SessionHistory subscribed to VPN status events. Call Close to
+// unsubscribe and finalize any in-progress session.
+func NewSessionHistory(logger *slog.Logger, info SessionInfo) *SessionHistory {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	h := &SessionHistory{
+		logger: logger,
+		info:   info,
+	}
+	h.sub = events.Subscribe(h.handleStatus)
+	h.startPruner()
+	return h
+}
+
+// Close unsubscribes and finalizes any in-progress session. Safe to call multiple times.
+func (h *SessionHistory) Close() {
+	h.closeOnce.Do(func() {
+		h.sub.Unsubscribe()
+		h.stopPruner()
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		if h.current != nil {
+			h.finalizeLocked("")
+		}
+	})
+}
+
+func (h *SessionHistory) handleStatus(evt StatusUpdateEvent) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	// Status events are dispatched in unordered goroutines, so reacting to intermediate statuses
+	// risks a stale handler tearing down a session a concurrent Connected handler just started.
+	// Gate on the live VPNClient status rather than the event payload.
+	live := h.info.Status()
+	switch evt.Status {
+	case Connected:
+		if live != Connected {
+			return
+		}
+		// A Connected event arriving while a session is already active means the tunnel
+		// re-attached after a restart; the existing session continues.
+		if h.current != nil {
+			return
+		}
+		tag, city, country := h.info.SelectedServer()
+		h.startSessionLocked(tag, city, country)
+	case Disconnected, ErrorStatus:
+		if live == Connected || live == Restarting {
+			return
+		}
+		h.finalizeLocked(evt.Error)
+	}
+}
+
+// HandleServerChange finalizes the current per-server session and starts a new one for the new
+// server. No-op when no session is active or when tag matches the current server.
+func (h *SessionHistory) HandleServerChange(tag, city, country string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.current == nil {
+		return
+	}
+	if h.current.Server.Tag == tag {
+		return
+	}
+	h.finalizeLocked("")
+	h.startSessionLocked(tag, city, country)
+}
+
+func (h *SessionHistory) startSessionLocked(tag, city, country string) {
+	h.current = &Session{
+		ConnectedAt: time.Now(),
+		Server: SessionServer{
+			Tag:     tag,
+			City:    city,
+			Country: country,
+		},
+	}
+	h.snapshotStartBytesLocked()
+	if h.pollCancel == nil {
+		h.startPollLocked()
+	}
+}
+
+func (h *SessionHistory) startPollLocked() {
+	ctx, cancel := context.WithCancel(context.Background())
+	h.pollCancel = cancel
+	h.pollDone = make(chan struct{})
+	go h.poll(ctx, h.pollDone)
+}
+
+func (h *SessionHistory) stopPollLocked() {
+	if h.pollCancel == nil {
+		return
+	}
+	h.pollCancel()
+	<-h.pollDone
+	h.pollCancel = nil
+	h.pollDone = nil
+}
+
+func (h *SessionHistory) finalizeLocked(errMsg string) {
+	if h.current == nil {
+		return
+	}
+	h.stopPollLocked()
+	h.sampleBytesLocked()
+	now := time.Now()
+	h.current.DisconnectedAt = now
+	if errMsg != "" {
+		h.current.Error = errMsg
+	}
+	s := *h.current
+	h.current = nil
+	h.stored = append([]Session{s}, h.stored...)
+	if len(h.stored) > maxSessions {
+		h.stored = h.stored[:maxSessions]
+	}
+	h.pruneLocked(now)
+}
+
+func (h *SessionHistory) pruneLocked(now time.Time) {
+	cutoff := now.Add(-sessionRetention)
+	for i, s := range h.stored {
+		if s.DisconnectedAt.Before(cutoff) {
+			h.stored = h.stored[:i]
+			return
+		}
+	}
+}
+
+func (h *SessionHistory) startPruner() {
+	ctx, cancel := context.WithCancel(context.Background())
+	h.pruneCancel = cancel
+	h.pruneDone = make(chan struct{})
+	go h.prune(ctx, h.pruneDone)
+}
+
+func (h *SessionHistory) stopPruner() {
+	if h.pruneCancel == nil {
+		return
+	}
+	h.pruneCancel()
+	<-h.pruneDone
+	h.pruneCancel = nil
+	h.pruneDone = nil
+}
+
+func (h *SessionHistory) prune(ctx context.Context, done chan struct{}) {
+	defer close(done)
+	ticker := time.NewTicker(prunePeriod)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			h.mu.Lock()
+			h.pruneLocked(now)
+			h.mu.Unlock()
+		}
+	}
+}
+
+func (h *SessionHistory) sampleBytesLocked() {
+	if h.current == nil {
+		return
+	}
+	if up, down, ok := h.info.Bytes(); ok {
+		h.observeBytes(up, down)
+	}
+	h.current.BytesUp, h.current.BytesDown = h.sessionBytes()
+}
+
+func (h *SessionHistory) poll(ctx context.Context, done chan struct{}) {
+	defer close(done)
+	ticker := time.NewTicker(sessionPollEvery)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if up, down, ok := h.info.Bytes(); ok {
+				h.observeBytes(up, down)
+			}
+		}
+	}
+}
+
+func (h *SessionHistory) observeBytes(up, down int64) {
+	h.bytesMu.Lock()
+	defer h.bytesMu.Unlock()
+	// Decrease means the tunnel restarted and reset its counters; fold the prior tally forward.
+	if up < h.livePolledUp {
+		h.baselineUp += h.livePolledUp
+	}
+	if down < h.livePolledDown {
+		h.baselineDown += h.livePolledDown
+	}
+	h.livePolledUp = up
+	h.livePolledDown = down
+}
+
+func (h *SessionHistory) sessionBytes() (int64, int64) {
+	h.bytesMu.Lock()
+	defer h.bytesMu.Unlock()
+	up := h.baselineUp + h.livePolledUp - h.startUp
+	down := h.baselineDown + h.livePolledDown - h.startDown
+	if up < 0 {
+		up = 0
+	}
+	if down < 0 {
+		down = 0
+	}
+	return up, down
+}
+
+func (h *SessionHistory) snapshotStartBytesLocked() {
+	if up, down, ok := h.info.Bytes(); ok {
+		h.observeBytes(up, down)
+	}
+	h.bytesMu.Lock()
+	defer h.bytesMu.Unlock()
+	h.startUp = h.baselineUp + h.livePolledUp
+	h.startDown = h.baselineDown + h.livePolledDown
+}
+
+// Sessions returns recorded sessions in descending order (most recent first), including the
+// current session if active. A limit value of 0 returns all sessions up to maxSessions.
+func (h *SessionHistory) Sessions(limit int) []Session {
+	h.mu.Lock()
+	h.pruneLocked(time.Now())
+	h.sampleBytesLocked()
+	out := make([]Session, 0, len(h.stored)+1)
+	if h.current != nil {
+		out = append(out, *h.current)
+	}
+	out = append(out, h.stored...)
+	h.mu.Unlock()
+	if limit > 0 && limit < len(out) {
+		out = out[:limit]
+	}
+	return out
+}

--- a/vpn/session_history_test.go
+++ b/vpn/session_history_test.go
@@ -1,0 +1,278 @@
+package vpn
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeInfo struct {
+	mu       sync.Mutex
+	status   VPNStatus
+	tag      string
+	city     string
+	country  string
+	up, down int64
+	bytesOK  bool
+}
+
+func (f *fakeInfo) info() SessionInfo {
+	return SessionInfo{
+		Status: func() VPNStatus {
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			return f.status
+		},
+		SelectedServer: func() (string, string, string) {
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			return f.tag, f.city, f.country
+		},
+		Bytes: func() (int64, int64, bool) {
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			return f.up, f.down, f.bytesOK
+		},
+	}
+}
+
+func (f *fakeInfo) set(status VPNStatus, tag, city, country string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.status = status
+	f.tag, f.city, f.country = tag, city, country
+}
+
+func (f *fakeInfo) setBytes(up, down int64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.up, f.down, f.bytesOK = up, down, true
+}
+
+// newTestHistory skips the global event subscription and pruner goroutine
+// so tests can drive state directly.
+func newTestHistory(t *testing.T, status VPNStatus, tag string, up, down int64) (*SessionHistory, *fakeInfo) {
+	t.Helper()
+	info := &fakeInfo{}
+	info.set(status, tag, "", "")
+	info.setBytes(up, down)
+	return &SessionHistory{info: info.info()}, info
+}
+
+func TestSessionHistory_StatusEvents(t *testing.T) {
+	tests := []struct {
+		name        string
+		run         func(h *SessionHistory, info *fakeInfo)
+		wantCurrent bool
+		wantStored  int
+		extra       func(t *testing.T, h *SessionHistory)
+	}{
+		{
+			name: "connect then disconnect records session",
+			run: func(h *SessionHistory, info *fakeInfo) {
+				h.handleStatus(StatusUpdateEvent{Status: Connected})
+				info.set(Disconnected, "", "", "")
+				info.setBytes(500, 1000)
+				h.handleStatus(StatusUpdateEvent{Status: Disconnected})
+			},
+			wantStored: 1,
+			extra: func(t *testing.T, h *SessionHistory) {
+				assert.Equal(t, int64(500), h.stored[0].BytesUp)
+				assert.Equal(t, int64(1000), h.stored[0].BytesDown)
+				assert.False(t, h.stored[0].DisconnectedAt.IsZero())
+			},
+		},
+		{
+			name: "repeat Connected leaves current session intact",
+			run: func(h *SessionHistory, info *fakeInfo) {
+				h.handleStatus(StatusUpdateEvent{Status: Connected})
+				h.handleStatus(StatusUpdateEvent{Status: Connected})
+			},
+			wantCurrent: true,
+		},
+		{
+			name: "Disconnected ignored while live=Connected",
+			run: func(h *SessionHistory, info *fakeInfo) {
+				h.handleStatus(StatusUpdateEvent{Status: Connected})
+				info.set(Connected, "vpn-a", "", "")
+				h.handleStatus(StatusUpdateEvent{Status: Disconnected})
+			},
+			wantCurrent: true,
+		},
+		{
+			name: "Disconnected ignored while live=Restarting",
+			run: func(h *SessionHistory, info *fakeInfo) {
+				h.handleStatus(StatusUpdateEvent{Status: Connected})
+				info.set(Restarting, "vpn-a", "", "")
+				h.handleStatus(StatusUpdateEvent{Status: Disconnected})
+			},
+			wantCurrent: true,
+		},
+		{
+			name: "stale Connected (live != Connected) ignored",
+			run: func(h *SessionHistory, info *fakeInfo) {
+				h.handleStatus(StatusUpdateEvent{Status: Connected})
+				info.set(Connecting, "vpn-a", "", "")
+				h.handleStatus(StatusUpdateEvent{Status: Connected})
+			},
+			wantCurrent: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, info := newTestHistory(t, Connected, "vpn-a", 0, 0)
+			tt.run(h, info)
+			if tt.wantCurrent {
+				assert.NotNil(t, h.current)
+			} else {
+				assert.Nil(t, h.current)
+			}
+			require.Len(t, h.stored, tt.wantStored)
+			if tt.extra != nil {
+				tt.extra(t, h)
+			}
+		})
+	}
+}
+
+func TestSessionHistory_ServerSwitch(t *testing.T) {
+	tests := []struct {
+		name         string
+		startStatus  VPNStatus
+		startBytes   [2]int64
+		setup        func(h *SessionHistory, info *fakeInfo)
+		switchTag    string
+		wantCurrent  string
+		wantStored   []string
+		wantBytesUp  int64
+		wantBytesDow int64
+	}{
+		{
+			name:        "same tag is a no-op",
+			startStatus: Connected,
+			setup: func(h *SessionHistory, info *fakeInfo) {
+				h.handleStatus(StatusUpdateEvent{Status: Connected})
+			},
+			switchTag:   "vpn-a",
+			wantCurrent: "vpn-a",
+		},
+		{
+			name:        "new tag finalizes prior session with carried bytes",
+			startStatus: Connected,
+			startBytes:  [2]int64{100, 200},
+			setup: func(h *SessionHistory, info *fakeInfo) {
+				h.handleStatus(StatusUpdateEvent{Status: Connected})
+				info.setBytes(300, 600)
+			},
+			switchTag:    "vpn-b",
+			wantCurrent:  "vpn-b",
+			wantStored:   []string{"vpn-a"},
+			wantBytesUp:  200,
+			wantBytesDow: 400,
+		},
+		{
+			name:        "no current session is a no-op",
+			startStatus: Disconnected,
+			setup:       func(h *SessionHistory, info *fakeInfo) {},
+			switchTag:   "vpn-a",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, info := newTestHistory(t, tt.startStatus, "vpn-a", tt.startBytes[0], tt.startBytes[1])
+			tt.setup(h, info)
+			h.HandleServerChange(tt.switchTag, "", "")
+
+			if tt.wantCurrent == "" {
+				assert.Nil(t, h.current)
+			} else {
+				require.NotNil(t, h.current)
+				assert.Equal(t, tt.wantCurrent, h.current.Server.Tag)
+			}
+			require.Len(t, h.stored, len(tt.wantStored))
+			for i, tag := range tt.wantStored {
+				assert.Equal(t, tag, h.stored[i].Server.Tag)
+			}
+			if len(tt.wantStored) > 0 {
+				assert.Equal(t, tt.wantBytesUp, h.stored[0].BytesUp)
+				assert.Equal(t, tt.wantBytesDow, h.stored[0].BytesDown)
+			}
+		})
+	}
+}
+
+func TestSessionHistory_ByteAccounting(t *testing.T) {
+	h, _ := newTestHistory(t, Connected, "vpn-a", 100, 200)
+	h.handleStatus(StatusUpdateEvent{Status: Connected})
+
+	tests := []struct {
+		name             string
+		observeUp, obDn  int64
+		wantUp, wantDown int64
+	}{
+		{"initial", 100, 200, 0, 0},
+		{"steady accumulation", 150, 260, 50, 60},
+		{"counter reset preserves prior tally", 10, 20, 60, 80},
+		{"continued growth after reset", 40, 70, 90, 130},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h.observeBytes(tt.observeUp, tt.obDn)
+			up, down := h.sessionBytes()
+			assert.Equal(t, tt.wantUp, up)
+			assert.Equal(t, tt.wantDown, down)
+		})
+	}
+}
+
+func TestSessionHistory_Storage(t *testing.T) {
+	t.Run("prune drops entries older than retention", func(t *testing.T) {
+		h, _ := newTestHistory(t, Disconnected, "", 0, 0)
+		now := time.Now()
+		h.stored = []Session{
+			{DisconnectedAt: now.Add(-30 * time.Second)},
+			{DisconnectedAt: now.Add(-9 * time.Minute)},
+			{DisconnectedAt: now.Add(-20 * time.Minute)},
+			{DisconnectedAt: now.Add(-50 * time.Minute)},
+		}
+		h.pruneLocked(now)
+		require.Len(t, h.stored, 2)
+		for _, s := range h.stored {
+			assert.WithinDuration(t, now, s.DisconnectedAt, sessionRetention)
+		}
+	})
+
+	t.Run("Sessions returns current first then stored, honoring limit", func(t *testing.T) {
+		h, _ := newTestHistory(t, Connected, "vpn-current", 0, 0)
+		now := time.Now()
+		h.stored = []Session{
+			{DisconnectedAt: now.Add(-30 * time.Second), Server: SessionServer{Tag: "older"}},
+			{DisconnectedAt: now.Add(-90 * time.Second), Server: SessionServer{Tag: "oldest"}},
+		}
+		h.handleStatus(StatusUpdateEvent{Status: Connected})
+
+		tags := func(ss []Session) []string {
+			out := make([]string, len(ss))
+			for i, s := range ss {
+				out[i] = s.Server.Tag
+			}
+			return out
+		}
+		assert.Equal(t, []string{"vpn-current", "older", "oldest"}, tags(h.Sessions(0)))
+		assert.Equal(t, []string{"vpn-current", "older"}, tags(h.Sessions(2)))
+	})
+
+	t.Run("stored slice caps at maxSessions", func(t *testing.T) {
+		h, info := newTestHistory(t, Connected, "tag", 0, 0)
+		for i := 0; i < maxSessions+3; i++ {
+			info.set(Connected, "tag", "", "")
+			h.handleStatus(StatusUpdateEvent{Status: Connected})
+			info.set(Disconnected, "", "", "")
+			h.handleStatus(StatusUpdateEvent{Status: Disconnected})
+		}
+		assert.LessOrEqual(t, len(h.stored), maxSessions)
+	})
+}

--- a/vpn/throughput_tracker.go
+++ b/vpn/throughput_tracker.go
@@ -1,0 +1,143 @@
+package vpn
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/sagernet/sing-box/experimental/clashapi/trafficontrol"
+)
+
+// Throughput reports network throughput in bits per second.
+type Throughput struct {
+	Up   int64 `json:"up"`
+	Down int64 `json:"down"`
+}
+
+const defaultThroughputSampleInterval = time.Second
+
+type byteTotals struct {
+	up   int64
+	down int64
+}
+
+// throughputTracker reports network throughput, globally and per outbound tag.
+// Throughput is sampled at a fixed interval; readers see the most recent
+// completed sample.
+type throughputTracker struct {
+	manager  *trafficontrol.Manager
+	interval time.Duration
+
+	mu               sync.RWMutex
+	perOutbound      map[string]Throughput
+	globalThroughput Throughput
+
+	seen       map[uuid.UUID]byteTotals
+	lastGlobal byteTotals
+	lastTickAt time.Time
+}
+
+func newThroughputTracker(manager *trafficontrol.Manager, interval time.Duration) *throughputTracker {
+	if interval <= 0 {
+		interval = defaultThroughputSampleInterval
+	}
+	return &throughputTracker{
+		manager:     manager,
+		interval:    interval,
+		perOutbound: make(map[string]Throughput),
+		seen:        make(map[uuid.UUID]byteTotals),
+	}
+}
+
+// Run samples the underlying counters until ctx is canceled. It blocks.
+func (s *throughputTracker) Run(ctx context.Context) {
+	s.lastTickAt = time.Now()
+	gUp, gDown := s.manager.Total()
+	s.lastGlobal = byteTotals{up: gUp, down: gDown}
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			s.sample(now)
+		}
+	}
+}
+
+func (s *throughputTracker) Global() Throughput {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.globalThroughput
+}
+
+// Outbound returns the most recent throughput sample for tag, or a zero
+// Throughput if no traffic has been observed for that tag.
+func (s *throughputTracker) Outbound(tag string) Throughput {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.perOutbound[tag]
+}
+
+// PerOutbound returns a snapshot copy of the most recent per-outbound samples.
+func (s *throughputTracker) PerOutbound() map[string]Throughput {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make(map[string]Throughput, len(s.perOutbound))
+	for k, v := range s.perOutbound {
+		out[k] = v
+	}
+	return out
+}
+
+func (s *throughputTracker) sample(now time.Time) {
+	elapsed := now.Sub(s.lastTickAt).Seconds()
+	// Skip on clock jumps or coalesced ticks: leaving lastTickAt and the byte baselines
+	// untouched means the next sample's elapsed and deltas span the same window.
+	if elapsed <= 0 {
+		return
+	}
+	s.lastTickAt = now
+
+	deltas := make(map[string]byteTotals)
+	nextSeen := make(map[uuid.UUID]byteTotals, len(s.seen))
+	visit := func(m trafficontrol.TrackerMetadata) {
+		up := m.Upload.Load()
+		down := m.Download.Load()
+		prev := s.seen[m.ID]
+		d := deltas[m.Outbound]
+		d.up += up - prev.up
+		d.down += down - prev.down
+		deltas[m.Outbound] = d
+		nextSeen[m.ID] = byteTotals{up: up, down: down}
+	}
+	for _, m := range s.manager.Connections() {
+		visit(m)
+	}
+	for _, m := range s.manager.ClosedConnections() {
+		visit(m)
+	}
+	s.seen = nextSeen
+
+	perOutbound := make(map[string]Throughput, len(deltas))
+	for tag, d := range deltas {
+		perOutbound[tag] = Throughput{
+			Up:   int64(float64(d.up*8) / elapsed),
+			Down: int64(float64(d.down*8) / elapsed),
+		}
+	}
+
+	gUp, gDown := s.manager.Total()
+	globalThroughput := Throughput{
+		Up:   int64(float64((gUp-s.lastGlobal.up)*8) / elapsed),
+		Down: int64(float64((gDown-s.lastGlobal.down)*8) / elapsed),
+	}
+	s.lastGlobal = byteTotals{up: gUp, down: gDown}
+
+	s.mu.Lock()
+	s.perOutbound = perOutbound
+	s.globalThroughput = globalThroughput
+	s.mu.Unlock()
+}

--- a/vpn/throughput_tracker_test.go
+++ b/vpn/throughput_tracker_test.go
@@ -1,0 +1,131 @@
+package vpn
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/sagernet/sing-box/experimental/clashapi/trafficontrol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeTracker struct {
+	md trafficontrol.TrackerMetadata
+}
+
+func (f *fakeTracker) Metadata() trafficontrol.TrackerMetadata { return f.md }
+func (f *fakeTracker) Close() error                            { return nil }
+
+func newFakeTracker(outbound string) *fakeTracker {
+	id, err := uuid.NewV4()
+	if err != nil {
+		panic(err)
+	}
+	return &fakeTracker{
+		md: trafficontrol.TrackerMetadata{
+			ID:        id,
+			CreatedAt: time.Now(),
+			Upload:    new(atomic.Int64),
+			Download:  new(atomic.Int64),
+			Outbound:  outbound,
+		},
+	}
+}
+
+// addBytes keeps the fake tracker and manager totals in sync; updating only one side
+// produces phantom throughput in the next sample.
+func addBytes(mgr *trafficontrol.Manager, t *fakeTracker, up, down int64) {
+	t.md.Upload.Add(up)
+	t.md.Download.Add(down)
+	mgr.PushUploaded(up)
+	mgr.PushDownloaded(down)
+}
+
+func TestThroughputTracker_Sample(t *testing.T) {
+	tests := []struct {
+		name       string
+		run        func(mgr *trafficontrol.Manager, tr *throughputTracker, t0 time.Time)
+		wantPer    map[string]Throughput
+		wantGlobal Throughput
+	}{
+		{
+			name: "computes per-outbound and global bps from byte deltas",
+			run: func(mgr *trafficontrol.Manager, tr *throughputTracker, t0 time.Time) {
+				a, b := newFakeTracker("vpn-a"), newFakeTracker("vpn-b")
+				mgr.Join(a)
+				mgr.Join(b)
+				addBytes(mgr, a, 125, 250)
+				addBytes(mgr, b, 500, 1000)
+				tr.sample(t0.Add(time.Second))
+			},
+			wantPer: map[string]Throughput{
+				"vpn-a": {Up: 125 * 8, Down: 250 * 8},
+				"vpn-b": {Up: 500 * 8, Down: 1000 * 8},
+			},
+			wantGlobal: Throughput{Up: 625 * 8, Down: 1250 * 8},
+		},
+		{
+			name: "includes bytes from connections closed during the window",
+			run: func(mgr *trafficontrol.Manager, tr *throughputTracker, t0 time.Time) {
+				live, closing := newFakeTracker("vpn-a"), newFakeTracker("vpn-a")
+				mgr.Join(live)
+				mgr.Join(closing)
+				addBytes(mgr, live, 100, 0)
+				addBytes(mgr, closing, 400, 0)
+				mgr.Leave(closing)
+				tr.sample(t0.Add(time.Second))
+			},
+			wantPer:    map[string]Throughput{"vpn-a": {Up: 500 * 8}},
+			wantGlobal: Throughput{Up: 500 * 8},
+		},
+		{
+			name: "non-positive elapsed leaves baselines untouched for the next tick",
+			run: func(mgr *trafficontrol.Manager, tr *throughputTracker, t0 time.Time) {
+				a := newFakeTracker("vpn-a")
+				mgr.Join(a)
+				addBytes(mgr, a, 100, 200)
+				tr.sample(t0)
+
+				addBytes(mgr, a, 50, 50)
+				tr.sample(t0.Add(time.Second))
+			},
+			wantPer:    map[string]Throughput{"vpn-a": {Up: 150 * 8, Down: 250 * 8}},
+			wantGlobal: Throughput{Up: 150 * 8, Down: 250 * 8},
+		},
+	}
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr := trafficontrol.NewManager()
+			tr := newThroughputTracker(mgr, time.Second)
+			t0 := time.Unix(int64(1000+i), 0)
+			tr.lastTickAt = t0
+			tt.run(mgr, tr, t0)
+			assert.Equal(t, tt.wantPer, tr.PerOutbound())
+			assert.Equal(t, tt.wantGlobal, tr.Global())
+		})
+	}
+}
+
+func TestThroughputTracker_PerOutboundIsIsolatedCopy(t *testing.T) {
+	mgr := trafficontrol.NewManager()
+	tr := newThroughputTracker(mgr, time.Second)
+	a := newFakeTracker("vpn-a")
+	mgr.Join(a)
+	addBytes(mgr, a, 10, 10)
+
+	t0 := time.Unix(4000, 0)
+	tr.lastTickAt = t0
+	tr.sample(t0.Add(time.Second))
+
+	snap := tr.PerOutbound()
+	require.Equal(t, Throughput{Up: 80, Down: 80}, snap["vpn-a"])
+	snap["vpn-a"] = Throughput{Up: 999}
+	assert.Equal(t, Throughput{Up: 80, Down: 80}, tr.PerOutbound()["vpn-a"])
+}
+
+func TestThroughputTracker_OutboundUnknownTag(t *testing.T) {
+	tr := newThroughputTracker(trafficontrol.NewManager(), time.Second)
+	assert.Equal(t, Throughput{}, tr.Outbound("missing"))
+}

--- a/vpn/types.go
+++ b/vpn/types.go
@@ -24,34 +24,42 @@ type Selector interface {
 }
 
 type OutboundGroup struct {
-	Tag       string
-	Type      string
-	Selected  string
-	Outbounds []Outbounds
+	Tag       string      `json:"tag"`
+	Type      string      `json:"type"`
+	Selected  string      `json:"selected"`
+	Outbounds []Outbounds `json:"outbounds"`
 }
 
 type Outbounds struct {
-	Tag  string
-	Type string
+	Tag  string `json:"tag"`
+	Type string `json:"type"`
+}
+
+// ThroughputSnapshot is the most recent throughput sample for the tunnel.
+type ThroughputSnapshot struct {
+	Global            Throughput            `json:"global"`
+	PerOutbound       map[string]Throughput `json:"per_outbound"`
+	ActiveConnections int                   `json:"active_connections"`
+	ActivePerOutbound map[string]int        `json:"active_per_outbound"`
 }
 
 type Connection struct {
-	ID           string
-	Inbound      string
-	IPVersion    int
-	Network      string
-	Source       string
-	Destination  string
-	Domain       string
-	Protocol     string
-	FromOutbound string
-	CreatedAt    int64
-	ClosedAt     int64
-	Uplink       int64
-	Downlink     int64
-	Rule         string
-	Outbound     string
-	ChainList    []string
+	ID           string   `json:"id"`
+	Inbound      string   `json:"inbound"`
+	IPVersion    int      `json:"ip_version"`
+	Network      string   `json:"network"`
+	Source       string   `json:"source"`
+	Destination  string   `json:"destination"`
+	Domain       string   `json:"domain,omitempty"`
+	Protocol     string   `json:"protocol,omitempty"`
+	FromOutbound string   `json:"from_outbound,omitempty"`
+	CreatedAt    int64    `json:"created_at"`
+	ClosedAt     int64    `json:"closed_at,omitempty"`
+	Uplink       int64    `json:"uplink"`
+	Downlink     int64    `json:"downlink"`
+	Rule         string   `json:"rule,omitempty"`
+	Outbound     string   `json:"outbound"`
+	ChainList    []string `json:"chain,omitempty"`
 }
 
 // NewConnection creates a Connection from tracker metadata.

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -29,6 +29,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	box "github.com/getlantern/lantern-box"
+
 	"github.com/getlantern/radiance/events"
 	"github.com/getlantern/radiance/log"
 	"github.com/getlantern/radiance/servers"
@@ -357,6 +358,41 @@ func (c *VPNClient) Connections() ([]Connection, error) {
 		connections = append(connections, newConnection(conn))
 	}
 	return connections, nil
+}
+
+// Bytes returns the cumulative up/down byte counters for the active tunnel. ok is false if the
+// tunnel is not connected; counters reset when a tunnel restarts.
+func (c *VPNClient) Bytes() (up, down int64, ok bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.tunnel == nil {
+		return 0, 0, false
+	}
+	up, down = c.tunnel.clashServer.TrafficManager().Total()
+	return up, down, true
+}
+
+// Throughput returns the most recent global and per-outbound throughput sample.
+// Returns ErrTunnelNotConnected if the tunnel is not connected.
+func (c *VPNClient) Throughput() (ThroughputSnapshot, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.tunnel == nil {
+		return ThroughputSnapshot{}, ErrTunnelNotConnected
+	}
+	tt := c.tunnel.clashServer.ThroughputTracker()
+	tm := c.tunnel.clashServer.TrafficManager()
+	active := tm.Connections()
+	perOut := make(map[string]int, len(active))
+	for _, m := range active {
+		perOut[m.Outbound]++
+	}
+	return ThroughputSnapshot{
+		Global:            tt.Global(),
+		PerOutbound:       tt.PerOutbound(),
+		ActiveConnections: len(active),
+		ActivePerOutbound: perOut,
+	}, nil
 }
 
 // AutoSelectedEvent is emitted when the auto-selected server changes.


### PR DESCRIPTION
## Summary

- Adds `lantern monitor`, a live TUI showing VPN status, throughput, recent sessions, server-pool health, and warn/error log entries (with `--json` for one snapshot per tick and `--reconnect-timeout` to ride out daemon restarts).
- Tracks throughput globally and per-outbound on `VPNClient` and records a rolling session history across server changes; exposes both via new `/vpn/throughput` and `/vpn/sessions` IPC endpoints. Session history lives only in the daemon process — it is lost when the daemon exits, and each closed session is pruned 15 minutes after its disconnect timestamp.
- Polishes the rest of the CLI: `--json` on `status`, `ip`, and `servers list`; promotes `servers` / `private` to subcommands with positional args; adds a `throughput` subcommand; `logs` gains `--level` / `--grep` filters and reconnects when the daemon comes back.
- Wires `SessionHistory` into `LocalBackend`, disconnects the VPN cleanly on shutdown, and maps IPC network errors to `ErrIPCNotRunning` so clients can drive their own reconnect logic.
