### PR TITLE
deps: bump kindling for method-aware retry across transports

### DIFF
--- a/config/fetcher.go
+++ b/config/fetcher.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/getlantern/kindling"
 	"github.com/getlantern/lantern-box/protocol"
 
 	"github.com/getlantern/radiance/account"
@@ -153,6 +154,14 @@ func (f *fetcher) send(ctx context.Context, body io.Reader) ([]byte, error) {
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Cache-Control", "no-cache")
+	// /config-new is POST-shaped (request carries last-known etag/version
+	// + client metadata in the body) but is semantically a read-only
+	// fetch — no server-side state mutates. Tag it idempotent so kindling's
+	// raceTransport falls back to the next transport on transport-level
+	// errors and 5xx, the same way it does for GET/HEAD. Without this, a
+	// single fronting CDN returning 5xx (e.g., during a localized block)
+	// would fail the whole fetch instead of being routed around.
+	req.Header.Set(kindling.IdempotentHeader, "1")
 
 	if val := env.GetString(env.Country); val != "" {
 		slog.Info("Setting x-lantern-client-country header", "country", val)

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/getlantern/dnstt v0.0.0-20260112160750-05100563bd0d
 	github.com/getlantern/domainfront v0.0.0-20260419161617-0bff0b2169f4
 	github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694
-	github.com/getlantern/kindling v0.0.0-20260507160243-03bc719abfe3
+	github.com/getlantern/kindling v0.0.0-20260507163327-92a44d03bdc5
 	github.com/getlantern/lantern-box v0.0.78
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/getlantern/dnstt v0.0.0-20260112160750-05100563bd0d
 	github.com/getlantern/domainfront v0.0.0-20260419161617-0bff0b2169f4
 	github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694
-	github.com/getlantern/kindling v0.0.0-20260428171407-6143132aaf40
+	github.com/getlantern/kindling v0.0.0-20260507160243-03bc719abfe3
 	github.com/getlantern/lantern-box v0.0.78
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,8 @@ github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 h1:cSrD9ryDfTV2y
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770/go.mod h1:GOQsoDnEHl6ZmNIL+5uVo+JWRFWozMEp18Izcb++H+A=
 github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694 h1:iLWm6S/47Hfk7FjW6yaD+1h6kO7C/iauV0DkVia/bXU=
 github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
-github.com/getlantern/kindling v0.0.0-20260507160243-03bc719abfe3 h1:w1NRYV7eCMYoDd6CQ5hjx473jstwq+I8wbSX2sBZAwY=
-github.com/getlantern/kindling v0.0.0-20260507160243-03bc719abfe3/go.mod h1:TGTxpoNVwc8Be4qkBNtf5oj2psJaEIZEq47GOPS7zkA=
+github.com/getlantern/kindling v0.0.0-20260507163327-92a44d03bdc5 h1:ukTEQ2S16zMK2BJxIM0qKz+WiiyiPwvmLCWlK1EOvVU=
+github.com/getlantern/kindling v0.0.0-20260507163327-92a44d03bdc5/go.mod h1:TGTxpoNVwc8Be4qkBNtf5oj2psJaEIZEq47GOPS7zkA=
 github.com/getlantern/lantern-box v0.0.78 h1:6P68+v7zukSXs3KFEfqY6iKBtqV3bLCzKouigN4kaw4=
 github.com/getlantern/lantern-box v0.0.78/go.mod h1:wJhPQKdnwD6qW/ghAfzsrj/IfHZbvFSAfr52+Tu6dbw=
 github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90 h1:P9JX1yAu2uq3b5YiT0sLtHkTrkZuttV8gPZh81nUuag=

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,8 @@ github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 h1:cSrD9ryDfTV2y
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770/go.mod h1:GOQsoDnEHl6ZmNIL+5uVo+JWRFWozMEp18Izcb++H+A=
 github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694 h1:iLWm6S/47Hfk7FjW6yaD+1h6kO7C/iauV0DkVia/bXU=
 github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
-github.com/getlantern/kindling v0.0.0-20260428171407-6143132aaf40 h1:P5pkaBGxWOGBn7bKzjzdln/ro+ShG1RUbOuy+7pSzXE=
-github.com/getlantern/kindling v0.0.0-20260428171407-6143132aaf40/go.mod h1:TGTxpoNVwc8Be4qkBNtf5oj2psJaEIZEq47GOPS7zkA=
+github.com/getlantern/kindling v0.0.0-20260507160243-03bc719abfe3 h1:w1NRYV7eCMYoDd6CQ5hjx473jstwq+I8wbSX2sBZAwY=
+github.com/getlantern/kindling v0.0.0-20260507160243-03bc719abfe3/go.mod h1:TGTxpoNVwc8Be4qkBNtf5oj2psJaEIZEq47GOPS7zkA=
 github.com/getlantern/lantern-box v0.0.78 h1:6P68+v7zukSXs3KFEfqY6iKBtqV3bLCzKouigN4kaw4=
 github.com/getlantern/lantern-box v0.0.78/go.mod h1:wJhPQKdnwD6qW/ghAfzsrj/IfHZbvFSAfr52+Tu6dbw=
 github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90 h1:P9JX1yAu2uq3b5YiT0sLtHkTrkZuttV8gPZh81nUuag=


### PR DESCRIPTION
## Summary

Bumps `getlantern/kindling` to pull in [#32](https://github.com/getlantern/kindling/pull/32) (method-aware retry) and [#33](https://github.com/getlantern/kindling/pull/33) (`X-Kindling-Idempotent` opt-in), and opts `/config-new` POST into the idempotent path so cross-transport fallback is preserved for it.

## Why

`raceTransport` was retrying every request on every 4xx/5xx response and on any post-RoundTrip transport error. Non-idempotent endpoints — most visibly `POST /peer/verify` during Share-My-Connection testing — were getting replayed across transports, with the first request deprecating its peer-route row server-side and subsequent replays 404'ing on the now-deprecated row.

Concrete trace from prod on 2026-05-07 15:19:31 UTC, single client `Verify()` call:

| Time | Pod | Status | Body |
|---|---|---|---|
| 15:19:36.977 | api-bp9w | 422 (5005ms) | `peer verify failed, deprecating row` |
| 15:19:37.139 | api-0ldc | 404 | `peer verify lookup miss` |
| 15:19:37.387 | api-0ldc | 404 | `peer verify lookup miss` |

Three pod hits, one success-then-failure pattern, one client-side intent.

## What changes

The bumped `kindling` ships these semantics:

| Method class | Connect failure | RoundTrip error | 4xx | 5xx |
|---|---|---|---|---|
| Non-idempotent (POST/PUT/DELETE/PATCH/OPTIONS) | fall back | **return** | **return** | **return** |
| Idempotent (GET/HEAD) | fall back | fall back | **return** | fall back |
| Any method + `X-Kindling-Idempotent: 1` | fall back | fall back | **return** | fall back |

So:

- **`/peer/register`, `/peer/verify`, `/peer/heartbeat`, `/peer/deregister` (POST)** — single-shot, removing the multi-pod-deprecation pattern observed above.
- **`/issue/*` (POST)** — single-shot, correct (each submission creates a record).
- **`/config-new` (POST, read-only fetch)** — opts into retry via `kindling.IdempotentHeader`. Net behavior identical to pre-bump: cross-transport fallback on 5xx is preserved.

The `/config-new` body carries the client's last-known etag/version and metadata; the server returns the latest config bytes regardless of how many times it's called for the same client state, so retrying on a different transport is safe.

## Commits

1. `e9e327d` — bump kindling to PR #32 merge
2. `b7b3a9d` — bump kindling to PR #33 merge + set `kindling.IdempotentHeader` on `/config-new` (addresses Copilot review)

## Test plan

- [x] `go test ./peer/ ./backend/ ./config/ ./kindling/...` clean (peer/ tested locally on `fisk/peer-call-verify` since the package isn't on `main` yet)
- [x] `go test ./...` clean across the bumped tree (one pre-existing `cmd/lantern` build error unrelated to the bump)
- [ ] Rebuild lantern, re-run the peer-share toggle in prod — SigNoz should show exactly one `/peer/verify` per toggle instead of three
- [ ] Verify `/config-new` continues to fetch successfully under simulated single-transport-5xx (manual: block one fronting CDN at the network layer, observe radiance falls back to another transport)

🤖 Generated with [Claude Code](https://claude.com/claude-code)