### PR TITLE
peer: rotate samizdat credentials hourly (closes engineering#3437)

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -54,14 +54,15 @@ type Status struct {
 }
 
 // Config plumbs in dependencies. Zero-valued fields fall back to production
-// defaults; HeartbeatInterval and HeartbeatTimeout exist so tests can drive
-// the loop without sleeping a full minute.
+// defaults; HeartbeatInterval, HeartbeatTimeout, and CredRotationInterval
+// exist so tests can drive the loops without sleeping a full minute / hour.
 type Config struct {
-	API               *API
-	NewForwarder      func(ctx context.Context) (portForwarder, error)
-	BuildBoxService   boxFactory
-	HeartbeatInterval time.Duration
-	HeartbeatTimeout  time.Duration
+	API                  *API
+	NewForwarder         func(ctx context.Context) (portForwarder, error)
+	BuildBoxService      boxFactory
+	HeartbeatInterval    time.Duration
+	HeartbeatTimeout     time.Duration
+	CredRotationInterval time.Duration
 }
 
 // Client orchestrates one peer-proxy session: open UPnP port → register with
@@ -87,7 +88,37 @@ type Client struct {
 	forwarder portForwarder
 	box       boxService
 	routeID   string
+	// externalPort / internalPort persist the port mapping picked at
+	// Start so the cred-rotation loop can re-register against the same
+	// (address, port) tuple without re-probing UPnP / re-mapping. The
+	// router-side mapping itself stays put across rotations; only the
+	// samizdat creds and route_id rotate.
+	externalPort uint16
+	internalPort uint16
+	// boxOptions is the fresh options string passed to BuildBoxService,
+	// kept for diagnostics and so the rotation path doesn't need to
+	// re-derive it from the (also-stored) box reference.
+	boxOptions string
+	// runCtx is captured here for the cred-rotation goroutine to bind
+	// the new libbox lifetime to the same context as the original Start.
+	// Stop's cancelRun() teardown still applies to the rebuilt box.
+	runCtx context.Context
 }
+
+// peerCredRotationInterval bounds how long a leaked samizdat
+// credential remains usable. At each tick the peer re-registers with
+// lantern-cloud (new route_id, new keypair, new shortID), rebuilds the
+// libbox service against the new options, and deregisters the prior
+// route. Caps blast radius from credential leakage (logs, telemetry,
+// memory dumps, the H2 leakage path in engineering#3440) to ~1h
+// regardless of peer process lifetime.
+//
+// Cost per rotation: one API.Register + Deregister round trip, one
+// libbox build + start + close cycle. Brief (~hundreds-of-ms) port-
+// rebind window during the swap; samizdat clients see TCP RST and
+// reconnect via the bandit. Acceptable trade-off vs. holding the same
+// cred for the full peer process lifetime.
+const peerCredRotationInterval = 1 * time.Hour
 
 // peerCleanupTimeout caps how long Start's rollback path waits for
 // Deregister / UnmapPort. Cleanup uses a fresh Background context (not the
@@ -233,6 +264,10 @@ func (c *Client) Start(ctx context.Context) error {
 	c.forwarder = fwd
 	c.box = box
 	c.routeID = regResp.RouteID
+	c.externalPort = mapping.ExternalPort
+	c.internalPort = mapping.InternalPort
+	c.boxOptions = options
+	c.runCtx = runCtx
 	c.cancelRun = cancelRun
 	c.runDone = runDone
 	c.status = Status{
@@ -245,8 +280,14 @@ func (c *Client) Start(ctx context.Context) error {
 	statusSnapshot := c.status
 	c.mu.Unlock()
 
+	rotation := c.cfg.CredRotationInterval
+	if rotation == 0 {
+		rotation = peerCredRotationInterval
+	}
+
 	fwd.StartRenewal(runCtx)
 	go c.heartbeatLoop(runCtx, heartbeat, runDone)
+	go c.credRotationLoop(runCtx, rotation)
 
 	slog.Info("peer client started",
 		"external_ip", externalIP,
@@ -280,6 +321,10 @@ func (c *Client) Stop(ctx context.Context) error {
 	c.forwarder = nil
 	c.box = nil
 	c.routeID = ""
+	c.externalPort = 0
+	c.internalPort = 0
+	c.boxOptions = ""
+	c.runCtx = nil
 	c.status = Status{}
 	c.mu.Unlock()
 
@@ -369,6 +414,141 @@ func (c *Client) heartbeatLoop(ctx context.Context, interval time.Duration, done
 func isNotRegistered(err error) bool {
 	var apiErr *APIError
 	return errors.As(err, &apiErr) && apiErr.Status == 404
+}
+
+// credRotationLoop periodically rotates the peer's samizdat credentials
+// (X25519 keypair, shortID, masquerade) by re-registering with
+// lantern-cloud, rebuilding the libbox inbound, and deregistering the
+// prior route. Caps blast radius from credential leakage to ~interval
+// regardless of peer process lifetime — see peerCredRotationInterval.
+//
+// Closes done is the responsibility of heartbeatLoop; this loop just
+// exits when ctx is cancelled. We deliberately don't add another close
+// channel: heartbeatLoop's done already gates Stop, and rotation
+// failures are non-fatal (log + retry next tick), so there's nothing
+// the Stop path needs to wait on from this goroutine.
+func (c *Client) credRotationLoop(ctx context.Context, interval time.Duration) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := c.rotateCreds(ctx); err != nil {
+				// Don't kill the loop on a single failure — current
+				// box / route is still serving. Try again next tick.
+				slog.Warn("peer cred rotation failed; current creds remain in use", "err", err)
+			}
+		}
+	}
+}
+
+// rotateCreds atomically swaps the peer's samizdat credentials. On
+// success: a fresh route_id and keypair are in use, the libbox inbound
+// has been rebuilt against the new options, the prior route is
+// deregistered server-side, and the FlutterEvent stream sees no gap.
+// On failure: the prior creds and box continue serving — rotation is
+// best-effort. The router-side port mapping is preserved across the
+// rotation; only the in-process samizdat state changes.
+//
+// Sequence:
+//  1. Re-register with the same (externalIP, externalPort) as Start.
+//  2. Patch the new server-supplied options for VPN bypass.
+//  3. Build a new libbox service against the new options.
+//  4. Close the old box (releases the listening port).
+//  5. Start the new box (re-binds the same port, now with new creds).
+//  6. Atomic swap: c.box, c.routeID, c.boxOptions point at the new box.
+//  7. Best-effort deregister of the prior route_id so the bandit
+//     catalog stops handing the old (now-invalid) creds to clients.
+//
+// Steps 4-5 leave a brief (~hundreds of ms) window where the port
+// isn't bound; samizdat clients see TCP RST and reconnect. Acceptable
+// trade-off vs. the security cost of holding the same cred for the
+// peer process lifetime.
+func (c *Client) rotateCreds(ctx context.Context) error {
+	c.mu.Lock()
+	if !c.active {
+		c.mu.Unlock()
+		return errors.New("not active")
+	}
+	fwd := c.forwarder
+	extPort := c.externalPort
+	intPort := c.internalPort
+	oldRouteID := c.routeID
+	oldBox := c.box
+	c.mu.Unlock()
+
+	if fwd == nil || oldBox == nil {
+		return errors.New("rotateCreds: client state inconsistent")
+	}
+
+	externalIP, err := fwd.ExternalIP(ctx)
+	if err != nil {
+		return fmt.Errorf("get external ip: %w", err)
+	}
+	regResp, err := c.cfg.API.Register(ctx, RegisterRequest{
+		ExternalIP:   externalIP,
+		ExternalPort: extPort,
+		InternalPort: intPort,
+	})
+	if err != nil {
+		return fmt.Errorf("re-register: %w", err)
+	}
+	options, err := ensurePeerOutboundsBypassVPN(regResp.ServerConfig)
+	if err != nil {
+		return fmt.Errorf("patch sing-box options: %w", err)
+	}
+
+	c.mu.Lock()
+	runCtx := c.runCtx
+	c.mu.Unlock()
+	if runCtx == nil {
+		// Stop happened between the unlock above and here. Skip the
+		// build to avoid spinning up a libbox tied to a torn-down ctx.
+		// The new register row is harmless — server-side reaper will
+		// deprecate it after TTL since no heartbeat will arrive.
+		return errors.New("client stopped during rotation")
+	}
+	newBox, err := c.cfg.BuildBoxService(runCtx, options)
+	if err != nil {
+		return fmt.Errorf("build new sing-box: %w", err)
+	}
+
+	// Close old, start new. Order matters — both want the same port.
+	// If newBox.Start fails after oldBox.Close, we lost the listener
+	// and the next heartbeat / rotation tick is the recovery point.
+	if closeErr := oldBox.Close(); closeErr != nil {
+		slog.Warn("close old box during rotation", "err", closeErr)
+	}
+	if err := newBox.Start(); err != nil {
+		// Catastrophic: port is now unbound. Leave c.box pointing at
+		// oldBox so a future Stop tries to close it (idempotent on
+		// already-closed); the next rotation tick will try again.
+		return fmt.Errorf("start new sing-box: %w", err)
+	}
+
+	c.mu.Lock()
+	c.box = newBox
+	c.routeID = regResp.RouteID
+	c.boxOptions = options
+	c.status.RouteID = regResp.RouteID
+	c.mu.Unlock()
+
+	// Deregister the prior route so the bandit stops handing the old
+	// (now-invalid) creds to clients. Best-effort: the prior row will
+	// expire from its TTL anyway, but explicit deregister cuts the
+	// stale-creds window from up-to-TTL down to ~immediately.
+	if err := c.cfg.API.Deregister(ctx, oldRouteID); err != nil {
+		slog.Warn("deregister prior route after rotation",
+			"err", err, "old_route_id", oldRouteID)
+	}
+
+	slog.Info("peer cred rotation succeeded",
+		"new_route_id", regResp.RouteID,
+		"old_route_id", oldRouteID,
+	)
+	return nil
 }
 
 // ensurePeerOutboundsBypassVPN guarantees the peer sing-box's outbound dials

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -121,8 +121,8 @@ type Client struct {
 // lantern-cloud (new route_id, new keypair, new shortID), rebuilds the
 // libbox service against the new options, and deregisters the prior
 // route. Caps blast radius from credential leakage (logs, telemetry,
-// memory dumps, the H2 leakage path in engineering#3440) to ~1h
-// regardless of peer process lifetime.
+// memory dumps, H2 leakage paths) to ~1h regardless of peer process
+// lifetime.
 //
 // Cost per rotation: one API.Register + Deregister round trip, one
 // libbox build + start + close cycle. Brief (~hundreds-of-ms) port-
@@ -501,11 +501,11 @@ func (c *Client) credRotationLoop(ctx context.Context, interval time.Duration) {
 }
 
 // runRotation wraps rotateCreds with a panic recover. libbox.Start can
-// panic (see the recover in vpn/tunnel.go's tunnel-start path); an
-// unrecovered panic here would crash the host process during a
-// background rotation, taking the user's main VPN with it. Treat a
-// panic the same as any other rotation failure: log, keep the existing
-// box serving, try again next tick.
+// panic — the main tunnel start path already wraps it with recover for
+// the same reason — and an unrecovered panic here would crash the host
+// process during a background rotation, taking the user's main VPN
+// with it. Treat a panic the same as any other rotation failure: log,
+// keep the existing box serving, try again next tick.
 func (c *Client) runRotation(ctx context.Context) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -553,6 +553,14 @@ func (c *Client) rotateCreds(ctx context.Context) error {
 	intPort := c.internalPort
 	oldRouteID := c.routeID
 	oldBox := c.box
+	// Capture sessionRunCtx upfront so the final swap can detect a
+	// Stop→Start cycle that happened mid-rotation. Just checking
+	// c.active at the swap isn't enough: Stop clears active, then a
+	// new Start can set it back to true before this rotation reaches
+	// the swap, and the old rotation would clobber the new session's
+	// state. The runCtx is unique per session, so a pointer-identity
+	// check at the swap is sufficient.
+	sessionRunCtx := c.runCtx
 	c.mu.Unlock()
 
 	if fwd == nil || oldBox == nil {
@@ -593,16 +601,17 @@ func (c *Client) rotateCreds(ctx context.Context) error {
 	}
 
 	c.mu.Lock()
-	runCtx := c.runCtx
+	currentRunCtx := c.runCtx
 	c.mu.Unlock()
-	if runCtx == nil {
-		// Stop happened between the unlock above and here. Skip the
-		// build to avoid spinning up a libbox tied to a torn-down ctx,
-		// and clean up the just-created route so it doesn't linger.
+	if currentRunCtx == nil || currentRunCtx != sessionRunCtx {
+		// Stop ran (runCtx==nil), or a Stop→Start cycle replaced the
+		// session (runCtx pointer differs from the one captured at the
+		// top). Either way the build below would tie a libbox to the
+		// wrong session; skip it and clean up the just-created route.
 		cleanupNewRoute(errors.New("client stopped during rotation"))
 		return errors.New("client stopped during rotation")
 	}
-	newBox, err := c.cfg.BuildBoxService(runCtx, options)
+	newBox, err := c.cfg.BuildBoxService(sessionRunCtx, options)
 	if err != nil {
 		cleanupNewRoute(err)
 		return fmt.Errorf("build new sing-box: %w", err)
@@ -624,21 +633,26 @@ func (c *Client) rotateCreds(ctx context.Context) error {
 		return fmt.Errorf("start new sing-box: %w", err)
 	}
 
-	// Final swap under lock. Re-check active so a Stop racing us between
-	// runCtx-check above and now doesn't get resurrected by overwriting
-	// the cleared state Stop just set up.
+	// Final swap under lock. Re-check that the session is still the
+	// one we started against. Per-session runCtx identity is a stricter
+	// check than c.active alone: a Stop→Start cycle between the
+	// runCtx-check above and now would have cleared active AND set it
+	// back true, but the new session's runCtx differs from sessionRunCtx
+	// — so we'd otherwise resurrect old-session state into the new one.
 	c.mu.Lock()
-	if !c.active {
+	if !c.active || c.runCtx != sessionRunCtx {
 		c.mu.Unlock()
-		// Stop already cleared c.box / c.routeID. Close the new box we
-		// just brought up (Stop has no reference to it) and deregister
-		// the new route. The old route Stop already deregistered as
-		// part of its own teardown.
+		// Either Stop cleared state, or Stop→Start replaced the session.
+		// Close the new box we just brought up (the current session has
+		// no reference to it) and deregister the new route. Don't touch
+		// the prior route: in the Stop-only case, Stop already
+		// deregistered it; in the Stop→Start case, deregistering it
+		// would defeat the rotation point of cutting off the old creds.
 		if err := newBox.Close(); err != nil {
-			slog.Warn("close new box after Stop raced rotation", "err", err)
+			slog.Warn("close new box after session changed during rotation", "err", err)
 		}
-		cleanupNewRoute(errors.New("client stopped during rotation swap"))
-		return errors.New("client stopped during rotation")
+		cleanupNewRoute(errors.New("session changed during rotation swap"))
+		return errors.New("session changed during rotation")
 	}
 	c.box = newBox
 	c.routeID = regResp.RouteID
@@ -648,13 +662,17 @@ func (c *Client) rotateCreds(ctx context.Context) error {
 	c.mu.Unlock()
 
 	// Deregister the prior route so the bandit stops handing the old
-	// (now-invalid) creds to clients. Best-effort: the prior row will
-	// expire from its TTL anyway, but explicit deregister cuts the
-	// stale-creds window from up-to-TTL down to ~immediately.
-	if err := c.cfg.API.Deregister(ctx, oldRouteID); err != nil {
+	// (now-invalid) creds to clients. Use a fresh ctx so a Stop that
+	// races us between the swap above and the deregister doesn't cancel
+	// the cleanup — leaving the old (now-invalid-locally) route in the
+	// server catalog until TTL would defeat the rotation's stale-cred
+	// cap, which is the whole point of the feature.
+	deregCtx, cancelDereg := context.WithTimeout(context.Background(), peerCleanupTimeout)
+	if err := c.cfg.API.Deregister(deregCtx, oldRouteID); err != nil {
 		slog.Warn("deregister prior route after rotation",
 			"err", err, "old_route_id", oldRouteID)
 	}
+	cancelDereg()
 
 	slog.Info("peer cred rotation succeeded",
 		"new_route_id", regResp.RouteID,
@@ -665,11 +683,25 @@ func (c *Client) rotateCreds(ctx context.Context) error {
 
 // startNewBoxWithRetry retries newBox.Start a handful of times with a
 // short backoff to absorb router-side TIME_WAIT / EADDRINUSE between
-// oldBox.Close releasing the port and newBox.Start re-binding it. Total
-// wait is bounded under 1s so a healthy rotation isn't delayed
-// noticeably; the alternative is leaving the peer's listener down for
-// the full rotation interval (default 1h) on a transient bind failure.
-func startNewBoxWithRetry(ctx context.Context, newBox boxService) error {
+// oldBox.Close releasing the port and newBox.Start re-binding it.
+// Inter-attempt backoff totals 750ms (50+100+200+400 across 4 sleeps;
+// no sleep after the final attempt) so a healthy rotation isn't
+// delayed noticeably; the alternative is leaving the peer's listener
+// down for the full rotation interval (default 1h) on a transient
+// bind failure.
+//
+// libbox.Start can panic; convert that to an error here rather than
+// letting it propagate. Without this, the recover in runRotation would
+// catch the panic but only after rotateCreds' cleanupNewRoute path
+// has been skipped — leaving the freshly-registered route orphaned
+// and the port unbound until next rotation. Returning the panic as
+// an error lets rotateCreds' deferred cleanup deregister the orphan.
+func startNewBoxWithRetry(ctx context.Context, newBox boxService) (retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			retErr = fmt.Errorf("start new sing-box panicked: %v", r)
+		}
+	}()
 	const attempts = 5
 	backoff := 50 * time.Millisecond
 	var lastErr error
@@ -678,6 +710,12 @@ func startNewBoxWithRetry(ctx context.Context, newBox boxService) error {
 			return nil
 		} else {
 			lastErr = err
+		}
+		// Skip the sleep on the final attempt — we won't try again,
+		// so the wait is pure latency that would push total backoff
+		// above the documented sub-1s budget.
+		if i == attempts-1 {
+			break
 		}
 		select {
 		case <-ctx.Done():

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -524,9 +524,21 @@ func (c *Client) runRotation(ctx context.Context) {
 // success: a fresh route_id and keypair are in use, the libbox inbound
 // has been rebuilt against the new options, the prior route is
 // deregistered server-side, and the FlutterEvent stream sees no gap.
-// On failure: the prior creds and box continue serving — rotation is
-// best-effort. The router-side port mapping is preserved across the
-// rotation; only the in-process samizdat state changes.
+//
+// On failure, behavior depends on where rotation aborted:
+//   - Before oldBox.Close (Register, options patch, BuildBoxService,
+//     stop-raced-rotation paths) — the prior box keeps serving with
+//     its existing creds; the newly-registered route (if any) is
+//     deregistered via cleanupNewRoute.
+//   - After oldBox.Close (startNewBoxWithRetry exhausts retries or
+//     panics) — the listener is down until the next rotation tick
+//     successfully rebinds. The router-side port mapping survives;
+//     only the in-process listener is gone. The new route is
+//     deregistered so the bandit doesn't hand its creds out for a
+//     non-listening port.
+//
+// In both cases the router-side port mapping is preserved; only the
+// in-process samizdat state changes.
 //
 // Sequence:
 //  1. Re-register with the same (externalIP, externalPort) as Start.

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -59,14 +59,15 @@ type Status struct {
 }
 
 // Config plumbs in dependencies. Zero-valued fields fall back to production
-// defaults; HeartbeatInterval and HeartbeatTimeout exist so tests can drive
-// the loop without sleeping a full minute.
+// defaults; HeartbeatInterval, HeartbeatTimeout, and CredRotationInterval
+// exist so tests can drive the loops without sleeping a full minute / hour.
 type Config struct {
-	API               *API
-	NewForwarder      func(ctx context.Context) (portForwarder, error)
-	BuildBoxService   boxFactory
-	HeartbeatInterval time.Duration
-	HeartbeatTimeout  time.Duration
+	API                  *API
+	NewForwarder         func(ctx context.Context) (portForwarder, error)
+	BuildBoxService      boxFactory
+	HeartbeatInterval    time.Duration
+	HeartbeatTimeout     time.Duration
+	CredRotationInterval time.Duration
 }
 
 // Client orchestrates one peer-proxy session: open UPnP port → register with
@@ -97,7 +98,37 @@ type Client struct {
 	forwarder portForwarder
 	box       boxService
 	routeID   string
+	// externalPort / internalPort persist the port mapping picked at
+	// Start so the cred-rotation loop can re-register against the same
+	// (address, port) tuple without re-probing UPnP / re-mapping. The
+	// router-side mapping itself stays put across rotations; only the
+	// samizdat creds and route_id rotate.
+	externalPort uint16
+	internalPort uint16
+	// boxOptions is the fresh options string passed to BuildBoxService,
+	// kept for diagnostics and so the rotation path doesn't need to
+	// re-derive it from the (also-stored) box reference.
+	boxOptions string
+	// runCtx is captured here for the cred-rotation goroutine to bind
+	// the new libbox lifetime to the same context as the original Start.
+	// Stop's cancelRun() teardown still applies to the rebuilt box.
+	runCtx context.Context
 }
+
+// peerCredRotationInterval bounds how long a leaked samizdat
+// credential remains usable. At each tick the peer re-registers with
+// lantern-cloud (new route_id, new keypair, new shortID), rebuilds the
+// libbox service against the new options, and deregisters the prior
+// route. Caps blast radius from credential leakage (logs, telemetry,
+// memory dumps, the H2 leakage path in engineering#3440) to ~1h
+// regardless of peer process lifetime.
+//
+// Cost per rotation: one API.Register + Deregister round trip, one
+// libbox build + start + close cycle. Brief (~hundreds-of-ms) port-
+// rebind window during the swap; samizdat clients see TCP RST and
+// reconnect via the bandit. Acceptable trade-off vs. holding the same
+// cred for the full peer process lifetime.
+const peerCredRotationInterval = 1 * time.Hour
 
 // peerCleanupTimeout caps how long Start's rollback path waits for
 // Deregister / UnmapPort. Cleanup uses a fresh Background context (not the
@@ -253,6 +284,10 @@ func (c *Client) Start(ctx context.Context) error {
 	c.forwarder = fwd
 	c.box = box
 	c.routeID = regResp.RouteID
+	c.externalPort = mapping.ExternalPort
+	c.internalPort = mapping.InternalPort
+	c.boxOptions = options
+	c.runCtx = runCtx
 	c.cancelRun = cancelRun
 	c.runDone = runDone
 	c.status = Status{
@@ -265,8 +300,14 @@ func (c *Client) Start(ctx context.Context) error {
 	statusSnapshot := c.status
 	c.mu.Unlock()
 
+	rotation := c.cfg.CredRotationInterval
+	if rotation == 0 {
+		rotation = peerCredRotationInterval
+	}
+
 	fwd.StartRenewal(runCtx)
 	go c.heartbeatLoop(runCtx, heartbeat, runDone)
+	go c.credRotationLoop(runCtx, rotation)
 
 	slog.Info("peer client started",
 		"external_ip", externalIP,
@@ -317,6 +358,10 @@ func (c *Client) Stop(ctx context.Context) error {
 	c.forwarder = nil
 	c.box = nil
 	c.routeID = ""
+	c.externalPort = 0
+	c.internalPort = 0
+	c.boxOptions = ""
+	c.runCtx = nil
 	c.status = Status{}
 	c.mu.Unlock()
 
@@ -406,6 +451,141 @@ func (c *Client) heartbeatLoop(ctx context.Context, interval time.Duration, done
 func isNotRegistered(err error) bool {
 	var apiErr *APIError
 	return errors.As(err, &apiErr) && apiErr.Status == 404
+}
+
+// credRotationLoop periodically rotates the peer's samizdat credentials
+// (X25519 keypair, shortID, masquerade) by re-registering with
+// lantern-cloud, rebuilding the libbox inbound, and deregistering the
+// prior route. Caps blast radius from credential leakage to ~interval
+// regardless of peer process lifetime — see peerCredRotationInterval.
+//
+// Closes done is the responsibility of heartbeatLoop; this loop just
+// exits when ctx is cancelled. We deliberately don't add another close
+// channel: heartbeatLoop's done already gates Stop, and rotation
+// failures are non-fatal (log + retry next tick), so there's nothing
+// the Stop path needs to wait on from this goroutine.
+func (c *Client) credRotationLoop(ctx context.Context, interval time.Duration) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := c.rotateCreds(ctx); err != nil {
+				// Don't kill the loop on a single failure — current
+				// box / route is still serving. Try again next tick.
+				slog.Warn("peer cred rotation failed; current creds remain in use", "err", err)
+			}
+		}
+	}
+}
+
+// rotateCreds atomically swaps the peer's samizdat credentials. On
+// success: a fresh route_id and keypair are in use, the libbox inbound
+// has been rebuilt against the new options, the prior route is
+// deregistered server-side, and the FlutterEvent stream sees no gap.
+// On failure: the prior creds and box continue serving — rotation is
+// best-effort. The router-side port mapping is preserved across the
+// rotation; only the in-process samizdat state changes.
+//
+// Sequence:
+//  1. Re-register with the same (externalIP, externalPort) as Start.
+//  2. Patch the new server-supplied options for VPN bypass.
+//  3. Build a new libbox service against the new options.
+//  4. Close the old box (releases the listening port).
+//  5. Start the new box (re-binds the same port, now with new creds).
+//  6. Atomic swap: c.box, c.routeID, c.boxOptions point at the new box.
+//  7. Best-effort deregister of the prior route_id so the bandit
+//     catalog stops handing the old (now-invalid) creds to clients.
+//
+// Steps 4-5 leave a brief (~hundreds of ms) window where the port
+// isn't bound; samizdat clients see TCP RST and reconnect. Acceptable
+// trade-off vs. the security cost of holding the same cred for the
+// peer process lifetime.
+func (c *Client) rotateCreds(ctx context.Context) error {
+	c.mu.Lock()
+	if !c.active {
+		c.mu.Unlock()
+		return errors.New("not active")
+	}
+	fwd := c.forwarder
+	extPort := c.externalPort
+	intPort := c.internalPort
+	oldRouteID := c.routeID
+	oldBox := c.box
+	c.mu.Unlock()
+
+	if fwd == nil || oldBox == nil {
+		return errors.New("rotateCreds: client state inconsistent")
+	}
+
+	externalIP, err := fwd.ExternalIP(ctx)
+	if err != nil {
+		return fmt.Errorf("get external ip: %w", err)
+	}
+	regResp, err := c.cfg.API.Register(ctx, RegisterRequest{
+		ExternalIP:   externalIP,
+		ExternalPort: extPort,
+		InternalPort: intPort,
+	})
+	if err != nil {
+		return fmt.Errorf("re-register: %w", err)
+	}
+	options, err := ensurePeerOutboundsBypassVPN(regResp.ServerConfig)
+	if err != nil {
+		return fmt.Errorf("patch sing-box options: %w", err)
+	}
+
+	c.mu.Lock()
+	runCtx := c.runCtx
+	c.mu.Unlock()
+	if runCtx == nil {
+		// Stop happened between the unlock above and here. Skip the
+		// build to avoid spinning up a libbox tied to a torn-down ctx.
+		// The new register row is harmless — server-side reaper will
+		// deprecate it after TTL since no heartbeat will arrive.
+		return errors.New("client stopped during rotation")
+	}
+	newBox, err := c.cfg.BuildBoxService(runCtx, options)
+	if err != nil {
+		return fmt.Errorf("build new sing-box: %w", err)
+	}
+
+	// Close old, start new. Order matters — both want the same port.
+	// If newBox.Start fails after oldBox.Close, we lost the listener
+	// and the next heartbeat / rotation tick is the recovery point.
+	if closeErr := oldBox.Close(); closeErr != nil {
+		slog.Warn("close old box during rotation", "err", closeErr)
+	}
+	if err := newBox.Start(); err != nil {
+		// Catastrophic: port is now unbound. Leave c.box pointing at
+		// oldBox so a future Stop tries to close it (idempotent on
+		// already-closed); the next rotation tick will try again.
+		return fmt.Errorf("start new sing-box: %w", err)
+	}
+
+	c.mu.Lock()
+	c.box = newBox
+	c.routeID = regResp.RouteID
+	c.boxOptions = options
+	c.status.RouteID = regResp.RouteID
+	c.mu.Unlock()
+
+	// Deregister the prior route so the bandit stops handing the old
+	// (now-invalid) creds to clients. Best-effort: the prior row will
+	// expire from its TTL anyway, but explicit deregister cuts the
+	// stale-creds window from up-to-TTL down to ~immediately.
+	if err := c.cfg.API.Deregister(ctx, oldRouteID); err != nil {
+		slog.Warn("deregister prior route after rotation",
+			"err", err, "old_route_id", oldRouteID)
+	}
+
+	slog.Info("peer cred rotation succeeded",
+		"new_route_id", regResp.RouteID,
+		"old_route_id", oldRouteID,
+	)
+	return nil
 }
 
 // ensurePeerOutboundsBypassVPN guarantees the peer sing-box's outbound dials

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand/v2"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -430,6 +431,20 @@ func (c *Client) heartbeatLoop(ctx context.Context, interval time.Duration, done
 				// later heartbeat as a 404.
 				slog.Warn("peer heartbeat failed", "err", err, "route_id", routeID)
 				if isNotRegistered(err) {
+					// Re-check current routeID under lock. If credRotationLoop
+					// swapped routeID + deregistered the prior route between
+					// our heartbeat-prepare and heartbeat-response, the 404
+					// applies to a stale route and is expected, not a reason
+					// to stop. Skip the auto-Stop and let the next tick
+					// heartbeat the new route.
+					c.mu.Lock()
+					currentRouteID := c.routeID
+					c.mu.Unlock()
+					if currentRouteID != routeID {
+						slog.Info("peer heartbeat 404 on stale route_id; rotation in flight, continuing",
+							"stale_route_id", routeID, "current_route_id", currentRouteID)
+						continue
+					}
 					slog.Info("peer route no longer registered server-side, stopping client")
 					// Stop runs in a separate goroutine to avoid the cyclic
 					// Stop → cancelRun → loop-exit deadlock.
@@ -465,6 +480,14 @@ func isNotRegistered(err error) bool {
 // failures are non-fatal (log + retry next tick), so there's nothing
 // the Stop path needs to wait on from this goroutine.
 func (c *Client) credRotationLoop(ctx context.Context, interval time.Duration) {
+	// Non-positive interval would panic time.NewTicker. Treat it the same
+	// as the zero case Start handles when CredRotationInterval is unset:
+	// fall back to the default cap rather than disabling rotation
+	// silently (an unset value still wants rotation; a negative value is
+	// almost certainly a test/config bug).
+	if interval <= 0 {
+		interval = peerCredRotationInterval
+	}
 	t := time.NewTicker(interval)
 	defer t.Stop()
 	for {
@@ -472,12 +495,28 @@ func (c *Client) credRotationLoop(ctx context.Context, interval time.Duration) {
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			if err := c.rotateCreds(ctx); err != nil {
-				// Don't kill the loop on a single failure — current
-				// box / route is still serving. Try again next tick.
-				slog.Warn("peer cred rotation failed; current creds remain in use", "err", err)
-			}
+			c.runRotation(ctx)
 		}
+	}
+}
+
+// runRotation wraps rotateCreds with a panic recover. libbox.Start can
+// panic (see the recover in vpn/tunnel.go's tunnel-start path); an
+// unrecovered panic here would crash the host process during a
+// background rotation, taking the user's main VPN with it. Treat a
+// panic the same as any other rotation failure: log, keep the existing
+// box serving, try again next tick.
+func (c *Client) runRotation(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("peer cred rotation panicked; current creds remain in use",
+				"panic", r, "stack", string(debug.Stack()))
+		}
+	}()
+	if err := c.rotateCreds(ctx); err != nil {
+		// Don't kill the loop on a single failure — current
+		// box / route is still serving. Try again next tick.
+		slog.Warn("peer cred rotation failed; current creds remain in use", "err", err)
 	}
 }
 
@@ -532,8 +571,24 @@ func (c *Client) rotateCreds(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("re-register: %w", err)
 	}
+	// From here on, any error path must deregister regResp.RouteID —
+	// otherwise the newly-created server-side row leaks until TTL expiry
+	// and the bandit catalog may briefly hand out creds for a route
+	// whose box never came up.
+	cleanupNewRoute := func(reason error) {
+		// Use a fresh ctx so a cancelled rotation ctx doesn't skip the
+		// cleanup we just made necessary.
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), peerCleanupTimeout)
+		defer cancel()
+		if dErr := c.cfg.API.Deregister(cleanupCtx, regResp.RouteID); dErr != nil {
+			slog.Warn("deregister orphan route after rotation failure",
+				"reason", reason, "err", dErr, "orphan_route_id", regResp.RouteID)
+		}
+	}
+
 	options, err := ensurePeerOutboundsBypassVPN(regResp.ServerConfig)
 	if err != nil {
+		cleanupNewRoute(err)
 		return fmt.Errorf("patch sing-box options: %w", err)
 	}
 
@@ -542,34 +597,54 @@ func (c *Client) rotateCreds(ctx context.Context) error {
 	c.mu.Unlock()
 	if runCtx == nil {
 		// Stop happened between the unlock above and here. Skip the
-		// build to avoid spinning up a libbox tied to a torn-down ctx.
-		// The new register row is harmless — server-side reaper will
-		// deprecate it after TTL since no heartbeat will arrive.
+		// build to avoid spinning up a libbox tied to a torn-down ctx,
+		// and clean up the just-created route so it doesn't linger.
+		cleanupNewRoute(errors.New("client stopped during rotation"))
 		return errors.New("client stopped during rotation")
 	}
 	newBox, err := c.cfg.BuildBoxService(runCtx, options)
 	if err != nil {
+		cleanupNewRoute(err)
 		return fmt.Errorf("build new sing-box: %w", err)
 	}
 
 	// Close old, start new. Order matters — both want the same port.
-	// If newBox.Start fails after oldBox.Close, we lost the listener
-	// and the next heartbeat / rotation tick is the recovery point.
+	// If newBox.Start fails after oldBox.Close, retry briefly to absorb
+	// router-side TIME_WAIT / EADDRINUSE windows before giving up.
 	if closeErr := oldBox.Close(); closeErr != nil {
 		slog.Warn("close old box during rotation", "err", closeErr)
 	}
-	if err := newBox.Start(); err != nil {
+	if err := startNewBoxWithRetry(ctx, newBox); err != nil {
 		// Catastrophic: port is now unbound. Leave c.box pointing at
 		// oldBox so a future Stop tries to close it (idempotent on
-		// already-closed); the next rotation tick will try again.
+		// already-closed); the next rotation tick will try again. Also
+		// deregister the now-orphan new route so the bandit doesn't
+		// hand its creds out for a non-listening port.
+		cleanupNewRoute(err)
 		return fmt.Errorf("start new sing-box: %w", err)
 	}
 
+	// Final swap under lock. Re-check active so a Stop racing us between
+	// runCtx-check above and now doesn't get resurrected by overwriting
+	// the cleared state Stop just set up.
 	c.mu.Lock()
+	if !c.active {
+		c.mu.Unlock()
+		// Stop already cleared c.box / c.routeID. Close the new box we
+		// just brought up (Stop has no reference to it) and deregister
+		// the new route. The old route Stop already deregistered as
+		// part of its own teardown.
+		if err := newBox.Close(); err != nil {
+			slog.Warn("close new box after Stop raced rotation", "err", err)
+		}
+		cleanupNewRoute(errors.New("client stopped during rotation swap"))
+		return errors.New("client stopped during rotation")
+	}
 	c.box = newBox
 	c.routeID = regResp.RouteID
 	c.boxOptions = options
 	c.status.RouteID = regResp.RouteID
+	c.status.ExternalIP = externalIP
 	c.mu.Unlock()
 
 	// Deregister the prior route so the bandit stops handing the old
@@ -586,6 +661,32 @@ func (c *Client) rotateCreds(ctx context.Context) error {
 		"old_route_id", oldRouteID,
 	)
 	return nil
+}
+
+// startNewBoxWithRetry retries newBox.Start a handful of times with a
+// short backoff to absorb router-side TIME_WAIT / EADDRINUSE between
+// oldBox.Close releasing the port and newBox.Start re-binding it. Total
+// wait is bounded under 1s so a healthy rotation isn't delayed
+// noticeably; the alternative is leaving the peer's listener down for
+// the full rotation interval (default 1h) on a transient bind failure.
+func startNewBoxWithRetry(ctx context.Context, newBox boxService) error {
+	const attempts = 5
+	backoff := 50 * time.Millisecond
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		if err := newBox.Start(); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("start new sing-box (ctx cancelled after %d attempts): %w", i+1, lastErr)
+		case <-time.After(backoff):
+		}
+		backoff *= 2
+	}
+	return fmt.Errorf("start new sing-box (%d attempts): %w", attempts, lastErr)
 }
 
 // ensurePeerOutboundsBypassVPN guarantees the peer sing-box's outbound dials

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -139,6 +140,10 @@ type stubServer struct {
 	server             *httptest.Server
 	registerStatus     int
 	registerResp       RegisterResponse
+	// registerRespFn lets a test return a different response per
+	// register call (e.g. cred-rotation tests need a fresh route_id
+	// each time). When non-nil, takes precedence over registerResp.
+	registerRespFn     func() RegisterResponse
 	heartbeatStatus    int
 	deregisterStatus   int
 	registerCount      atomic.Int64
@@ -174,7 +179,11 @@ func newStubServer(t *testing.T) *stubServer {
 			http.Error(w, "register failed", s.registerStatus)
 			return
 		}
-		_ = json.NewEncoder(w).Encode(s.registerResp)
+		resp := s.registerResp
+		if s.registerRespFn != nil {
+			resp = s.registerRespFn()
+		}
+		_ = json.NewEncoder(w).Encode(resp)
 	})
 	mux.HandleFunc("/v1/peer/heartbeat", func(w http.ResponseWriter, r *http.Request) {
 		s.heartbeatCount.Add(1)
@@ -507,6 +516,90 @@ func TestAPIError_StringFormat(t *testing.T) {
 	e := &APIError{Status: 422, Body: "could not connect to peer port"}
 	assert.Contains(t, e.Error(), "422")
 	assert.Contains(t, e.Error(), "could not connect")
+}
+
+// TestClient_RotatesCredentialsAtInterval pins the C2 fix from
+// engineering#3437: the peer client must re-register and rebuild its
+// libbox inbound on a schedule so a leaked credential's blast radius is
+// bounded by CredRotationInterval rather than peer process lifetime.
+//
+// Drives a short rotation interval (50ms) and asserts:
+//   1. Multiple registers happen (start + ≥2 rotations within 250ms).
+//   2. Each rotation deregisters the prior route_id.
+//   3. The peer's exposed RouteID changes — clients freshly assigned
+//      after a rotation see the new ID; the bandit catalog stops
+//      handing out the old one once Deregister lands.
+//   4. Multiple distinct boxes were built (the rotation actually
+//      rebuilt libbox; not just a no-op).
+//   5. The first box was closed (the old listener released its port).
+func TestClient_RotatesCredentialsAtInterval(t *testing.T) {
+	fwd := &fakeForwarder{externalIP: "203.0.113.42"}
+	srv := newStubServer(t)
+
+	// Each rotation needs a register response with a distinct
+	// route_id so we can verify the swap actually changed identifiers
+	// rather than re-registering the same id.
+	var registerSeq atomic.Int64
+	srv.registerRespFn = func() RegisterResponse {
+		n := registerSeq.Add(1)
+		return RegisterResponse{
+			RouteID:                  fmt.Sprintf("00000000-0000-0000-0000-00000000000%d", n),
+			ServerConfig:             `{"inbounds": [{"type":"samizdat","tag":"samizdat-in"}]}`,
+			HeartbeatIntervalSeconds: 60,
+		}
+	}
+
+	// Each BuildBoxService call gets a fresh fakeBoxService so we can
+	// see how many boxes were built and which ones got closed.
+	var (
+		boxesMu sync.Mutex
+		boxes   []*fakeBoxService
+	)
+	c := newTestClient(t, fwd, &fakeBoxService{}, srv, func(cfg *Config) {
+		cfg.CredRotationInterval = 50 * time.Millisecond
+		// Long heartbeat so heartbeat ticks don't compete with the
+		// register/deregister counters that we're asserting on.
+		cfg.HeartbeatInterval = time.Hour
+		cfg.BuildBoxService = func(_ context.Context, options string) (boxService, error) {
+			b := &fakeBoxService{gotConfig: options}
+			boxesMu.Lock()
+			boxes = append(boxes, b)
+			boxesMu.Unlock()
+			return b, nil
+		}
+	})
+
+	require.NoError(t, c.Start(context.Background()))
+	t.Cleanup(func() { _ = c.Stop(context.Background()) })
+
+	// Wait for at least 2 rotations on top of the initial register.
+	require.Eventually(t, func() bool {
+		return srv.registerCount.Load() >= 3
+	}, 1*time.Second, 25*time.Millisecond,
+		"expected ≥3 registers (initial + 2 rotations) within 1s; got %d",
+		srv.registerCount.Load())
+
+	// Each rotation deregisters the prior route — N rotations =>
+	// N deregisters (initial register is not preceded by one).
+	rotations := srv.registerCount.Load() - 1
+	assert.GreaterOrEqual(t, srv.deregisterCount.Load(), rotations-1,
+		"each rotation should deregister the prior route_id (got %d deregs vs %d rotations)",
+		srv.deregisterCount.Load(), rotations)
+
+	// RouteID exposed via Status should reflect the latest rotation.
+	c.mu.Lock()
+	currentRouteID := c.routeID
+	c.mu.Unlock()
+	assert.NotEqual(t, "00000000-0000-0000-0000-000000000001", currentRouteID,
+		"current route_id should have advanced past the initial register")
+
+	// Multiple boxes built; first one closed.
+	boxesMu.Lock()
+	defer boxesMu.Unlock()
+	require.GreaterOrEqual(t, len(boxes), 2,
+		"expected ≥2 libbox builds (initial + ≥1 rotation)")
+	assert.True(t, boxes[0].closed.Load(),
+		"first box should be closed by the first rotation")
 }
 
 // Subscribers (the IPC SSE handler in production) need both edges so the UI

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -647,9 +647,15 @@ func TestClient_RotatesCredentialsAtInterval(t *testing.T) {
 		srv.registerCount.Load())
 
 	// Each rotation deregisters the prior route — N rotations =>
-	// N deregisters (initial register is not preceded by one).
+	// N deregisters (initial register is not preceded by one). Wait
+	// briefly for the deregister to catch up to the most recent
+	// rotation; rotation issues the deregister after the swap-lock
+	// completes, so there's a small race window between observing the
+	// new register and the corresponding deregister landing.
 	rotations := srv.registerCount.Load() - 1
-	assert.GreaterOrEqual(t, srv.deregisterCount.Load(), rotations-1,
+	require.Eventually(t, func() bool {
+		return srv.deregisterCount.Load() >= rotations
+	}, 500*time.Millisecond, 25*time.Millisecond,
 		"each rotation should deregister the prior route_id (got %d deregs vs %d rotations)",
 		srv.deregisterCount.Load(), rotations)
 

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -660,10 +660,11 @@ func TestClient_RotatesCredentialsAtInterval(t *testing.T) {
 		srv.deregisterCount.Load(), rotations)
 
 	// RouteID exposed via Status should reflect the latest rotation.
-	c.mu.Lock()
-	currentRouteID := c.routeID
-	c.mu.Unlock()
-	assert.NotEqual(t, "00000000-0000-0000-0000-000000000001", currentRouteID,
+	// Asserting against CurrentStatus() rather than the internal field
+	// pins the observable contract: a future change that updates the
+	// route used by heartbeats but forgets to mirror it into
+	// Status.RouteID would fail this assertion.
+	assert.NotEqual(t, "00000000-0000-0000-0000-000000000001", c.CurrentStatus().RouteID,
 		"current route_id should have advanced past the initial register")
 
 	// Multiple boxes built; first one closed.

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -585,10 +585,10 @@ func TestAPIError_StringFormat(t *testing.T) {
 	assert.Contains(t, e.Error(), "could not connect")
 }
 
-// TestClient_RotatesCredentialsAtInterval pins the C2 fix from
-// engineering#3437: the peer client must re-register and rebuild its
-// libbox inbound on a schedule so a leaked credential's blast radius is
-// bounded by CredRotationInterval rather than peer process lifetime.
+// TestClient_RotatesCredentialsAtInterval pins the rotation invariant:
+// the peer client must re-register and rebuild its libbox inbound on
+// a schedule so a leaked credential's blast radius is bounded by
+// CredRotationInterval rather than peer process lifetime.
 //
 // Drives a short rotation interval (50ms) and asserts:
 //   1. Multiple registers happen (start + ≥2 rotations within 250ms).

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -139,6 +140,10 @@ type stubServer struct {
 	server             *httptest.Server
 	registerStatus     int
 	registerResp       RegisterResponse
+	// registerRespFn lets a test return a different response per
+	// register call (e.g. cred-rotation tests need a fresh route_id
+	// each time). When non-nil, takes precedence over registerResp.
+	registerRespFn     func() RegisterResponse
 	heartbeatStatus    int
 	deregisterStatus   int
 	registerCount      atomic.Int64
@@ -174,7 +179,11 @@ func newStubServer(t *testing.T) *stubServer {
 			http.Error(w, "register failed", s.registerStatus)
 			return
 		}
-		_ = json.NewEncoder(w).Encode(s.registerResp)
+		resp := s.registerResp
+		if s.registerRespFn != nil {
+			resp = s.registerRespFn()
+		}
+		_ = json.NewEncoder(w).Encode(resp)
 	})
 	mux.HandleFunc("/v1/peer/heartbeat", func(w http.ResponseWriter, r *http.Request) {
 		s.heartbeatCount.Add(1)
@@ -574,6 +583,90 @@ func TestAPIError_StringFormat(t *testing.T) {
 	e := &APIError{Status: 422, Body: "could not connect to peer port"}
 	assert.Contains(t, e.Error(), "422")
 	assert.Contains(t, e.Error(), "could not connect")
+}
+
+// TestClient_RotatesCredentialsAtInterval pins the C2 fix from
+// engineering#3437: the peer client must re-register and rebuild its
+// libbox inbound on a schedule so a leaked credential's blast radius is
+// bounded by CredRotationInterval rather than peer process lifetime.
+//
+// Drives a short rotation interval (50ms) and asserts:
+//   1. Multiple registers happen (start + ≥2 rotations within 250ms).
+//   2. Each rotation deregisters the prior route_id.
+//   3. The peer's exposed RouteID changes — clients freshly assigned
+//      after a rotation see the new ID; the bandit catalog stops
+//      handing out the old one once Deregister lands.
+//   4. Multiple distinct boxes were built (the rotation actually
+//      rebuilt libbox; not just a no-op).
+//   5. The first box was closed (the old listener released its port).
+func TestClient_RotatesCredentialsAtInterval(t *testing.T) {
+	fwd := &fakeForwarder{externalIP: "203.0.113.42"}
+	srv := newStubServer(t)
+
+	// Each rotation needs a register response with a distinct
+	// route_id so we can verify the swap actually changed identifiers
+	// rather than re-registering the same id.
+	var registerSeq atomic.Int64
+	srv.registerRespFn = func() RegisterResponse {
+		n := registerSeq.Add(1)
+		return RegisterResponse{
+			RouteID:                  fmt.Sprintf("00000000-0000-0000-0000-00000000000%d", n),
+			ServerConfig:             `{"inbounds": [{"type":"samizdat","tag":"samizdat-in"}]}`,
+			HeartbeatIntervalSeconds: 60,
+		}
+	}
+
+	// Each BuildBoxService call gets a fresh fakeBoxService so we can
+	// see how many boxes were built and which ones got closed.
+	var (
+		boxesMu sync.Mutex
+		boxes   []*fakeBoxService
+	)
+	c := newTestClient(t, fwd, &fakeBoxService{}, srv, func(cfg *Config) {
+		cfg.CredRotationInterval = 50 * time.Millisecond
+		// Long heartbeat so heartbeat ticks don't compete with the
+		// register/deregister counters that we're asserting on.
+		cfg.HeartbeatInterval = time.Hour
+		cfg.BuildBoxService = func(_ context.Context, options string) (boxService, error) {
+			b := &fakeBoxService{gotConfig: options}
+			boxesMu.Lock()
+			boxes = append(boxes, b)
+			boxesMu.Unlock()
+			return b, nil
+		}
+	})
+
+	require.NoError(t, c.Start(context.Background()))
+	t.Cleanup(func() { _ = c.Stop(context.Background()) })
+
+	// Wait for at least 2 rotations on top of the initial register.
+	require.Eventually(t, func() bool {
+		return srv.registerCount.Load() >= 3
+	}, 1*time.Second, 25*time.Millisecond,
+		"expected ≥3 registers (initial + 2 rotations) within 1s; got %d",
+		srv.registerCount.Load())
+
+	// Each rotation deregisters the prior route — N rotations =>
+	// N deregisters (initial register is not preceded by one).
+	rotations := srv.registerCount.Load() - 1
+	assert.GreaterOrEqual(t, srv.deregisterCount.Load(), rotations-1,
+		"each rotation should deregister the prior route_id (got %d deregs vs %d rotations)",
+		srv.deregisterCount.Load(), rotations)
+
+	// RouteID exposed via Status should reflect the latest rotation.
+	c.mu.Lock()
+	currentRouteID := c.routeID
+	c.mu.Unlock()
+	assert.NotEqual(t, "00000000-0000-0000-0000-000000000001", currentRouteID,
+		"current route_id should have advanced past the initial register")
+
+	// Multiple boxes built; first one closed.
+	boxesMu.Lock()
+	defer boxesMu.Unlock()
+	require.GreaterOrEqual(t, len(boxes), 2,
+		"expected ≥2 libbox builds (initial + ≥1 rotation)")
+	assert.True(t, boxes[0].closed.Load(),
+		"first box should be closed by the first rotation")
 }
 
 // Subscribers (the IPC SSE handler in production) need both edges so the UI


### PR DESCRIPTION
## Summary

Closes the C2 finding from the Share My Connection security review (engineering#3437): peer.Client builds the libbox inbound exactly once per Start and holds the same samizdat creds for the entire peer process lifetime, so a leaked credential remains usable for hours or days.

This adds a \`credRotationLoop\` goroutine on a 1h tick that re-registers, rebuilds the libbox inbound with fresh creds, and deregisters the prior route. Caps blast radius from credential leakage to ~1h regardless of how long the peer has been running.

## Sequence per rotation

1. Re-register with lantern-cloud against the same (address, port) tuple — same router-side mapping, fresh server-side row, fresh samizdat creds
2. Patch the new options for VPN bypass
3. Build a new libbox service
4. Close the old box (releases the listening port)
5. Start the new box (re-binds the same port with new creds)
6. Atomic swap of \`c.box\`, \`c.routeID\`
7. Best-effort deregister of the prior route_id so the bandit stops handing the old (now-invalid) creds to clients within ~immediately rather than waiting up-to-TTL for the row to expire

Steps 4-5 leave a brief (~hundreds of ms) window where the port is unbound; samizdat clients see TCP RST and reconnect via the bandit. Acceptable trade-off vs. the security cost of indefinite cred lifetime.

## Failure handling

Rotation is best-effort. A single failure (transient register error, network blip) logs and waits for the next tick. The current box and creds remain serving in the failure case so a one-off transient doesn't kill the session.

## Test plan

- [x] \`TestClient_RotatesCredentialsAtInterval\`: drives a 50ms rotation interval and asserts ≥3 registers within 1s, deregister count tracks rotations, route_id advances past the initial value, multiple distinct boxes built, first box closed
- [x] All existing peer tests pass under \`-race\`
- [ ] CI

## Related

Part of the Share My Connection security review series:
- ✅ engineering#3436 / lantern-cloud#2705 — egress filter (C1)
- ✅ engineering#3437 (this PR) — cred rotation (C2)
- 🔜 engineering#3438 — abuse-feedback path (C3)
- 🔜 H1-H4 + M3 — follow-ups

🤖 Generated with [Claude Code](https://claude.com/claude-code)