### PR TITLE
vpn: tune base box options and route RU locale to Yandex DNS

### DIFF
--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -115,9 +115,9 @@ func baseOpts(basePath string) O.Options {
 					Address: []netip.Prefix{
 						netip.MustParsePrefix("10.10.1.1/30"),
 					},
-					AutoRoute:   true,
-					StrictRoute: true,
-					MTU:         1500,
+					AutoRoute:              true,
+					StrictRoute:            true,
+					EndpointIndependentNat: true, // needed for QUIC migration and hole-punching
 				},
 			},
 			{
@@ -164,9 +164,11 @@ func baseOpts(basePath string) O.Options {
 				ExternalController: "", // intentionally left empty
 			},
 			CacheFile: &O.CacheFileOptions{
-				Enabled: true,
-				Path:    cacheFile,
-				CacheID: cacheID,
+				Enabled:     true,
+				Path:        cacheFile,
+				CacheID:     cacheID,
+				StoreFakeIP: true,
+				StoreRDRC:   true,
 			},
 		},
 	}
@@ -182,8 +184,8 @@ func baseRoutingRules() []O.Rule {
 	// 4.    Route private IPs to direct outbound
 	// 5.    Split tunnel rule (user-configurable)
 	// 6.    Rules from config file (added in buildOptions)
-	// 7-9.  Group rules for auto, lantern, and user (added in buildOptions)
-	// 10.   Catch-all blocking rule (added in buildOptions). This ensures that any traffic not covered
+	// 7,8.  Group rules for auto and manual selector modes (added in buildOptions).
+	// 9.    Catch-all blocking rule (added in buildOptions). This ensures that any traffic not covered
 	//       by previous rules does not automatically bypass the VPN.
 	//
 	// * DO NOT change the order of these rules unless you know what you're doing. Changing these

--- a/vpn/dnsoptions.go
+++ b/vpn/dnsoptions.go
@@ -79,7 +79,6 @@ func buildDNSServers() []option.DNSServerOptions {
 var aliDNSLocales = map[string]struct{}{
 	"FAIR": {},
 	"ZHCN": {},
-	"RURU": {},
 	"CN":   {},
 	"IR":   {},
 }
@@ -91,7 +90,7 @@ func localDNSIP() string {
 		slog.Info("Using AliDNS for locale", "locale", locale)
 		return "223.5.5.5"
 	}
-	if normalizedLocale == "RU" {
+	if normalizedLocale == "RU" || normalizedLocale == "RURU" {
 		slog.Info("Using Yandex DNS for locale", "locale", locale)
 		return "77.88.8.8"
 	}

--- a/vpn/dnsoptions.go
+++ b/vpn/dnsoptions.go
@@ -5,18 +5,18 @@ import (
 	"net/netip"
 	"strings"
 
-	"github.com/getlantern/radiance/common/settings"
 	"github.com/miekg/dns"
 	"github.com/sagernet/sing-box/constant"
 	"github.com/sagernet/sing-box/option"
 	"github.com/sagernet/sing/common/json/badoption"
+
+	"github.com/getlantern/radiance/common/settings"
 )
 
 // buildDNSServers returns a list of three DNSServerOptions, a local DNS server
-// used for local requests; a remote DNS server (like quad9)
-// for remote websites without sharing user private IP; and fake IP dns server, which
-// effectively resolves DNS locally while allowing us to route traffic based on
-// domains.
+// used for local requests; a remote DNS server (like quad9) for remote websites
+// without sharing user private IP; and fake IP dns server, which effectively resolves
+// DNS locally while allowing us to route traffic based on domains.
 func buildDNSServers() []option.DNSServerOptions {
 	local := option.DNSServerOptions{
 		Tag:  "dns_local",
@@ -82,27 +82,26 @@ var aliDNSLocales = map[string]struct{}{
 	"RURU": {},
 	"CN":   {},
 	"IR":   {},
-	"RU":   {},
 }
 
 func localDNSIP() string {
-	// First, normalize the locale to upper case and remove any hyphens or underscores.
 	locale := settings.GetString(settings.LocaleKey)
 	normalizedLocale := normalizeLocale(locale)
 	if _, ok := aliDNSLocales[normalizedLocale]; ok {
 		slog.Info("Using AliDNS for locale", "locale", locale)
-		// AliDNS
 		return "223.5.5.5"
 	}
-	// Quad9, which is more privacy preserving by doing things such as
-	// not sending EDNS Client-Subnet data
+	if normalizedLocale == "RU" {
+		slog.Info("Using Yandex DNS for locale", "locale", locale)
+		return "77.88.8.8"
+	}
+	// default to Quad9
 	slog.Info("Using Quad9 for locale", "locale", locale)
 	return "9.9.9.9"
 }
 
 // normalizeLocale normalizes the locale string by converting it to upper case
-// and removing any hyphens or underscores. Locales can come it from all platforms in various
-// formats, so this helps standardize them for comparison.
+// and removing any hyphens or underscores.
 func normalizeLocale(locale string) string {
 	return strings.ReplaceAll(strings.ReplaceAll(strings.ToUpper(locale), "-", ""), "_", "")
 }

--- a/vpn/dnsoptions.go
+++ b/vpn/dnsoptions.go
@@ -71,6 +71,12 @@ func buildDNSServers() []option.DNSServerOptions {
 	}
 }
 
+const (
+	aliDNS    = "223.5.5.5"
+	yandexDNS = "77.88.8.8"
+	quad9DNS  = "9.9.9.9"
+)
+
 // Locales where AliDNS is used as local DNS server. Note that AliDNS is
 // primarily attractive because it is accessible but is understood to return
 // results that are DNS poisoned for many sites. This is fine because our
@@ -88,15 +94,15 @@ func localDNSIP() string {
 	normalizedLocale := normalizeLocale(locale)
 	if _, ok := aliDNSLocales[normalizedLocale]; ok {
 		slog.Info("Using AliDNS for locale", "locale", locale)
-		return "223.5.5.5"
+		return aliDNS
 	}
 	if normalizedLocale == "RU" || normalizedLocale == "RURU" {
 		slog.Info("Using Yandex DNS for locale", "locale", locale)
-		return "77.88.8.8"
+		return yandexDNS
 	}
 	// default to Quad9
 	slog.Info("Using Quad9 for locale", "locale", locale)
-	return "9.9.9.9"
+	return quad9DNS
 }
 
 // normalizeLocale normalizes the locale string by converting it to upper case

--- a/vpn/dnsoptions_test.go
+++ b/vpn/dnsoptions_test.go
@@ -77,57 +77,57 @@ func TestLocalDNSIP(t *testing.T) {
 		{
 			name:     "FAIR locale returns AliDNS",
 			locale:   "FAIR",
-			expected: "223.5.5.5",
+			expected: aliDNS,
 		},
 		{
 			name:     "fair lowercase returns AliDNS",
 			locale:   "fair",
-			expected: "223.5.5.5",
+			expected: aliDNS,
 		},
 		{
 			name:     "ZHCN locale returns AliDNS",
 			locale:   "ZHCN",
-			expected: "223.5.5.5",
+			expected: aliDNS,
 		},
 		{
 			name:     "zh-cn with hyphen returns AliDNS",
 			locale:   "zh-cn",
-			expected: "223.5.5.5",
+			expected: aliDNS,
 		},
 		{
 			name:     "zh_cn with underscore returns AliDNS",
 			locale:   "zh_cn",
-			expected: "223.5.5.5",
+			expected: aliDNS,
 		},
 		{
 			name:     "RURU locale returns AliDNS",
 			locale:   "RURU",
-			expected: "223.5.5.5",
+			expected: yandexDNS,
 		},
 		{
 			name:     "ru-ru with hyphen returns AliDNS",
 			locale:   "ru-ru",
-			expected: "223.5.5.5",
+			expected: yandexDNS,
 		},
 		{
 			name:     "en-US returns Quad9",
 			locale:   "en-US",
-			expected: "9.9.9.9",
+			expected: quad9DNS,
 		},
 		{
 			name:     "enus returns Quad9",
 			locale:   "enus",
-			expected: "9.9.9.9",
+			expected: quad9DNS,
 		},
 		{
 			name:     "empty locale returns Quad9",
 			locale:   "",
-			expected: "9.9.9.9",
+			expected: quad9DNS,
 		},
 		{
 			name:     "unknown locale returns Quad9",
 			locale:   "fr-FR",
-			expected: "9.9.9.9",
+			expected: quad9DNS,
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Drop the explicit `MTU: 1500` on the TUN inbound and let sing-box pick the platform default.
- Enable `EndpointIndependentNat` on the TUN inbound so UDP flows share a single mapping per source when using gvisor stack — required for QUIC connection migration, STUN/ICE, WebRTC, and similar UDP hole-punching.
- Enable `StoreFakeIP` and `StoreRDRC` on the cache file so fake-IP allocations and reject-DNS-response decisions survive tunnel restarts (less DNS churn, less mapping drift mid-session).
- Stop using AliDNS for `RU` and `RURU` locales; resolve via Yandex DNS (`77.88.8.8`) instead. AliDNS is poison-tolerant for CN/IR where downstream Lantern routing handles re-resolution, but RU users get better local accuracy from a domestic resolver.
