### PR TITLE
settings: also migrate from pre-9.x flashlight/lantern-client YAML

### DIFF
--- a/common/settings/legacy_yaml.go
+++ b/common/settings/legacy_yaml.go
@@ -23,10 +23,14 @@ import (
 // readable from Go; Android stored its state in an encrypted SQLite
 // and needs a Kotlin-side migration):
 //
-//	macOS:   ~/.lantern/settings.yaml         (desktop schema)
-//	Windows: %APPDATA%\Lantern\settings.yaml  (desktop schema)
-//	Linux:   ~/.config/lantern/settings.yaml  (desktop schema)
-//	iOS:     <fileDir>/userconfig.yaml        (ios schema)
+//	macOS:   ~/Library/Application Support/Lantern/settings.yaml  (desktop)
+//	Windows: %APPDATA%\Lantern\settings.yaml                      (desktop)
+//	Linux:   ~/.config/lantern/settings.yaml                      (desktop)
+//	iOS:     <fileDir>/userconfig.yaml                            (ios)
+//
+// These match the path the pre-9.x flashlight + lantern-client used
+// (getlantern/appdir.General("Lantern"), with the linux build tag
+// lowercasing the app name).
 //
 // Field translation (desktop → canonical):
 //
@@ -46,8 +50,15 @@ import (
 // the Session proto and refreshed from the server. Leaving user_level
 // unset means the next /account/login decides; user_id/device_id
 // continuity is what we're after on iOS.)
+// legacyYAMLPathFn is the function legacyYAMLCandidate uses to resolve
+// the on-disk location of the pre-9.x YAML. Set as a package-level var
+// (rather than calling legacyYAMLPath directly) so tests can redirect
+// the lookup to a temp dir without mutating the host's
+// ~/Library/Application Support / %APPDATA% / ~/.config layout.
+var legacyYAMLPathFn = legacyYAMLPath
+
 func legacyYAMLCandidate(fileDir string) candidateSource {
-	path, layout := legacyYAMLPath(fileDir)
+	path, layout := legacyYAMLPathFn(fileDir)
 	if path == "" {
 		return candidateSource{}
 	}
@@ -75,34 +86,36 @@ func legacyYAMLCandidate(fileDir string) candidateSource {
 // settings file for this platform, plus the layout name we'll need to
 // pick the right unmarshal struct. Returns ("", "") if this platform
 // isn't supported here.
+//
+// Mirrors what getlantern/appdir.General("Lantern") produced in the
+// pre-9.x desktop clients:
+//   - darwin/windows: os.UserConfigDir() + "Lantern" (capitalized)
+//   - linux:          os.UserConfigDir() + "lantern" (the linux build
+//     tag in appdir lowercased the app name; pre-9.x clients on linux
+//     wrote to ~/.config/lantern, not ~/.config/Lantern)
+//
+// On iOS the YAML lives inside the app sandbox alongside the radiance
+// dataDir, so we look there directly.
 func legacyYAMLPath(fileDir string) (path, layout string) {
 	switch runtime.GOOS {
 	case "darwin":
-		// Note: this targets the pre-9.x desktop client, which wrote
-		// to ~/.lantern. The v9.x macOS app uses /Users/Shared/Lantern
-		// as its dataDir, so the legacy path is outside the dataDir
-		// we're handed. iOS (also runtime.GOOS == "darwin" with the
-		// "ios" build tag) uses a different layout — see the ios case.
-		if runtime.GOARCH == "arm64" || runtime.GOARCH == "amd64" {
-			// macOS desktop. We use $HOME instead of UserConfigDir
-			// because the pre-9.x client used ~/.lantern, not
-			// ~/Library/Application Support/Lantern.
-			if home, err := os.UserHomeDir(); err == nil {
-				return filepath.Join(home, ".lantern", "settings.yaml"), "desktop"
-			}
+		// macOS desktop. iOS uses GOOS=ios in modern Go (>= 1.16) and
+		// is handled separately below.
+		if cfg, err := os.UserConfigDir(); err == nil {
+			return filepath.Join(cfg, "Lantern", "settings.yaml"), "desktop"
 		}
 	case "windows":
-		if appdata := os.Getenv("APPDATA"); appdata != "" {
-			return filepath.Join(appdata, "Lantern", "settings.yaml"), "desktop"
+		if cfg, err := os.UserConfigDir(); err == nil {
+			return filepath.Join(cfg, "Lantern", "settings.yaml"), "desktop"
 		}
 	case "linux":
-		if home, err := os.UserHomeDir(); err == nil {
-			return filepath.Join(home, ".config", "lantern", "settings.yaml"), "desktop"
+		// Linux pre-9.x lowercased the app name (see appdir_linux.go).
+		if cfg, err := os.UserConfigDir(); err == nil {
+			return filepath.Join(cfg, "lantern", "settings.yaml"), "desktop"
 		}
 	case "ios":
-		// iOS Lantern wrote userconfig.yaml inside the app's data
-		// directory. The radiance dataDir on iOS is the same sandbox,
-		// so look right next to where settings.json now lives.
+		// iOS lantern-client wrote userconfig.yaml inside the app
+		// sandbox. The radiance dataDir on iOS is in the same sandbox.
 		return filepath.Join(fileDir, "userconfig.yaml"), "ios"
 	}
 	return "", ""

--- a/common/settings/legacy_yaml.go
+++ b/common/settings/legacy_yaml.go
@@ -1,0 +1,167 @@
+package settings
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/goccy/go-yaml"
+)
+
+// legacyYAMLCandidate looks for a pre-9.0.x flashlight/lantern-client
+// settings file on disk and, if found, returns its translation into the
+// current canonical JSON schema as a candidateSource. Returns the
+// zero-value candidate when no pre-9.x file is present for this
+// platform or when read/parse fails.
+//
+// Per-platform layout (only the platforms below have pre-9.x files
+// readable from Go; Android stored its state in an encrypted SQLite
+// and needs a Kotlin-side migration):
+//
+//	macOS:   ~/.lantern/settings.yaml         (desktop schema)
+//	Windows: %APPDATA%\Lantern\settings.yaml  (desktop schema)
+//	Linux:   ~/.config/lantern/settings.yaml  (desktop schema)
+//	iOS:     <fileDir>/userconfig.yaml        (ios schema)
+//
+// Field translation (desktop → canonical):
+//
+//	userID       (int64)  → user_id
+//	deviceID     (string) → device_id
+//	userPro      (bool)   → user_level ("pro" if true, "free" if id known)
+//	userToken    (string) → token
+//	emailAddress (string) → email
+//
+// Field translation (ios → canonical):
+//
+//	UserID   (int64)  → user_id
+//	DeviceID (string) → device_id
+//	Token    (string) → token
+//
+// (iOS didn't persist user_level in this YAML — pro state was kept in
+// the Session proto and refreshed from the server. Leaving user_level
+// unset means the next /account/login decides; user_id/device_id
+// continuity is what we're after on iOS.)
+func legacyYAMLCandidate(fileDir string) candidateSource {
+	path, layout := legacyYAMLPath(fileDir)
+	if path == "" {
+		return candidateSource{}
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			slog.Warn("pre-9.x yaml read failed", "path", path, "error", err)
+		}
+		return candidateSource{}
+	}
+	translated, err := translateLegacyYAML(raw, layout)
+	if err != nil {
+		slog.Warn("pre-9.x yaml translate failed", "path", path, "error", err)
+		return candidateSource{}
+	}
+	return candidateSource{
+		path:     path,
+		contents: translated,
+		exists:   true,
+		label:    fmt.Sprintf("pre-9.x %s yaml", layout),
+	}
+}
+
+// legacyYAMLPath returns the on-disk location of the pre-9.x YAML
+// settings file for this platform, plus the layout name we'll need to
+// pick the right unmarshal struct. Returns ("", "") if this platform
+// isn't supported here.
+func legacyYAMLPath(fileDir string) (path, layout string) {
+	switch runtime.GOOS {
+	case "darwin":
+		// Note: this targets the pre-9.x desktop client, which wrote
+		// to ~/.lantern. The v9.x macOS app uses /Users/Shared/Lantern
+		// as its dataDir, so the legacy path is outside the dataDir
+		// we're handed. iOS (also runtime.GOOS == "darwin" with the
+		// "ios" build tag) uses a different layout — see the ios case.
+		if runtime.GOARCH == "arm64" || runtime.GOARCH == "amd64" {
+			// macOS desktop. We use $HOME instead of UserConfigDir
+			// because the pre-9.x client used ~/.lantern, not
+			// ~/Library/Application Support/Lantern.
+			if home, err := os.UserHomeDir(); err == nil {
+				return filepath.Join(home, ".lantern", "settings.yaml"), "desktop"
+			}
+		}
+	case "windows":
+		if appdata := os.Getenv("APPDATA"); appdata != "" {
+			return filepath.Join(appdata, "Lantern", "settings.yaml"), "desktop"
+		}
+	case "linux":
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, ".config", "lantern", "settings.yaml"), "desktop"
+		}
+	case "ios":
+		// iOS Lantern wrote userconfig.yaml inside the app's data
+		// directory. The radiance dataDir on iOS is the same sandbox,
+		// so look right next to where settings.json now lives.
+		return filepath.Join(fileDir, "userconfig.yaml"), "ios"
+	}
+	return "", ""
+}
+
+// translateLegacyYAML parses the pre-9.x YAML and emits the equivalent
+// canonical settings.json bytes. Unknown fields in the source are
+// ignored; unset fields in the destination are omitted via omitempty.
+func translateLegacyYAML(raw []byte, layout string) ([]byte, error) {
+	type canonical struct {
+		UserID    int64  `json:"user_id,omitempty"`
+		DeviceID  string `json:"device_id,omitempty"`
+		UserLevel string `json:"user_level,omitempty"`
+		Token     string `json:"token,omitempty"`
+		Email     string `json:"email,omitempty"`
+	}
+
+	var out canonical
+	switch layout {
+	case "desktop":
+		var d struct {
+			UserID       int64  `yaml:"userID"`
+			DeviceID     string `yaml:"deviceID"`
+			UserPro      bool   `yaml:"userPro"`
+			UserToken    string `yaml:"userToken"`
+			EmailAddress string `yaml:"emailAddress"`
+		}
+		if err := yaml.Unmarshal(raw, &d); err != nil {
+			return nil, fmt.Errorf("desktop yaml: %w", err)
+		}
+		out.UserID = d.UserID
+		out.DeviceID = d.DeviceID
+		out.Token = d.UserToken
+		out.Email = d.EmailAddress
+		switch {
+		case d.UserPro:
+			out.UserLevel = "pro"
+		case d.UserID != 0:
+			// User identified but not pro — write "free" so downstream
+			// code sees a real value instead of an empty string.
+			out.UserLevel = "free"
+		}
+	case "ios":
+		var i struct {
+			UserID   int64  `yaml:"UserID"`
+			DeviceID string `yaml:"DeviceID"`
+			Token    string `yaml:"Token"`
+		}
+		if err := yaml.Unmarshal(raw, &i); err != nil {
+			return nil, fmt.Errorf("ios yaml: %w", err)
+		}
+		out.UserID = i.UserID
+		out.DeviceID = i.DeviceID
+		out.Token = i.Token
+		// user_level intentionally left empty — iOS didn't persist it
+		// in this YAML, and an empty value lets the next /account/login
+		// be authoritative.
+	default:
+		return nil, fmt.Errorf("unknown layout: %s", layout)
+	}
+	return json.Marshal(out)
+}

--- a/common/settings/legacy_yaml.go
+++ b/common/settings/legacy_yaml.go
@@ -13,50 +13,14 @@ import (
 	"github.com/goccy/go-yaml"
 )
 
-// legacyYAMLCandidate looks for a pre-9.0.x flashlight/lantern-client
-// settings file on disk and, if found, returns its translation into the
-// current canonical JSON schema as a candidateSource. Returns the
-// zero-value candidate when no pre-9.x file is present for this
-// platform or when read/parse fails.
-//
-// Per-platform layout (only the platforms below have pre-9.x files
-// readable from Go; Android stored its state in an encrypted SQLite
-// and needs a Kotlin-side migration):
-//
-//	macOS:   ~/Library/Application Support/Lantern/settings.yaml  (desktop)
-//	Windows: %APPDATA%\Lantern\settings.yaml                      (desktop)
-//	Linux:   ~/.config/lantern/settings.yaml                      (desktop)
-//	iOS:     <fileDir>/userconfig.yaml                            (ios)
-//
-// These match the path the pre-9.x flashlight + lantern-client used
-// (getlantern/appdir.General("Lantern"), with the linux build tag
-// lowercasing the app name).
-//
-// Field translation (desktop → canonical):
-//
-//	userID       (int64)  → user_id
-//	deviceID     (string) → device_id
-//	userPro      (bool)   → user_level ("pro" if true, "free" if id known)
-//	userToken    (string) → token
-//	emailAddress (string) → email
-//
-// Field translation (ios → canonical):
-//
-//	UserID   (int64)  → user_id
-//	DeviceID (string) → device_id
-//	Token    (string) → token
-//
-// (iOS didn't persist user_level in this YAML — pro state was kept in
-// the Session proto and refreshed from the server. Leaving user_level
-// unset means the next /account/login decides; user_id/device_id
-// continuity is what we're after on iOS.)
-// legacyYAMLPathFn is the function legacyYAMLCandidate uses to resolve
-// the on-disk location of the pre-9.x YAML. Set as a package-level var
-// (rather than calling legacyYAMLPath directly) so tests can redirect
-// the lookup to a temp dir without mutating the host's
-// ~/Library/Application Support / %APPDATA% / ~/.config layout.
+// legacyYAMLPathFn is overridable so tests can redirect lookup to a temp
+// dir without touching the host's app-config layout.
 var legacyYAMLPathFn = legacyYAMLPath
 
+// legacyYAMLCandidate returns the pre-9.x flashlight/lantern-client
+// settings file (if any), translated into canonical JSON. Android is
+// excluded — it persisted state in an encrypted SQLite that needs a
+// Kotlin-side migration.
 func legacyYAMLCandidate(fileDir string) candidateSource {
 	path, layout := legacyYAMLPathFn(fileDir)
 	if path == "" {
@@ -82,48 +46,25 @@ func legacyYAMLCandidate(fileDir string) candidateSource {
 	}
 }
 
-// legacyYAMLPath returns the on-disk location of the pre-9.x YAML
-// settings file for this platform, plus the layout name we'll need to
-// pick the right unmarshal struct. Returns ("", "") if this platform
-// isn't supported here.
-//
-// Mirrors what getlantern/appdir.General("Lantern") produced in the
-// pre-9.x desktop clients:
-//   - darwin/windows: os.UserConfigDir() + "Lantern" (capitalized)
-//   - linux:          os.UserConfigDir() + "lantern" (the linux build
-//     tag in appdir lowercased the app name; pre-9.x clients on linux
-//     wrote to ~/.config/lantern, not ~/.config/Lantern)
-//
-// On iOS the YAML lives inside the app sandbox alongside the radiance
-// dataDir, so we look there directly.
 func legacyYAMLPath(fileDir string) (path, layout string) {
 	switch runtime.GOOS {
-	case "darwin":
-		// macOS desktop. iOS uses GOOS=ios in modern Go (>= 1.16) and
-		// is handled separately below.
-		if cfg, err := os.UserConfigDir(); err == nil {
-			return filepath.Join(cfg, "Lantern", "settings.yaml"), "desktop"
-		}
-	case "windows":
+	case "darwin", "windows":
 		if cfg, err := os.UserConfigDir(); err == nil {
 			return filepath.Join(cfg, "Lantern", "settings.yaml"), "desktop"
 		}
 	case "linux":
-		// Linux pre-9.x lowercased the app name (see appdir_linux.go).
+		// Pre-9.x appdir lowercased the app name on linux only.
 		if cfg, err := os.UserConfigDir(); err == nil {
 			return filepath.Join(cfg, "lantern", "settings.yaml"), "desktop"
 		}
 	case "ios":
-		// iOS lantern-client wrote userconfig.yaml inside the app
-		// sandbox. The radiance dataDir on iOS is in the same sandbox.
+		// iOS lantern-client wrote userconfig.yaml inside the app sandbox,
+		// the same sandbox radiance's dataDir lives in.
 		return filepath.Join(fileDir, "userconfig.yaml"), "ios"
 	}
 	return "", ""
 }
 
-// translateLegacyYAML parses the pre-9.x YAML and emits the equivalent
-// canonical settings.json bytes. Unknown fields in the source are
-// ignored; unset fields in the destination are omitted via omitempty.
 func translateLegacyYAML(raw []byte, layout string) ([]byte, error) {
 	type canonical struct {
 		UserID    int64  `json:"user_id,omitempty"`
@@ -154,8 +95,7 @@ func translateLegacyYAML(raw []byte, layout string) ([]byte, error) {
 		case d.UserPro:
 			out.UserLevel = "pro"
 		case d.UserID != 0:
-			// User identified but not pro — write "free" so downstream
-			// code sees a real value instead of an empty string.
+			// Identified-but-not-pro → "free" so downstream sees a real value.
 			out.UserLevel = "free"
 		}
 	case "ios":
@@ -170,9 +110,8 @@ func translateLegacyYAML(raw []byte, layout string) ([]byte, error) {
 		out.UserID = i.UserID
 		out.DeviceID = i.DeviceID
 		out.Token = i.Token
-		// user_level intentionally left empty — iOS didn't persist it
-		// in this YAML, and an empty value lets the next /account/login
-		// be authoritative.
+		// user_level left empty: iOS didn't persist it here, so the next
+		// /account/login is authoritative.
 	default:
 		return nil, fmt.Errorf("unknown layout: %s", layout)
 	}

--- a/common/settings/legacy_yaml_test.go
+++ b/common/settings/legacy_yaml_test.go
@@ -1,0 +1,89 @@
+package settings
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTranslateLegacyYAML_Desktop(t *testing.T) {
+	t.Run("pro user with all fields", func(t *testing.T) {
+		// Shape mirrors what the pre-9.x desktop client (flashlight +
+		// lantern-client) wrote into ~/.lantern/settings.yaml /
+		// %APPDATA%\Lantern\settings.yaml / ~/.config/lantern/settings.yaml.
+		yaml := []byte(`userID: 3580849
+deviceID: 84e9c7b2-2a54-44f3-9ec6-276086017e49
+userPro: true
+userToken: abc123token
+emailAddress: derek@example.com
+userFirstVisit: true
+otherStuff: ignored
+`)
+
+		out, err := translateLegacyYAML(yaml, "desktop")
+		require.NoError(t, err)
+
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(out, &got))
+		assert.Equal(t, float64(3580849), got["user_id"])
+		assert.Equal(t, "84e9c7b2-2a54-44f3-9ec6-276086017e49", got["device_id"])
+		assert.Equal(t, "pro", got["user_level"])
+		assert.Equal(t, "abc123token", got["token"])
+		assert.Equal(t, "derek@example.com", got["email"])
+	})
+
+	t.Run("free user with id is marked free", func(t *testing.T) {
+		yaml := []byte(`userID: 100
+deviceID: dev-abc
+userPro: false
+userToken: tok
+`)
+		out, err := translateLegacyYAML(yaml, "desktop")
+		require.NoError(t, err)
+		assert.Equal(t, "free", userLevelInJSON(out),
+			"a known but non-pro user should translate to user_level=free")
+	})
+
+	t.Run("anonymous (no user id) leaves user_level empty", func(t *testing.T) {
+		yaml := []byte(`userPro: false
+userToken: ""
+`)
+		out, err := translateLegacyYAML(yaml, "desktop")
+		require.NoError(t, err)
+		assert.Equal(t, "", userLevelInJSON(out),
+			"no user_id means we shouldn't claim 'free'; let next login decide")
+	})
+
+	t.Run("malformed yaml errors", func(t *testing.T) {
+		_, err := translateLegacyYAML([]byte("\tnot: a [valid yaml: doc\n"), "desktop")
+		assert.Error(t, err)
+	})
+}
+
+func TestTranslateLegacyYAML_iOS(t *testing.T) {
+	yaml := []byte(`AppName: lantern
+DeviceID: ios-device-9000
+UserID: 7777
+Token: ios-token
+Language: en
+Country: US
+`)
+	out, err := translateLegacyYAML(yaml, "ios")
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out, &got))
+	assert.Equal(t, float64(7777), got["user_id"])
+	assert.Equal(t, "ios-device-9000", got["device_id"])
+	assert.Equal(t, "ios-token", got["token"])
+	// iOS yaml didn't carry user_level — should be omitted, not "free".
+	_, hasLevel := got["user_level"]
+	assert.False(t, hasLevel, "iOS yaml should not produce a user_level field")
+}
+
+func TestTranslateLegacyYAML_UnknownLayout(t *testing.T) {
+	_, err := translateLegacyYAML([]byte(`userID: 1`), "android")
+	assert.Error(t, err)
+}

--- a/common/settings/settings.go
+++ b/common/settings/settings.go
@@ -112,10 +112,9 @@ func InitSettings(fileDir string) error {
 	return nil
 }
 
-// candidateSource describes one possible location of persisted user
-// state. `contents` is always JSON in the current canonical schema —
-// either read directly (for the v9.x JSON files) or translated from a
-// pre-9.x platform-specific YAML on the way in.
+// candidateSource is one possible location of persisted user state.
+// contents is always canonical JSON — direct for v9.x, translated for
+// pre-9.x YAML.
 type candidateSource struct {
 	path     string
 	contents []byte
@@ -124,48 +123,23 @@ type candidateSource struct {
 }
 
 // migrateLegacySettingsIfNeeded recovers persisted user state written
-// by older client versions. Candidate paths considered in priority
-// order (highest first):
+// by older client versions. Candidates in priority order:
 //
-//  1. <fileDir>/settings.json         — current canonical path
-//  2. <fileDir>/local.json            — what v9.0.x wrote (renamed in #370)
-//  3. pre-9.x platform-specific YAML  — flashlight/lantern-client era:
-//     macOS:   ~/.lantern/settings.yaml
-//     Windows: %APPDATA%\Lantern\settings.yaml
-//     Linux:   ~/.config/lantern/settings.yaml
-//     iOS:     <fileDir>/userconfig.yaml
-//     (Android stored its state in an encrypted SQLite that we can't
-//     read here; that case needs a Kotlin-side migration outside this
-//     package.)
-//  4. <fileDir>/data/settings.json    — what v9.1.x wrote, due to a bug
-//                                       in #370's setupDirectories that
-//                                       appended an unconditional "/data"
-//                                       suffix to the caller's data dir
+//  1. <fileDir>/settings.json       — canonical
+//  2. <fileDir>/local.json          — v9.0.x (renamed in #370)
+//  3. pre-9.x platform-specific YAML (legacy_yaml.go); spliced in below
+//  4. <fileDir>/data/settings.json  — v9.1.x (bugged: #370's
+//                                     setupDirectories appended an
+//                                     unconditional "/data" suffix)
 //
-// On the first launch of a fixed client, any subset of these may exist
-// depending on the user's upgrade path. Pick whichever has
-// user_level == "pro" so anyone who legitimately paid keeps their Pro
-// state regardless of which file holds the good copy. If none have
-// pro, prefer the higher-priority source so the user's identifiers
-// (user_id, token, device_id) survive — losing Pro is recoverable,
-// losing the device registration creates server-side orphans.
-//
-// Order rationale: canonical is most recent and authoritative.
-// v9.0.x's local.json is the next-most-recent legitimate state.
-// Pre-9.x YAML is older but trusted (real user state from
-// flashlight/lantern-client). v9.1.x's nested file is most recent but
-// known to be bugged (fresh device_id, possibly wrong user_id).
-//
-// Runs unconditionally — quick stat-and-read of a handful of small
-// files; no-op for the vast majority of installs that don't have any
-// of the legacy files.
+// Pick the highest-priority candidate with user_level=="pro"; if none
+// is pro, the highest-priority candidate that exists. Losing Pro is
+// recoverable; losing the device registration creates server-side
+// orphans, so identifier continuity wins ties.
 func migrateLegacySettingsIfNeeded(fileDir, canonicalPath string) {
 	candidates := []candidateSource{
 		{path: canonicalPath, label: "canonical settings.json"},
 		{path: filepath.Join(fileDir, legacySettingsFileName), label: "v9.0.x local.json"},
-		// pre-9.x YAML is appended below after read+translate (only if
-		// it exists for this platform) so the pickIdx loop sees it as
-		// just another candidate.
 		{path: filepath.Join(fileDir, "data", settingsFileName), label: "v9.1.x data/settings.json"},
 	}
 	for i := range candidates {
@@ -189,12 +163,9 @@ func migrateLegacySettingsIfNeeded(fileDir, canonicalPath string) {
 			}
 		}
 	}
-	// Insert the pre-9.x YAML candidate (translated to canonical JSON)
-	// between local.json and data/settings.json. Only the platforms with
-	// known pre-9.x file layouts return a non-empty result here.
+	// Splice the pre-9.x YAML candidate before the v9.1.x nested file so
+	// priority is canonical > local.json > pre-9.x > nested.
 	if yc := legacyYAMLCandidate(fileDir); yc.exists {
-		// Splice in at index 2 (just before data/settings.json) so
-		// priority order is canonical > local.json > pre-9.x > nested.
 		candidates = append(candidates[:2], append([]candidateSource{yc}, candidates[2:]...)...)
 	}
 

--- a/common/settings/settings.go
+++ b/common/settings/settings.go
@@ -112,38 +112,60 @@ func InitSettings(fileDir string) error {
 	return nil
 }
 
+// candidateSource describes one possible location of persisted user
+// state. `contents` is always JSON in the current canonical schema —
+// either read directly (for the v9.x JSON files) or translated from a
+// pre-9.x platform-specific YAML on the way in.
+type candidateSource struct {
+	path     string
+	contents []byte
+	exists   bool
+	label    string
+}
+
 // migrateLegacySettingsIfNeeded recovers persisted user state written
-// by older client versions. Three candidate paths are considered:
+// by older client versions. Candidate paths considered in priority
+// order (highest first):
 //
-//   - <fileDir>/settings.json         — the current canonical path
-//   - <fileDir>/local.json            — what v9.0.x wrote (renamed in #370)
-//   - <fileDir>/data/settings.json    — what v9.1.x wrote, due to a bug in
-//                                       #370's setupDirectories that
+//  1. <fileDir>/settings.json         — current canonical path
+//  2. <fileDir>/local.json            — what v9.0.x wrote (renamed in #370)
+//  3. pre-9.x platform-specific YAML  — flashlight/lantern-client era:
+//     macOS:   ~/.lantern/settings.yaml
+//     Windows: %APPDATA%\Lantern\settings.yaml
+//     Linux:   ~/.config/lantern/settings.yaml
+//     iOS:     <fileDir>/userconfig.yaml
+//     (Android stored its state in an encrypted SQLite that we can't
+//     read here; that case needs a Kotlin-side migration outside this
+//     package.)
+//  4. <fileDir>/data/settings.json    — what v9.1.x wrote, due to a bug
+//                                       in #370's setupDirectories that
 //                                       appended an unconditional "/data"
 //                                       suffix to the caller's data dir
 //
-// On the first launch of a fixed client, any of the three may exist
+// On the first launch of a fixed client, any subset of these may exist
 // depending on the user's upgrade path. Pick whichever has
 // user_level == "pro" so anyone who legitimately paid keeps their Pro
-// state regardless of which file holds the good copy. If none have pro,
-// prefer canonical → v9.0.x → v9.1.x in that order so the user's
-// identifiers (user_id, token, device_id) survive — losing Pro is
-// recoverable, losing the device registration creates server-side
-// orphans.
+// state regardless of which file holds the good copy. If none have
+// pro, prefer the higher-priority source so the user's identifiers
+// (user_id, token, device_id) survive — losing Pro is recoverable,
+// losing the device registration creates server-side orphans.
 //
-// Runs unconditionally — quick stat-and-read of three small files;
-// no-op for the vast majority of installs that don't have a nested or
-// legacy file.
+// Order rationale: canonical is most recent and authoritative.
+// v9.0.x's local.json is the next-most-recent legitimate state.
+// Pre-9.x YAML is older but trusted (real user state from
+// flashlight/lantern-client). v9.1.x's nested file is most recent but
+// known to be bugged (fresh device_id, possibly wrong user_id).
+//
+// Runs unconditionally — quick stat-and-read of a handful of small
+// files; no-op for the vast majority of installs that don't have any
+// of the legacy files.
 func migrateLegacySettingsIfNeeded(fileDir, canonicalPath string) {
-	type candidate struct {
-		path     string
-		contents []byte
-		exists   bool
-		label    string
-	}
-	candidates := []candidate{
+	candidates := []candidateSource{
 		{path: canonicalPath, label: "canonical settings.json"},
 		{path: filepath.Join(fileDir, legacySettingsFileName), label: "v9.0.x local.json"},
+		// pre-9.x YAML is appended below after read+translate (only if
+		// it exists for this platform) so the pickIdx loop sees it as
+		// just another candidate.
 		{path: filepath.Join(fileDir, "data", settingsFileName), label: "v9.1.x data/settings.json"},
 	}
 	for i := range candidates {
@@ -166,6 +188,14 @@ func migrateLegacySettingsIfNeeded(fileDir, canonicalPath string) {
 				return
 			}
 		}
+	}
+	// Insert the pre-9.x YAML candidate (translated to canonical JSON)
+	// between local.json and data/settings.json. Only the platforms with
+	// known pre-9.x file layouts return a non-empty result here.
+	if yc := legacyYAMLCandidate(fileDir); yc.exists {
+		// Splice in at index 2 (just before data/settings.json) so
+		// priority order is canonical > local.json > pre-9.x > nested.
+		candidates = append(candidates[:2], append([]candidateSource{yc}, candidates[2:]...)...)
 	}
 
 	// Pick: highest-priority file with user_level=="pro"; if none has pro,

--- a/common/settings/settings_test.go
+++ b/common/settings/settings_test.go
@@ -33,6 +33,15 @@ func TestInitSettings(t *testing.T) {
 }
 
 func TestMigrateLegacySettingsIfNeeded(t *testing.T) {
+	// Redirect the OS-specific pre-9.x YAML lookup to nowhere by
+	// default so individual tests don't pick up the host machine's
+	// actual ~/Library/Application Support/Lantern/settings.yaml or
+	// equivalent. Sub-tests that exercise the YAML path opt in by
+	// pointing the function at their tempDir.
+	prevYAMLPath := legacyYAMLPathFn
+	legacyYAMLPathFn = func(string) (string, string) { return "", "" }
+	t.Cleanup(func() { legacyYAMLPathFn = prevYAMLPath })
+
 	writeNested := func(t *testing.T, dir string, contents []byte) {
 		t.Helper()
 		nd := filepath.Join(dir, "data")
@@ -160,6 +169,81 @@ func TestMigrateLegacySettingsIfNeeded(t *testing.T) {
 
 		_, err := os.Stat(canonical)
 		assert.True(t, os.IsNotExist(err), "no migration when no source files exist")
+	})
+
+	t.Run("pre-9.x desktop YAML recovered when no JSON candidates exist", func(t *testing.T) {
+		// Redirect the YAML lookup at a tempDir-local file so the test
+		// is portable across OSes.
+		tempDir := t.TempDir()
+		yamlPath := filepath.Join(tempDir, "fake-pre9x-settings.yaml")
+		require.NoError(t, os.WriteFile(yamlPath, []byte(`userID: 3580849
+deviceID: legacy-device-id
+userPro: true
+userToken: legacy-token
+emailAddress: derek@example.com
+`), 0o644))
+		legacyYAMLPathFn = func(string) (string, string) { return yamlPath, "desktop" }
+		t.Cleanup(func() { legacyYAMLPathFn = func(string) (string, string) { return "", "" } })
+
+		canonical := filepath.Join(tempDir, settingsFileName)
+		migrateLegacySettingsIfNeeded(tempDir, canonical)
+
+		got, err := os.ReadFile(canonical)
+		require.NoError(t, err)
+		gotStr := string(got)
+		assert.Contains(t, gotStr, `"user_id":3580849`)
+		assert.Contains(t, gotStr, `"device_id":"legacy-device-id"`)
+		assert.Contains(t, gotStr, `"user_level":"pro"`)
+		assert.Contains(t, gotStr, `"token":"legacy-token"`)
+		assert.Contains(t, gotStr, `"email":"derek@example.com"`)
+	})
+
+	t.Run("v9.0.x local.json beats pre-9.x YAML", func(t *testing.T) {
+		// Both exist with pro state. local.json is the higher-priority
+		// (more recent) source, so it should win.
+		tempDir := t.TempDir()
+		yamlPath := filepath.Join(tempDir, "fake-pre9x-settings.yaml")
+		require.NoError(t, os.WriteFile(yamlPath, []byte(`userID: 1
+userPro: true
+userToken: legacy-token
+`), 0o644))
+		legacyYAMLPathFn = func(string) (string, string) { return yamlPath, "desktop" }
+		t.Cleanup(func() { legacyYAMLPathFn = func(string) (string, string) { return "", "" } })
+
+		writeLegacy(t, tempDir, []byte(`{"user_id": 2, "user_level": "pro", "token": "v9.0-token"}`))
+
+		canonical := filepath.Join(tempDir, settingsFileName)
+		migrateLegacySettingsIfNeeded(tempDir, canonical)
+
+		got, err := os.ReadFile(canonical)
+		require.NoError(t, err)
+		assert.Contains(t, string(got), `"user_id": 2`,
+			"v9.0.x local.json should win over pre-9.x YAML when both have pro")
+		assert.Contains(t, string(got), `"v9.0-token"`)
+	})
+
+	t.Run("pre-9.x YAML beats v9.1.x bugged nested file", func(t *testing.T) {
+		// Pre-9.x has pro; v9.1.x nested has expired (the bugged case).
+		// Pre-9.x must win.
+		tempDir := t.TempDir()
+		yamlPath := filepath.Join(tempDir, "fake-pre9x-settings.yaml")
+		require.NoError(t, os.WriteFile(yamlPath, []byte(`userID: 1
+userPro: true
+userToken: legacy-token
+`), 0o644))
+		legacyYAMLPathFn = func(string) (string, string) { return yamlPath, "desktop" }
+		t.Cleanup(func() { legacyYAMLPathFn = func(string) (string, string) { return "", "" } })
+
+		writeNested(t, tempDir, []byte(`{"user_id": 999, "user_level": "expired"}`))
+
+		canonical := filepath.Join(tempDir, settingsFileName)
+		migrateLegacySettingsIfNeeded(tempDir, canonical)
+
+		got, err := os.ReadFile(canonical)
+		require.NoError(t, err)
+		assert.Contains(t, string(got), `"user_level":"pro"`,
+			"pre-9.x YAML with pro should win over v9.1.x nested expired")
+		assert.Contains(t, string(got), `"legacy-token"`)
 	})
 
 	t.Run("iOS userconfig.yaml recovered when canonical is missing", func(t *testing.T) {

--- a/common/settings/settings_test.go
+++ b/common/settings/settings_test.go
@@ -162,6 +162,31 @@ func TestMigrateLegacySettingsIfNeeded(t *testing.T) {
 		assert.True(t, os.IsNotExist(err), "no migration when no source files exist")
 	})
 
+	t.Run("iOS userconfig.yaml recovered when canonical is missing", func(t *testing.T) {
+		// On iOS the legacy YAML is sandbox-relative — it lives next to
+		// where settings.json now lives, so legacyYAMLCandidate reads
+		// from fileDir directly and we can exercise it from a test
+		// without monkeypatching $HOME or $APPDATA. (Desktop legacy
+		// paths are covered via translateLegacyYAML's unit tests, which
+		// don't depend on the OS-specific path resolution.)
+		if runtime.GOOS != "ios" {
+			t.Skip("iOS-only path: legacy YAML elsewhere is OS-specific")
+		}
+		tempDir := t.TempDir()
+		yamlPath := filepath.Join(tempDir, "userconfig.yaml")
+		require.NoError(t, os.WriteFile(yamlPath, []byte(`UserID: 7777
+DeviceID: ios-device
+Token: tok
+`), 0o644))
+		canonical := filepath.Join(tempDir, settingsFileName)
+		migrateLegacySettingsIfNeeded(tempDir, canonical)
+
+		got, err := os.ReadFile(canonical)
+		require.NoError(t, err)
+		assert.Contains(t, string(got), `"user_id":7777`)
+		assert.Contains(t, string(got), `"device_id":"ios-device"`)
+	})
+
 	t.Run("unreadable canonical (non-ENOENT) skips migration", func(t *testing.T) {
 		// Permission error on the canonical path: don't fall through and
 		// overwrite a file we couldn't read. unix only — windows handles


### PR DESCRIPTION
## Summary

Follow-up to #463. That PR covered the v9.0.x → v9.1.x → fixed upgrade path. This one extends the same migration to recover state from the **pre-9.x flashlight + lantern-client** clients on desktop and iOS — anyone upgrading from v8.x (or anything with that schema) directly to v9.1+ was hitting the same "Pro lost on upgrade" symptom Derek reproduced for the v9.0.x case, because their good state lives in a YAML file the radiance migration didn't know about.

## What's added

A fourth candidate path in `migrateLegacySettingsIfNeeded`. Paths match exactly what `getlantern/appdir.General("Lantern")` produced in the pre-9.x desktop clients (verified against `lantern-client/desktop/app/settings.go:132` and `appdir/appdir_*.go`):

| Platform | Pre-9.x file |
|----------|-------------|
| **macOS**    | `~/Library/Application Support/Lantern/settings.yaml` |
| **Windows**  | `%APPDATA%\Lantern\settings.yaml` |
| **Linux**    | `~/.config/lantern/settings.yaml`  *(lowercase — `appdir_linux.go` lowercases the app name)* |
| **iOS**      | `<fileDir>/userconfig.yaml` *(sandbox-relative)* |

All three desktop platforms resolve via `os.UserConfigDir()` (just like the pre-9.x client did), so the lookup respects `$XDG_CONFIG_HOME` on Linux and the standard config-dir conventions on macOS/Windows.

Each candidate is read, parsed (YAML), and translated into the canonical `settings.json` schema before being handed to the same priority-pick logic the existing JSON candidates use.

### Priority order
1. canonical `settings.json`
2. v9.0.x `local.json`
3. **pre-9.x platform-specific YAML** ← new
4. v9.1.x `data/settings.json` (known-bugged)

The pre-9.x YAML beats the v9.1.x nested file because the nested file is known to have a bogus device id and possibly wrong user id (that was the whole point of #463), while the YAML is the user's real legitimate state from the prior client.

### Field translations

**Desktop** (the older flashlight client wrote bool `userPro`):
- `userID` → `user_id`
- `deviceID` → `device_id`
- `userPro` (bool) → `user_level` (`"pro"` if true; `"free"` if user_id is set; unset otherwise)
- `userToken` → `token`
- `emailAddress` → `email`

**iOS** (didn't persist user level locally):
- `UserID` → `user_id`
- `DeviceID` → `device_id`
- `Token` → `token`
- (no user_level — let next \`/account/login\` decide)

## What's NOT in this PR

**Android pre-9.x state lives in an encrypted SQLite** (\`/data/data/org.getlantern.lantern/files/masterDBv2/db\`, decrypted with a password from \`EncryptedSharedPreferences\`). Reading that requires Kotlin-side code in the lantern repo, not a pure-Go migration in radiance. That'll be a separate change. Anyone who upgraded through v9.0.x first already has their state migrated to \`local.json\`, which #463 handles; only direct-from-v8.x Android upgraders are affected, which is a smaller cohort.

## Test plan
- [x] \`go test ./common/settings/ -count=1\` — passes (12 sub-tests covering both new YAML migration paths and existing JSON candidate logic)
- [x] Test redirects \`legacyYAMLPathFn\` so the test temp dir is used in place of the host's actual \`~/Library/Application Support/Lantern/settings.yaml\` (otherwise the host's real Lantern install would interfere with the unit tests)
- [ ] Manual macOS upgrade test: install v8.x desktop → log in to Pro → upgrade to a build with this fix → verify Pro state survives via \`~/Library/Application Support/Lantern/settings.yaml\` migration
- [ ] Manual Linux upgrade test: same shape with \`~/.config/lantern/settings.yaml\`
- [ ] Manual Windows upgrade test: same shape with \`%APPDATA%\Lantern\settings.yaml\`
- [ ] Manual iOS upgrade test: same shape with sandbox-relative \`userconfig.yaml\`
- [ ] Confirm fresh installs still work (no migration trigger, no-op path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)