### PR TITLE
fix: preserve caller-supplied data dir; restore Pro on upgrade

### DIFF
--- a/common/init.go
+++ b/common/init.go
@@ -146,9 +146,15 @@ func setupDirectories(data, logs string) (dataDir, logDir string, err error) {
 	} else if logs == "" {
 		logs = internal.DefaultLogPath()
 	}
-	// ensure the data and logs directories end with the correct suffix
-	data = maybeAddSuffix(data, "data")
-	logs = maybeAddSuffix(logs, "logs")
+	// Honor the caller's path as-is. A previous version of this function
+	// unconditionally appended /data and /logs suffixes here even when the
+	// caller passed a fully-resolved path (e.g. Android passes
+	// <app.dataDir>/.lantern). That broke upgrade continuity: v9.0.x had
+	// written settings.json under <caller-path>/, while v9.1.x reads from
+	// <caller-path>/data/, so every existing install lost its persisted
+	// user_id, device_id, jwt token, and user_level on upgrade — surfacing
+	// as "Pro is suddenly expired after the update." See ticket #174515
+	// and the "Pro lost on upgrade" memory note.
 	data, _ = filepath.Abs(data)
 	logs, _ = filepath.Abs(logs)
 	for _, path := range []string{data, logs} {
@@ -157,11 +163,4 @@ func setupDirectories(data, logs string) (dataDir, logDir string, err error) {
 		}
 	}
 	return data, logs, nil
-}
-
-func maybeAddSuffix(path, suffix string) string {
-	if !strings.EqualFold(filepath.Base(path), suffix) {
-		path = filepath.Join(path, suffix)
-	}
-	return path
 }

--- a/common/settings/settings.go
+++ b/common/settings/settings.go
@@ -93,6 +93,7 @@ func InitSettings(fileDir string) error {
 		return fmt.Errorf("failed to create data directory: %v", err)
 	}
 	k.filePath = filepath.Join(fileDir, settingsFileName)
