### PR TITLE
ci: open a PR for fronted refresh instead of pushing direct to main

### DIFF
--- a/.github/workflows/refresh-fronted-config.yml
+++ b/.github/workflows/refresh-fronted-config.yml
@@ -53,7 +53,7 @@ jobs:
       # superseded by the next one rather than piling up as separate PRs.
       - name: Open / update refresh PR
         if: steps.diff.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@8a45c9a0f9071f4b1e4a0f3b660a1e9e3d9f0d7f # v7
         with:
           commit-message: "fronted: refresh embedded fronted.yaml.gz"
           title: "fronted: refresh embedded fronted.yaml.gz"

--- a/.github/workflows/refresh-fronted-config.yml
+++ b/.github/workflows/refresh-fronted-config.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 # Serialize concurrent runs (cron + manual dispatch can race). cancel-in-progress
 # is false so a manual dispatch during a cron run still completes rather than
@@ -46,20 +47,20 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Commit and push
+      # Open a PR rather than pushing directly: main is protected by a
+      # "Changes must be made through a pull request" repo rule. The PR
+      # branch is reused day-to-day so a stale unmerged refresh gets
+      # superseded by the next one rather than piling up as separate PRs.
+      - name: Open / update refresh PR
         if: steps.diff.outputs.changed == 'true'
-        run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add kindling/fronted/fronted.yaml.gz
-          git commit -m "fronted: refresh embedded fronted.yaml.gz"
-          # Rebase-and-retry to survive concurrent commits to the target branch.
-          for attempt in 1 2 3; do
-            if git push; then
-              exit 0
-            fi
-            echo "Push attempt $attempt failed, rebasing on latest origin and retrying..."
-            git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"
-          done
-          echo "Push failed after 3 attempts" >&2
-          exit 1
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "fronted: refresh embedded fronted.yaml.gz"
+          title: "fronted: refresh embedded fronted.yaml.gz"
+          body: |
+            Automated daily refresh of `kindling/fronted/fronted.yaml.gz`
+            from `getlantern/fronted@main`. Safe to merge once CI passes.
+          branch: chore/refresh-fronted-config
+          delete-branch: true
+          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"


### PR DESCRIPTION
## Summary

The daily \`Refresh embedded fronted.yaml.gz\` workflow has been failing every run since the \`pull_request\` repo rule was added — it tries to \`git push\` directly to \`main\` and gets back \`GH013: Repository rule violations found for refs/heads/main — Changes must be made through a pull request\`.

Latest failing run: https://github.com/getlantern/radiance/actions/runs/25478096992

Switch the workflow to [\`peter-evans/create-pull-request@v7\`](https://github.com/peter-evans/create-pull-request) so the refresh lands as a PR on a stable branch (\`chore/refresh-fronted-config\`). Successive runs reuse that branch, so a stale unmerged refresh gets superseded by the next day's rather than piling up as separate PRs.

## What changes

- Workflow opens/updates a PR instead of pushing direct.
- Branch \`chore/refresh-fronted-config\` is reused across runs and deleted on merge.
- Adds \`pull-requests: write\` to the workflow's \`permissions\` block (required for the action to open PRs).
- All other behavior preserved: same cron schedule, same gzip integrity check, same diff-and-skip when upstream hasn't changed.

## Test plan

- [ ] Manually trigger the workflow via \`workflow_dispatch\` after merging — should produce a \`chore/refresh-fronted-config\` PR if upstream has drifted, or a clean no-op run if it hasn't.
- [ ] Verify the next scheduled (cron) run also succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)