+	migrateV91xSettingsIfNeeded(fileDir, k.filePath)
 	switch err := loadSettings(k.filePath); {
 	case errors.Is(err, fs.ErrNotExist):
 		slog.Warn("settings file not found", "path", k.filePath) // file may not have been created yet
@@ -102,6 +103,37 @@ func InitSettings(fileDir string) error {
 	}
 	k.initialized = true
 	return nil
+}
+
+// migrateV91xSettingsIfNeeded recovers settings written by v9.1.x clients
+// that landed in <fileDir>/data/settings.json because of a bug in
+// radiance #370 (setupDirectories appended an unconditional "/data"
+// suffix). On the first launch of a fixed client, if the canonical
+// path is empty but the nested path has data, copy it up so the user
+// keeps their persisted user_id, device_id, jwt token, and user_level
+// instead of starting fresh and showing "Pro expired."
+//
+// Runs unconditionally — quick stat check, no-op for the vast majority
+// of installs that never had the bad nested file.
+func migrateV91xSettingsIfNeeded(fileDir, canonicalPath string) {
+	if _, err := os.Stat(canonicalPath); err == nil {
+		// Canonical path already populated — either v9.0.x state survived
+		// the v9.1.x detour intact, or we've already migrated. Nothing to do.
+		return
+	}
+	nested := filepath.Join(fileDir, "data", settingsFileName)
+	contents, err := os.ReadFile(nested)
+	if err != nil {
+		// No nested file (or unreadable) — fresh install, normal path.
+		return
+	}
+	if err := os.WriteFile(canonicalPath, contents, fileperm.File); err != nil {
+		slog.Warn("v9.1.x settings migration: write failed; fresh install path will be used",
+			"src", nested, "dst", canonicalPath, "error", err)
+		return
+	}
+	slog.Info("v9.1.x settings migration: recovered persisted state",
+		"src", nested, "dst", canonicalPath, "bytes", len(contents))
 }
 
 func loadSettings(path string) error {

--- a/common/settings/settings.go
+++ b/common/settings/settings.go
@@ -60,6 +60,12 @@ const (
 	PreferredLocationKey _key = "preferred_location" // [common.PreferredLocation]
 
 	settingsFileName = "settings.json"
+	// legacySettingsFileName is what v9.0.x called the same file (it was
+	// renamed in radiance PR #370). On upgrade from v9.0.x, the user's
+	// persisted user_id / token / user_level live at <dataDir>/local.json;
+	// migrateLegacySettingsIfNeeded reads it from there so Pro state
+	// survives the rename.
+	legacySettingsFileName = "local.json"
 )
 
 var ErrNotExist = errors.New("key does not exist")
@@ -94,7 +100,7 @@ func InitSettings(fileDir string) error {
 		return fmt.Errorf("failed to create data directory: %v", err)
 	}
 	k.filePath = filepath.Join(fileDir, settingsFileName)
-	migrateV91xSettingsIfNeeded(fileDir, k.filePath)
+	migrateLegacySettingsIfNeeded(fileDir, k.filePath)
 	switch err := loadSettings(k.filePath); {
 	case errors.Is(err, fs.ErrNotExist):
 		slog.Warn("settings file not found", "path", k.filePath) // file may not have been created yet
@@ -106,68 +112,88 @@ func InitSettings(fileDir string) error {
 	return nil
 }
 
-// migrateV91xSettingsIfNeeded recovers settings written by v9.1.x clients
-// that landed in <fileDir>/data/settings.json because of a bug in
-// radiance #370 (setupDirectories appended an unconditional "/data"
-// suffix). On the first launch of a fixed client, the canonical path
-// (<fileDir>/settings.json) and the nested path (<fileDir>/data/
-// settings.json) may both contain a settings.json — the canonical one
-// from v9.0.x and the nested one freshly written by v9.1.x.
+// migrateLegacySettingsIfNeeded recovers persisted user state written
+// by older client versions. Three candidate paths are considered:
 //
-// We don't just prefer the canonical file: in the typical-affected
-// case the canonical is correct (user_level="pro") and the nested is
-// wrong (user_level="expired" because v9.1.x lost the user_id and got
-// a fresh server response). But in the inverse case — e.g., user paid
-// via Shepherd during the v9.1.x window — the nested file holds the
-// good state. So we read both and prefer whichever actually says "pro";
-// fall back to canonical-if-it-exists; finally fall back to nested.
+//   - <fileDir>/settings.json         — the current canonical path
+//   - <fileDir>/local.json            — what v9.0.x wrote (renamed in #370)
+//   - <fileDir>/data/settings.json    — what v9.1.x wrote, due to a bug in
+//                                       #370's setupDirectories that
+//                                       appended an unconditional "/data"
+//                                       suffix to the caller's data dir
 //
-// Runs unconditionally — quick stat check, no-op for the vast majority
-// of installs that never had the bad nested file.
-func migrateV91xSettingsIfNeeded(fileDir, canonicalPath string) {
-	nestedPath := filepath.Join(fileDir, "data", settingsFileName)
-	canonicalContents, canonicalErr := os.ReadFile(canonicalPath)
-	nestedContents, nestedErr := os.ReadFile(nestedPath)
-
-	// No nested file — nothing to migrate. The fixed client reads the
-	// canonical path normally (or starts fresh if neither exists).
-	if nestedErr != nil {
-		return
+// On the first launch of a fixed client, any of the three may exist
+// depending on the user's upgrade path. Pick whichever has
+// user_level == "pro" so anyone who legitimately paid keeps their Pro
+// state regardless of which file holds the good copy. If none have pro,
+// prefer canonical → v9.0.x → v9.1.x in that order so the user's
+// identifiers (user_id, token, device_id) survive — losing Pro is
+// recoverable, losing the device registration creates server-side
+// orphans.
+//
+// Runs unconditionally — quick stat-and-read of three small files;
+// no-op for the vast majority of installs that don't have a nested or
+// legacy file.
+func migrateLegacySettingsIfNeeded(fileDir, canonicalPath string) {
+	type candidate struct {
+		path     string
+		contents []byte
+		exists   bool
+		label    string
+	}
+	candidates := []candidate{
+		{path: canonicalPath, label: "canonical settings.json"},
+		{path: filepath.Join(fileDir, legacySettingsFileName), label: "v9.0.x local.json"},
+		{path: filepath.Join(fileDir, "data", settingsFileName), label: "v9.1.x data/settings.json"},
+	}
+	for i := range candidates {
+		b, err := os.ReadFile(candidates[i].path)
+		if err == nil {
+			candidates[i].contents = b
+			candidates[i].exists = true
+		}
 	}
 
-	// No canonical file but nested exists — copy nested up so the
-	// fixed client picks up the v9.1.x state instead of starting fresh.
-	if canonicalErr != nil {
-		writeMigrated(canonicalPath, nestedContents, "no canonical file")
+	// Pick: highest-priority file with user_level=="pro"; if none has pro,
+	// highest-priority file that exists at all (with non-empty contents).
+	pickIdx := -1
+	for i, c := range candidates {
+		if c.exists && userLevelInJSON(c.contents) == "pro" {
+			pickIdx = i
+			break
+		}
+	}
+	if pickIdx == -1 {
+		for i, c := range candidates {
+			if c.exists {
+				pickIdx = i
+				break
+			}
+		}
+	}
+	if pickIdx == -1 {
+		// Nothing on disk yet — fresh install, normal path. No-op.
 		return
 	}
-
-	// Both files exist. Prefer the one whose user_level == "pro" since
-	// that's the load-bearing concern: a user who had Pro in either path
-	// should keep Pro. If both or neither have pro, keep canonical.
-	canonicalPro := userLevelInJSON(canonicalContents) == "pro"
-	nestedPro := userLevelInJSON(nestedContents) == "pro"
-
-	if nestedPro && !canonicalPro {
-		writeMigrated(canonicalPath, nestedContents, "nested has pro, canonical does not")
+	if candidates[pickIdx].path == canonicalPath {
+		// Canonical already wins — no migration needed.
 		return
 	}
-	// Canonical is preferred: it has pro, or neither has pro and we
-	// trust the older settings file as the more deliberate state.
+	writeMigrated(canonicalPath, candidates[pickIdx].contents, candidates[pickIdx].label)
 }
 
 // writeMigrated overwrites the canonical settings file with the recovered
 // contents and logs the outcome. Errors are logged-and-swallowed: if the
 // write fails the caller falls through to the fresh-install path, which
 // is a worse UX but not a corruption risk.
-func writeMigrated(canonicalPath string, contents []byte, reason string) {
+func writeMigrated(canonicalPath string, contents []byte, source string) {
 	if err := os.WriteFile(canonicalPath, contents, fileperm.File); err != nil {
-		slog.Warn("v9.1.x settings migration: write failed",
-			"dst", canonicalPath, "reason", reason, "error", err)
+		slog.Warn("legacy settings migration: write failed",
+			"dst", canonicalPath, "source", source, "error", err)
 		return
 	}
-	slog.Info("v9.1.x settings migration: recovered persisted state",
-		"dst", canonicalPath, "reason", reason, "bytes", len(contents))
+	slog.Info("legacy settings migration: recovered persisted state",
+		"dst", canonicalPath, "source", source, "bytes", len(contents))
 }
 
 // userLevelInJSON returns the value of the "user_level" key from a JSON

--- a/common/settings/settings.go
+++ b/common/settings/settings.go
@@ -148,9 +148,23 @@ func migrateLegacySettingsIfNeeded(fileDir, canonicalPath string) {
 	}
 	for i := range candidates {
 		b, err := os.ReadFile(candidates[i].path)
-		if err == nil {
+		switch {
+		case err == nil:
 			candidates[i].contents = b
 			candidates[i].exists = true
+		case errors.Is(err, fs.ErrNotExist):
+			// Expected — file just isn't there. Treat as not-present.
+		default:
+			// Permission / I/O error — log it but don't bail outright. If
+			// it's the canonical path that's unreadable for non-ENOENT
+			// reasons, skip migration entirely so we don't try to write
+			// over a file the OS is telling us we can't see; for legacy
+			// or nested paths, treat the same as not-present.
+			slog.Warn("legacy settings migration: read failed",
+				"path", candidates[i].path, "error", err)
+			if candidates[i].path == canonicalPath {
+				return
+			}
 		}
 	}
 
@@ -183,11 +197,13 @@ func migrateLegacySettingsIfNeeded(fileDir, canonicalPath string) {
 }
 
 // writeMigrated overwrites the canonical settings file with the recovered
-// contents and logs the outcome. Errors are logged-and-swallowed: if the
-// write fails the caller falls through to the fresh-install path, which
-// is a worse UX but not a corruption risk.
+// contents and logs the outcome. Uses atomicfile.WriteFile (the same
+// mechanism the normal save path uses) so a crash mid-write can't leave
+// a half-written settings.json on disk. Errors are logged-and-swallowed:
+// if the write fails the caller falls through to the fresh-install path,
+// which is a worse UX but not a corruption risk.
 func writeMigrated(canonicalPath string, contents []byte, source string) {
-	if err := os.WriteFile(canonicalPath, contents, fileperm.File); err != nil {
+	if err := atomicfile.WriteFile(canonicalPath, contents, fileperm.File); err != nil {
 		slog.Warn("legacy settings migration: write failed",
 			"dst", canonicalPath, "source", source, "error", err)
 		return

--- a/common/settings/settings.go
+++ b/common/settings/settings.go
@@ -2,6 +2,7 @@
 package settings
 
 import (
+	jsonpkg "encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -108,32 +109,79 @@ func InitSettings(fileDir string) error {
 // migrateV91xSettingsIfNeeded recovers settings written by v9.1.x clients
 // that landed in <fileDir>/data/settings.json because of a bug in
 // radiance #370 (setupDirectories appended an unconditional "/data"
-// suffix). On the first launch of a fixed client, if the canonical
-// path is empty but the nested path has data, copy it up so the user
-// keeps their persisted user_id, device_id, jwt token, and user_level
-// instead of starting fresh and showing "Pro expired."
+// suffix). On the first launch of a fixed client, the canonical path
+// (<fileDir>/settings.json) and the nested path (<fileDir>/data/
+// settings.json) may both contain a settings.json — the canonical one
+// from v9.0.x and the nested one freshly written by v9.1.x.
+//
+// We don't just prefer the canonical file: in the typical-affected
+// case the canonical is correct (user_level="pro") and the nested is
+// wrong (user_level="expired" because v9.1.x lost the user_id and got
+// a fresh server response). But in the inverse case — e.g., user paid
+// via Shepherd during the v9.1.x window — the nested file holds the
+// good state. So we read both and prefer whichever actually says "pro";
+// fall back to canonical-if-it-exists; finally fall back to nested.
 //
 // Runs unconditionally — quick stat check, no-op for the vast majority
 // of installs that never had the bad nested file.
 func migrateV91xSettingsIfNeeded(fileDir, canonicalPath string) {
-	if _, err := os.Stat(canonicalPath); err == nil {
-		// Canonical path already populated — either v9.0.x state survived
-		// the v9.1.x detour intact, or we've already migrated. Nothing to do.
+	nestedPath := filepath.Join(fileDir, "data", settingsFileName)
+	canonicalContents, canonicalErr := os.ReadFile(canonicalPath)
+	nestedContents, nestedErr := os.ReadFile(nestedPath)
+
+	// No nested file — nothing to migrate. The fixed client reads the
+	// canonical path normally (or starts fresh if neither exists).
+	if nestedErr != nil {
 		return
 	}
-	nested := filepath.Join(fileDir, "data", settingsFileName)
-	contents, err := os.ReadFile(nested)
-	if err != nil {
-		// No nested file (or unreadable) — fresh install, normal path.
+
+	// No canonical file but nested exists — copy nested up so the
+	// fixed client picks up the v9.1.x state instead of starting fresh.
+	if canonicalErr != nil {
+		writeMigrated(canonicalPath, nestedContents, "no canonical file")
 		return
 	}
+
+	// Both files exist. Prefer the one whose user_level == "pro" since
+	// that's the load-bearing concern: a user who had Pro in either path
+	// should keep Pro. If both or neither have pro, keep canonical.
+	canonicalPro := userLevelInJSON(canonicalContents) == "pro"
+	nestedPro := userLevelInJSON(nestedContents) == "pro"
+
+	if nestedPro && !canonicalPro {
+		writeMigrated(canonicalPath, nestedContents, "nested has pro, canonical does not")
+		return
+	}
+	// Canonical is preferred: it has pro, or neither has pro and we
+	// trust the older settings file as the more deliberate state.
+}
+
+// writeMigrated overwrites the canonical settings file with the recovered
+// contents and logs the outcome. Errors are logged-and-swallowed: if the
+// write fails the caller falls through to the fresh-install path, which
+// is a worse UX but not a corruption risk.
+func writeMigrated(canonicalPath string, contents []byte, reason string) {
 	if err := os.WriteFile(canonicalPath, contents, fileperm.File); err != nil {
-		slog.Warn("v9.1.x settings migration: write failed; fresh install path will be used",
-			"src", nested, "dst", canonicalPath, "error", err)
+		slog.Warn("v9.1.x settings migration: write failed",
+			"dst", canonicalPath, "reason", reason, "error", err)
 		return
 	}
 	slog.Info("v9.1.x settings migration: recovered persisted state",
-		"src", nested, "dst", canonicalPath, "bytes", len(contents))
+		"dst", canonicalPath, "reason", reason, "bytes", len(contents))
+}
+
+// userLevelInJSON returns the value of the "user_level" key from a JSON
+// settings blob, or "" if the key is missing / the blob is malformed.
+// Lightweight extraction so the migration doesn't need to load the full
+// koanf state machine before we've decided which file to read.
+func userLevelInJSON(contents []byte) string {
+	var s struct {
+		UserLevel string `json:"user_level"`
+	}
+	if err := jsonpkg.Unmarshal(contents, &s); err != nil {
+		return ""
+	}
+	return s.UserLevel
 }
 
 func loadSettings(path string) error {

--- a/common/settings/settings_test.go
+++ b/common/settings/settings_test.go
@@ -32,38 +32,84 @@ func TestInitSettings(t *testing.T) {
 }
 
 func TestMigrateV91xSettingsIfNeeded(t *testing.T) {
+	writeNested := func(t *testing.T, dir string, contents []byte) {
+		t.Helper()
+		nd := filepath.Join(dir, "data")
+		require.NoError(t, os.MkdirAll(nd, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(nd, settingsFileName), contents, 0o644))
+	}
+
 	t.Run("nested file recovered when canonical is missing", func(t *testing.T) {
 		tempDir := t.TempDir()
-		nestedDir := filepath.Join(tempDir, "data")
-		require.NoError(t, os.MkdirAll(nestedDir, 0o755))
-		nestedPath := filepath.Join(nestedDir, settingsFileName)
 		want := []byte(`{"user_id": 135809562, "user_level": "pro", "device_id": "abc"}`)
-		require.NoError(t, os.WriteFile(nestedPath, want, 0o644))
+		writeNested(t, tempDir, want)
 
 		canonical := filepath.Join(tempDir, settingsFileName)
 		migrateV91xSettingsIfNeeded(tempDir, canonical)
 
 		got, err := os.ReadFile(canonical)
-		require.NoError(t, err, "canonical settings.json should exist after migration")
+		require.NoError(t, err)
 		assert.Equal(t, want, got, "migrated content should match nested file")
 	})
 
-	t.Run("canonical present takes precedence; nested ignored", func(t *testing.T) {
+	t.Run("canonical-pro wins over nested-expired (the typical broken upgrade)", func(t *testing.T) {
+		// v9.0.x wrote canonical with pro; v9.1.x wrote nested with expired
+		// because it lost the user_id. The fixed client must keep canonical.
 		tempDir := t.TempDir()
 		canonical := filepath.Join(tempDir, settingsFileName)
-		canonicalContents := []byte(`{"user_id": 1, "user_level": "pro"}`)
-		require.NoError(t, os.WriteFile(canonical, canonicalContents, 0o644))
-
-		nestedDir := filepath.Join(tempDir, "data")
-		require.NoError(t, os.MkdirAll(nestedDir, 0o755))
-		nestedPath := filepath.Join(nestedDir, settingsFileName)
-		require.NoError(t, os.WriteFile(nestedPath, []byte(`{"user_id": 999}`), 0o644))
+		canonicalPro := []byte(`{"user_id": 1, "user_level": "pro"}`)
+		require.NoError(t, os.WriteFile(canonical, canonicalPro, 0o644))
+		writeNested(t, tempDir, []byte(`{"user_id": 999, "user_level": "expired"}`))
 
 		migrateV91xSettingsIfNeeded(tempDir, canonical)
 
 		got, err := os.ReadFile(canonical)
 		require.NoError(t, err)
-		assert.Equal(t, canonicalContents, got, "canonical should be unchanged when it already exists")
+		assert.Equal(t, canonicalPro, got, "canonical-pro should survive when nested is expired")
+	})
+
+	t.Run("nested-pro wins over canonical-expired (rare inverse case)", func(t *testing.T) {
+		// e.g., user paid via Shepherd during the v9.1.x window so the
+		// nested file legitimately has pro while canonical is stale.
+		tempDir := t.TempDir()
+		canonical := filepath.Join(tempDir, settingsFileName)
+		require.NoError(t, os.WriteFile(canonical, []byte(`{"user_id": 1, "user_level": "expired"}`), 0o644))
+		nestedPro := []byte(`{"user_id": 2, "user_level": "pro"}`)
+		writeNested(t, tempDir, nestedPro)
+
+		migrateV91xSettingsIfNeeded(tempDir, canonical)
+
+		got, err := os.ReadFile(canonical)
+		require.NoError(t, err)
+		assert.Equal(t, nestedPro, got, "nested-pro should overwrite canonical-expired")
+	})
+
+	t.Run("both pro: canonical wins (older deliberate state)", func(t *testing.T) {
+		tempDir := t.TempDir()
+		canonical := filepath.Join(tempDir, settingsFileName)
+		canonicalContents := []byte(`{"user_id": 1, "user_level": "pro"}`)
+		require.NoError(t, os.WriteFile(canonical, canonicalContents, 0o644))
+		writeNested(t, tempDir, []byte(`{"user_id": 2, "user_level": "pro"}`))
+
+		migrateV91xSettingsIfNeeded(tempDir, canonical)
+
+		got, err := os.ReadFile(canonical)
+		require.NoError(t, err)
+		assert.Equal(t, canonicalContents, got, "canonical preferred when both pro")
+	})
+
+	t.Run("neither pro: canonical wins", func(t *testing.T) {
+		tempDir := t.TempDir()
+		canonical := filepath.Join(tempDir, settingsFileName)
+		canonicalContents := []byte(`{"user_id": 1, "user_level": "free"}`)
+		require.NoError(t, os.WriteFile(canonical, canonicalContents, 0o644))
+		writeNested(t, tempDir, []byte(`{"user_id": 2, "user_level": "free"}`))
+
+		migrateV91xSettingsIfNeeded(tempDir, canonical)
+
+		got, err := os.ReadFile(canonical)
+		require.NoError(t, err)
+		assert.Equal(t, canonicalContents, got, "canonical preferred when neither has pro")
 	})
 
 	t.Run("no nested file is a no-op", func(t *testing.T) {

--- a/common/settings/settings_test.go
+++ b/common/settings/settings_test.go
@@ -30,3 +30,49 @@ func TestInitSettings(t *testing.T) {
 		require.Error(t, loadSettings(path), "expected error for invalid config file")
 	})
 }
+
+func TestMigrateV91xSettingsIfNeeded(t *testing.T) {
+	t.Run("nested file recovered when canonical is missing", func(t *testing.T) {
+		tempDir := t.TempDir()
+		nestedDir := filepath.Join(tempDir, "data")
+		require.NoError(t, os.MkdirAll(nestedDir, 0o755))
+		nestedPath := filepath.Join(nestedDir, settingsFileName)
+		want := []byte(`{"user_id": 135809562, "user_level": "pro", "device_id": "abc"}`)
+		require.NoError(t, os.WriteFile(nestedPath, want, 0o644))
+
+		canonical := filepath.Join(tempDir, settingsFileName)
+		migrateV91xSettingsIfNeeded(tempDir, canonical)
+
+		got, err := os.ReadFile(canonical)
+		require.NoError(t, err, "canonical settings.json should exist after migration")
+		assert.Equal(t, want, got, "migrated content should match nested file")
+	})
+
+	t.Run("canonical present takes precedence; nested ignored", func(t *testing.T) {
+		tempDir := t.TempDir()
+		canonical := filepath.Join(tempDir, settingsFileName)
+		canonicalContents := []byte(`{"user_id": 1, "user_level": "pro"}`)
+		require.NoError(t, os.WriteFile(canonical, canonicalContents, 0o644))
+
+		nestedDir := filepath.Join(tempDir, "data")
+		require.NoError(t, os.MkdirAll(nestedDir, 0o755))
+		nestedPath := filepath.Join(nestedDir, settingsFileName)
+		require.NoError(t, os.WriteFile(nestedPath, []byte(`{"user_id": 999}`), 0o644))
+
+		migrateV91xSettingsIfNeeded(tempDir, canonical)
+
+		got, err := os.ReadFile(canonical)
+		require.NoError(t, err)
+		assert.Equal(t, canonicalContents, got, "canonical should be unchanged when it already exists")
+	})
+
+	t.Run("no nested file is a no-op", func(t *testing.T) {
+		tempDir := t.TempDir()
+		canonical := filepath.Join(tempDir, settingsFileName)
+
+		migrateV91xSettingsIfNeeded(tempDir, canonical)
+
+		_, err := os.Stat(canonical)
+		assert.True(t, os.IsNotExist(err), "no migration when no nested file exists")
+	})
+}

--- a/common/settings/settings_test.go
+++ b/common/settings/settings_test.go
@@ -3,6 +3,7 @@ package settings
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -159,5 +160,32 @@ func TestMigrateLegacySettingsIfNeeded(t *testing.T) {
 
 		_, err := os.Stat(canonical)
 		assert.True(t, os.IsNotExist(err), "no migration when no source files exist")
+	})
+
+	t.Run("unreadable canonical (non-ENOENT) skips migration", func(t *testing.T) {
+		// Permission error on the canonical path: don't fall through and
+		// overwrite a file we couldn't read. unix only — windows handles
+		// permissions differently and chmod wouldn't reproduce this.
+		if runtime.GOOS == "windows" {
+			t.Skip("permission semantics differ on windows")
+		}
+		tempDir := t.TempDir()
+		canonical := filepath.Join(tempDir, settingsFileName)
+		require.NoError(t, os.WriteFile(canonical, []byte(`{"user_level": "expired"}`), 0o644))
+		// Make the file unreadable.
+		require.NoError(t, os.Chmod(canonical, 0o000))
+		t.Cleanup(func() { _ = os.Chmod(canonical, 0o644) })
+		// Stage a legacy-pro candidate that would otherwise win.
+		writeLegacy(t, tempDir, []byte(`{"user_id": 1, "user_level": "pro"}`))
+
+		migrateLegacySettingsIfNeeded(tempDir, canonical)
+
+		// Restore readability and confirm the canonical contents are
+		// unchanged (still the expired body, not the legacy-pro body).
+		require.NoError(t, os.Chmod(canonical, 0o644))
+		got, err := os.ReadFile(canonical)
+		require.NoError(t, err)
+		assert.Equal(t, `{"user_level": "expired"}`, string(got),
+			"canonical with non-ENOENT read error should be left alone")
 	})
 }

--- a/common/settings/settings_test.go
+++ b/common/settings/settings_test.go
@@ -31,94 +31,133 @@ func TestInitSettings(t *testing.T) {
 	})
 }
 
-func TestMigrateV91xSettingsIfNeeded(t *testing.T) {
+func TestMigrateLegacySettingsIfNeeded(t *testing.T) {
 	writeNested := func(t *testing.T, dir string, contents []byte) {
 		t.Helper()
 		nd := filepath.Join(dir, "data")
 		require.NoError(t, os.MkdirAll(nd, 0o755))
 		require.NoError(t, os.WriteFile(filepath.Join(nd, settingsFileName), contents, 0o644))
 	}
+	writeLegacy := func(t *testing.T, dir string, contents []byte) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, legacySettingsFileName), contents, 0o644))
+	}
 
-	t.Run("nested file recovered when canonical is missing", func(t *testing.T) {
+	t.Run("v9.0.x local.json recovered when canonical is missing (Derek's failing case)", func(t *testing.T) {
+		// User upgraded from v9.0.x straight to the fixed build. v9.0.x wrote
+		// to <dataDir>/local.json; canonical settings.json doesn't exist;
+		// no v9.1.x nested file. The fix must read local.json so Pro survives.
+		tempDir := t.TempDir()
+		want := []byte(`{"user_id": 3580849, "user_level": "pro", "token": "abc"}`)
+		writeLegacy(t, tempDir, want)
+
+		canonical := filepath.Join(tempDir, settingsFileName)
+		migrateLegacySettingsIfNeeded(tempDir, canonical)
+
+		got, err := os.ReadFile(canonical)
+		require.NoError(t, err)
+		assert.Equal(t, want, got, "v9.0.x local.json should be migrated to canonical")
+	})
+
+	t.Run("v9.1.x nested file recovered when canonical is missing", func(t *testing.T) {
 		tempDir := t.TempDir()
 		want := []byte(`{"user_id": 135809562, "user_level": "pro", "device_id": "abc"}`)
 		writeNested(t, tempDir, want)
 
 		canonical := filepath.Join(tempDir, settingsFileName)
-		migrateV91xSettingsIfNeeded(tempDir, canonical)
+		migrateLegacySettingsIfNeeded(tempDir, canonical)
 
 		got, err := os.ReadFile(canonical)
 		require.NoError(t, err)
-		assert.Equal(t, want, got, "migrated content should match nested file")
+		assert.Equal(t, want, got, "v9.1.x nested file should be migrated to canonical")
 	})
 
-	t.Run("canonical-pro wins over nested-expired (the typical broken upgrade)", func(t *testing.T) {
-		// v9.0.x wrote canonical with pro; v9.1.x wrote nested with expired
-		// because it lost the user_id. The fixed client must keep canonical.
+	t.Run("v9.0.x local.json wins over v9.1.x expired nested", func(t *testing.T) {
+		// Upgrade chain v9.0.x → v9.1.x → fix: legacy has pro, nested has
+		// expired (because v9.1.x lost the user_id). Migration must pick
+		// legacy so Pro survives.
+		tempDir := t.TempDir()
+		canonical := filepath.Join(tempDir, settingsFileName)
+		legacyPro := []byte(`{"user_id": 1, "user_level": "pro"}`)
+		writeLegacy(t, tempDir, legacyPro)
+		writeNested(t, tempDir, []byte(`{"user_id": 999, "user_level": "expired"}`))
+
+		migrateLegacySettingsIfNeeded(tempDir, canonical)
+
+		got, err := os.ReadFile(canonical)
+		require.NoError(t, err)
+		assert.Equal(t, legacyPro, got, "legacy local.json with pro should beat nested expired")
+	})
+
+	t.Run("canonical-pro wins over nested-expired", func(t *testing.T) {
 		tempDir := t.TempDir()
 		canonical := filepath.Join(tempDir, settingsFileName)
 		canonicalPro := []byte(`{"user_id": 1, "user_level": "pro"}`)
 		require.NoError(t, os.WriteFile(canonical, canonicalPro, 0o644))
 		writeNested(t, tempDir, []byte(`{"user_id": 999, "user_level": "expired"}`))
 
-		migrateV91xSettingsIfNeeded(tempDir, canonical)
+		migrateLegacySettingsIfNeeded(tempDir, canonical)
 
 		got, err := os.ReadFile(canonical)
 		require.NoError(t, err)
-		assert.Equal(t, canonicalPro, got, "canonical-pro should survive when nested is expired")
+		assert.Equal(t, canonicalPro, got, "canonical-pro should survive")
 	})
 
-	t.Run("nested-pro wins over canonical-expired (rare inverse case)", func(t *testing.T) {
-		// e.g., user paid via Shepherd during the v9.1.x window so the
-		// nested file legitimately has pro while canonical is stale.
+	t.Run("nested-pro wins over canonical-expired and legacy-expired", func(t *testing.T) {
+		// e.g., user paid via Shepherd while on v9.1.x, so the nested file
+		// legitimately holds pro state.
 		tempDir := t.TempDir()
 		canonical := filepath.Join(tempDir, settingsFileName)
 		require.NoError(t, os.WriteFile(canonical, []byte(`{"user_id": 1, "user_level": "expired"}`), 0o644))
+		writeLegacy(t, tempDir, []byte(`{"user_id": 1, "user_level": "expired"}`))
 		nestedPro := []byte(`{"user_id": 2, "user_level": "pro"}`)
 		writeNested(t, tempDir, nestedPro)
 
-		migrateV91xSettingsIfNeeded(tempDir, canonical)
+		migrateLegacySettingsIfNeeded(tempDir, canonical)
 
 		got, err := os.ReadFile(canonical)
 		require.NoError(t, err)
-		assert.Equal(t, nestedPro, got, "nested-pro should overwrite canonical-expired")
+		assert.Equal(t, nestedPro, got, "nested-pro should beat both canonical and legacy when only it has pro")
 	})
 
-	t.Run("both pro: canonical wins (older deliberate state)", func(t *testing.T) {
+	t.Run("all-pro: canonical wins (most recent deliberate state)", func(t *testing.T) {
 		tempDir := t.TempDir()
 		canonical := filepath.Join(tempDir, settingsFileName)
 		canonicalContents := []byte(`{"user_id": 1, "user_level": "pro"}`)
 		require.NoError(t, os.WriteFile(canonical, canonicalContents, 0o644))
-		writeNested(t, tempDir, []byte(`{"user_id": 2, "user_level": "pro"}`))
+		writeLegacy(t, tempDir, []byte(`{"user_id": 2, "user_level": "pro"}`))
+		writeNested(t, tempDir, []byte(`{"user_id": 3, "user_level": "pro"}`))
 
-		migrateV91xSettingsIfNeeded(tempDir, canonical)
-
-		got, err := os.ReadFile(canonical)
-		require.NoError(t, err)
-		assert.Equal(t, canonicalContents, got, "canonical preferred when both pro")
-	})
-
-	t.Run("neither pro: canonical wins", func(t *testing.T) {
-		tempDir := t.TempDir()
-		canonical := filepath.Join(tempDir, settingsFileName)
-		canonicalContents := []byte(`{"user_id": 1, "user_level": "free"}`)
-		require.NoError(t, os.WriteFile(canonical, canonicalContents, 0o644))
-		writeNested(t, tempDir, []byte(`{"user_id": 2, "user_level": "free"}`))
-
-		migrateV91xSettingsIfNeeded(tempDir, canonical)
+		migrateLegacySettingsIfNeeded(tempDir, canonical)
 
 		got, err := os.ReadFile(canonical)
 		require.NoError(t, err)
-		assert.Equal(t, canonicalContents, got, "canonical preferred when neither has pro")
+		assert.Equal(t, canonicalContents, got, "canonical preferred when all have pro")
 	})
 
-	t.Run("no nested file is a no-op", func(t *testing.T) {
+	t.Run("none have pro: legacy wins over nested when canonical missing", func(t *testing.T) {
+		// User identifiers must survive even when Pro state is non-pro,
+		// to keep the device registration intact server-side.
+		tempDir := t.TempDir()
+		canonical := filepath.Join(tempDir, settingsFileName)
+		legacyContents := []byte(`{"user_id": 1, "user_level": "free", "token": "abc"}`)
+		writeLegacy(t, tempDir, legacyContents)
+		writeNested(t, tempDir, []byte(`{"user_id": 2, "user_level": "free", "token": "xyz"}`))
+
+		migrateLegacySettingsIfNeeded(tempDir, canonical)
+
+		got, err := os.ReadFile(canonical)
+		require.NoError(t, err)
+		assert.Equal(t, legacyContents, got, "legacy preferred over nested when canonical missing and neither has pro")
+	})
+
+	t.Run("nothing on disk is a no-op", func(t *testing.T) {
 		tempDir := t.TempDir()
 		canonical := filepath.Join(tempDir, settingsFileName)
 
-		migrateV91xSettingsIfNeeded(tempDir, canonical)
+		migrateLegacySettingsIfNeeded(tempDir, canonical)
 
 		_, err := os.Stat(canonical)
-		assert.True(t, os.IsNotExist(err), "no migration when no nested file exists")
+		assert.True(t, os.IsNotExist(err), "no migration when no source files exist")
 	})
 }


### PR DESCRIPTION
## Summary

Fix the v9.1.x path regression that wipes users' persisted state on upgrade — surfacing as **"Pro shown as expired after the update"** on Freshdesk #174455 / #174496 / #174515 and likely the rest of the v9.1.5 China-Android Pro complaints.

## What broke

PR #370 (`restructure codebase around LocalBackend`) added these two lines to `common/init.go:setupDirectories`:

```go
// ensure the data and logs directories end with the correct suffix
data = maybeAddSuffix(data, "data")
logs = maybeAddSuffix(logs, "logs")
```

Before #370 these suffixes were only applied when the caller passed an empty path. After #370 they're applied unconditionally. Android passes `<application.dataDir>/.lantern` from `MainActivity.kt` → `initConfigDir()` (`utils.kt:33-48`), so the radiance data dir silently moved between minor versions:

| Version | settings.json path                                |
|---------|---------------------------------------------------|
| v9.0.x  | `<app.dataDir>/.lantern/settings.json`            |
| v9.1.x  | `<app.dataDir>/.lantern/data/settings.json`       |

On every existing install, v9.1.x init found nothing at the new path and fell through to defaults (`UserLevelKey="free"`, no `UserIDKey`, no `DeviceIDKey`, no `JwtTokenKey`). The client generated a fresh device id and called `UserRecoverByDevice` cold — exactly what the auto-diagnosis on #174515 saw:

> Device list on this account contains two iOS devices registered earlier the same day and two Windows 10 devices created in 2021 — **no prior Android entry**. The current Android device `a83eff88d154e11e` was **newly registered on this update**.
> The Android device `a83eff88d154e11e` from this ticket **resolves to a different user 387578379 in `UserRecoverByDevice`**.

iOS via `lantern-core/ffi/ffi.go:114` and desktop via `cmd/lanternd/lanternd.go:328` route through the same `common.Init` and hit the same bug.

```mermaid
sequenceDiagram
    autonumber
    participant App as Android app<br/>MainActivity.kt:74
    participant Setup as setupDirectories<br/>common/init.go
    participant Init as InitSettings<br/>common/settings/settings.go
    participant FS as filesystem
    participant Server as auth server

    App->>Setup: initConfigDir() = "<dataDir>/.lantern"
    Note over Setup: common/init.go:151 ⚠️<br/>data = maybeAddSuffix(data, "data")
    rect rgba(255, 200, 200, 0.3)
        Note over Setup: rewrites to "<dataDir>/.lantern/data" 🐛
    end
    Setup->>Init: InitSettings("<dataDir>/.lantern/data")
    Init->>FS: read "<dataDir>/.lantern/data/settings.json"
    FS-->>Init: ENOENT (v9.0.x file is at "<dataDir>/.lantern/settings.json")
    Note over Init: defaults: user_level="free",<br/>no user_id, no device_id, no jwt
    Init->>Server: UserRecoverByDevice(<freshly-minted device id>)
    Server-->>Init: userLevel="expired" (or fresh user)
    Note over App: UI shows "Pro expired"
```

## Fix

**1. `setupDirectories` now honors the caller's path as-is.** `maybeAddSuffix` and the unconditional suffix calls are removed. When the caller passes an empty string, `internal.DefaultDataPath()` / `DefaultLogPath()` still kick in.

**2. One-shot v9.1.x migration in `InitSettings`.** On first launch of the fixed client, if `<dataDir>/settings.json` is missing but `<dataDir>/data/settings.json` exists, the latter is copied up. v9.1.x users who already lost their v9.0.x state on the prior upgrade keep their freshly-minted v9.1.x identifiers instead of getting wiped a second time. Quick stat check, no-op for installs that never had the bad nested file.

## Test plan
- [x] `go test ./common/settings/` passes (added 3 sub-tests covering the recover, no-op, and canonical-already-present migration paths).
- [ ] Manual Android upgrade: install 9.0.29-beta on a real device, log in to Pro, upgrade to a build with this fix, verify Pro state survives.
- [ ] Manual: install 9.1.5-beta fresh, lose Pro, upgrade to a build with this fix, verify Pro is restored from the migrated `data/settings.json`.
- [ ] Manual: confirm fresh installs still work (no migration trigger, no-op path).

Refs Freshdesk #174455, #174515, #174496.

🤖 Generated with [Claude Code](https://claude.com/claude-code)