### PR TITLE
peer: in-memory abuse aggregator + periodic summary on the events bus (C3a)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,11 @@ module github.com/getlantern/radiance
 
 go 1.26.2
 
+// Local while peerconn Event-typed listener is in flight; remove once
+// lantern-box tags a release that includes the abuse-instrumentation
+// signature change.
+replace github.com/getlantern/lantern-box => ../lantern-box
+
 replace github.com/sagernet/sing => github.com/getlantern/sing v0.7.18-lantern
 
 replace github.com/sagernet/sing-box => github.com/getlantern/sing-box-minimal v1.12.22-lantern
@@ -113,7 +118,7 @@ require (
 	github.com/gaissmai/bart v0.11.1 // indirect
 	github.com/gaukas/wazerofs v0.1.0 // indirect
 	github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52 // indirect
-	github.com/getlantern/broflake v0.0.0-20260501210609-ce5f75aa2054 // indirect
+	github.com/getlantern/broflake v0.0.0-20260504215251-ed3cf75062d1 // indirect
 	github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90 // indirect
 	github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 // indirect
 	github.com/go-chi/chi/v5 v5.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52 h1:w2/RqYPw7Pb
 github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52/go.mod h1:PrNR8tMXO26YNs8K9653XCUH7u2Kv4OdfFC3Ke1GsX0=
 github.com/getlantern/amp v0.0.0-20260305201851-782bc8045e58 h1:3wxMKw90adxiEzsJmAmMHqBJQr/P/9Goqy/U2a1l/sg=
 github.com/getlantern/amp v0.0.0-20260305201851-782bc8045e58/go.mod h1:p6WdG48YAz5SCUpiMSGLy616A6YghKToc63y3NP7avI=
-github.com/getlantern/broflake v0.0.0-20260501210609-ce5f75aa2054 h1:nrRMiRRjzR43yihrVxdnmmt66ZqjRhHE73TyHW1ySgg=
-github.com/getlantern/broflake v0.0.0-20260501210609-ce5f75aa2054/go.mod h1:bZGGfTwne9NIsy3Kc1avcXNWn/yA8ghUwlXdS2z+AlA=
+github.com/getlantern/broflake v0.0.0-20260504215251-ed3cf75062d1 h1:3WYvObOo8gpKwjcLrV6O/vRp+ubKdjpvJwZrRkbbDWw=
+github.com/getlantern/broflake v0.0.0-20260504215251-ed3cf75062d1/go.mod h1:bZGGfTwne9NIsy3Kc1avcXNWn/yA8ghUwlXdS2z+AlA=
 github.com/getlantern/common v1.2.1-0.20260326210434-cb69537aaf46 h1:Ab2esudqgFz2K1WYQKtX+58kaiVMX0UohjW2XmdEgf4=
 github.com/getlantern/common v1.2.1-0.20260326210434-cb69537aaf46/go.mod h1:eSSuV4bMPgQJnczBw+KWWqWNo1itzmVxC++qUBPRTt0=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
@@ -248,8 +248,6 @@ github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694 h1:iLWm6S/4
 github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260428171407-6143132aaf40 h1:P5pkaBGxWOGBn7bKzjzdln/ro+ShG1RUbOuy+7pSzXE=
 github.com/getlantern/kindling v0.0.0-20260428171407-6143132aaf40/go.mod h1:TGTxpoNVwc8Be4qkBNtf5oj2psJaEIZEq47GOPS7zkA=
-github.com/getlantern/lantern-box v0.0.77 h1:2b2TyrPXYHzIx1aPUvpE//AxoW0TMl/EF/bQHaZyfqw=
-github.com/getlantern/lantern-box v0.0.77/go.mod h1:YV6+5bOdvw9rmc0cJoOTP7UaFt/6XWVOierv7KcfAkY=
 github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90 h1:P9JX1yAu2uq3b5YiT0sLtHkTrkZuttV8gPZh81nUuag=
 github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90/go.mod h1:3JpJgwi4KEI6rS9loOAvcBp+F2jP65d0tTg2GQcTPBU=
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 h1:3BwvWj0JZzFEvNNiMhCu4bf60nqcIuQpTYb00Ezm1ag=

--- a/peer/abuse.go
+++ b/peer/abuse.go
@@ -1,0 +1,225 @@
+package peer
+
+import (
+	"context"
+	"net"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/getlantern/radiance/events"
+)
+
+// AbuseSummaryEvent fires periodically (every flush interval) carrying a
+// snapshot of recent peer-share connection activity bucketed by source
+// IP and destination port-class. It's the input that downstream consumers
+// (lantern-cloud abuse aggregator, Flutter "your peer is being used for
+// X" diagnostic, future bandit blocklist) reason over.
+//
+// Why per-source AND per-port-class:
+//
+//   - source distinguishes one client from another for client-level
+//     blocklist decisions (one client doing 99% of the spam attempts
+//     should get cut off, the other clients should not).
+//   - port class lets the consumer reason about TYPE of activity
+//     without per-destination granularity, which would be both very
+//     noisy (long tail of HTTPS destinations) and privacy-sensitive
+//     (the destination list is the user's browsing history of the
+//     people using their connection).
+//
+// We deliberately do NOT carry full destination hostnames in the
+// summary — only the port-class bucket and a count. The destination
+// tail is the highest privacy-cost piece and the lowest abuse-
+// detection value piece.
+type AbuseSummaryEvent struct {
+	events.Event
+	// Window the summary covers, [Start, End].
+	WindowStart time.Time `json:"window_start"`
+	WindowEnd   time.Time `json:"window_end"`
+	// Sources is keyed by the connecting client's "ip:port" with the
+	// port stripped (so multiple connections from the same client IP
+	// roll up). Counts are connections accepted in the window (not
+	// "currently active").
+	Sources []SourceBucket `json:"sources"`
+}
+
+// SourceBucket aggregates a single source IP's activity within a
+// summary window. PortClassCounts maps a port-class label
+// (smtp/irc/https/http/dns/other) to the number of accepted
+// connections to destinations in that class.
+type SourceBucket struct {
+	SourceIP        string         `json:"source_ip"`
+	TotalAccepts    int            `json:"total_accepts"`
+	PortClassCounts map[string]int `json:"port_class_counts"`
+}
+
+// abuseAggregator buckets per-(source, port-class) within a rolling
+// window. Single-active per peer.Client; the lifecycle is bound to the
+// client's runCtx (Start/Stop create + tear it down).
+type abuseAggregator struct {
+	mu            sync.Mutex
+	windowStart   time.Time
+	bySource      map[string]*srcStats // keyed by source IP (no port)
+	flushInterval time.Duration
+}
+
+type srcStats struct {
+	totalAccepts    int
+	portClassCounts map[string]int
+}
+
+func newAbuseAggregator(flushInterval time.Duration) *abuseAggregator {
+	if flushInterval <= 0 {
+		flushInterval = 5 * time.Minute
+	}
+	return &abuseAggregator{
+		windowStart:   time.Now(),
+		bySource:      make(map[string]*srcStats),
+		flushInterval: flushInterval,
+	}
+}
+
+// note records one accept event. Cheap (one map lookup, one increment);
+// safe to call from the lantern-box peerconn listener path which fires
+// synchronously on the inbound's accept loop.
+func (a *abuseAggregator) note(source, destination string) {
+	if source == "" {
+		return
+	}
+	srcIP := stripPort(source)
+	if srcIP == "" {
+		return
+	}
+	class := classifyPort(destination)
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	s, ok := a.bySource[srcIP]
+	if !ok {
+		s = &srcStats{portClassCounts: make(map[string]int)}
+		a.bySource[srcIP] = s
+	}
+	s.totalAccepts++
+	s.portClassCounts[class]++
+}
+
+// flush returns the current window's contents and rolls the window
+// forward. Returns nil if no activity was observed in the window
+// (avoid emitting empty summaries that just clutter the event stream).
+func (a *abuseAggregator) flush() *AbuseSummaryEvent {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.bySource) == 0 {
+		// Roll the window even on empty so the start timestamp doesn't
+		// drift backwards relative to clock progress.
+		a.windowStart = time.Now()
+		return nil
+	}
+	now := time.Now()
+	evt := &AbuseSummaryEvent{
+		WindowStart: a.windowStart,
+		WindowEnd:   now,
+		Sources:     make([]SourceBucket, 0, len(a.bySource)),
+	}
+	for srcIP, stats := range a.bySource {
+		evt.Sources = append(evt.Sources, SourceBucket{
+			SourceIP:        srcIP,
+			TotalAccepts:    stats.totalAccepts,
+			PortClassCounts: stats.portClassCounts,
+		})
+	}
+	// Stable order so the same window content always serializes the
+	// same way — easier to diff in tests, easier to read in logs.
+	sort.Slice(evt.Sources, func(i, j int) bool {
+		return evt.Sources[i].SourceIP < evt.Sources[j].SourceIP
+	})
+	a.bySource = make(map[string]*srcStats)
+	a.windowStart = now
+	return evt
+}
+
+// runFlushLoop periodically drains the window and emits an
+// AbuseSummaryEvent on the radiance event bus. Returns when ctx is
+// cancelled (called from peer.Client.Start, ctx is the same runCtx
+// that gates the heartbeat / cred-rotation goroutines).
+func (a *abuseAggregator) runFlushLoop(ctx context.Context) {
+	t := time.NewTicker(a.flushInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			// One final flush so the last window's data isn't lost on
+			// graceful shutdown — useful when Stop runs right after a
+			// burst of connections during a peer rotation, etc.
+			if evt := a.flush(); evt != nil {
+				events.Emit(*evt)
+			}
+			return
+		case <-t.C:
+			if evt := a.flush(); evt != nil {
+				events.Emit(*evt)
+			}
+		}
+	}
+}
+
+// stripPort returns the host portion of an "ip:port" string, or the
+// input unchanged if it doesn't parse cleanly. Supports IPv6 bracketed
+// hosts ("[::1]:443" → "::1"). Empty in/out means "no signal".
+func stripPort(addr string) string {
+	if addr == "" {
+		return ""
+	}
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr // best-effort: surface what we got
+	}
+	return host
+}
+
+// classifyPort maps a "host:port" destination to a coarse abuse-relevant
+// port-class label. Designed to be tiny on purpose — finer buckets
+// would leak the destination tail, which is what we're trying NOT to
+// log. The classes:
+//
+//   smtp  — SMTP / submission / SMTPS (25, 465, 587, 2525). Spam relays.
+//   irc   — IRC / IRCS (6660-6669, 6697). Botnet C2.
+//   https — 443 / 8443. Bulk legitimate traffic, also credential stuffing.
+//   http  — 80 / 8080 / 8000. Bulk legitimate, also some scraping.
+//   dns   — 53 / 853. Mostly legit; flagged because a client doing many
+//           DNS resolutions through a peer is unusual and could indicate
+//           DNS tunneling.
+//   other — everything else. Volume here is normally near zero on a
+//           samizdat peer; spikes suggest something protocol-specific.
+func classifyPort(destination string) string {
+	if destination == "" {
+		return "other"
+	}
+	_, portStr, err := net.SplitHostPort(destination)
+	if err != nil {
+		// Sometimes "destination" is a hostname without a port; rare
+		// but possible if upstream callers pass a partial value.
+		// Treat as "other" rather than panicking.
+		return "other"
+	}
+	switch portStr {
+	case "25", "465", "587", "2525":
+		return "smtp"
+	case "443", "8443":
+		return "https"
+	case "80", "8080", "8000":
+		return "http"
+	case "53", "853":
+		return "dns"
+	case "6660", "6661", "6662", "6663", "6664", "6665",
+		"6666", "6667", "6668", "6669", "6697":
+		return "irc"
+	}
+	// Range checks for IRC (some servers use other ports in the range)
+	// and a quick range read for "other" — keep cheap, no regex.
+	if strings.HasPrefix(portStr, "66") && len(portStr) == 4 {
+		return "irc"
+	}
+	return "other"
+}

--- a/peer/abuse_test.go
+++ b/peer/abuse_test.go
@@ -1,0 +1,179 @@
+package peer
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/getlantern/radiance/events"
+)
+
+func TestClassifyPort(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		dest string
+		want string
+	}{
+		{"smtp 25", "smtp.example.com:25", "smtp"},
+		{"smtps 465", "smtp.example.com:465", "smtp"},
+		{"submission 587", "smtp.example.com:587", "smtp"},
+		{"alt smtp 2525", "smtp.example.com:2525", "smtp"},
+		{"https 443", "example.com:443", "https"},
+		{"https 8443", "example.com:8443", "https"},
+		{"http 80", "example.com:80", "http"},
+		{"http 8080", "example.com:8080", "http"},
+		{"http 8000", "example.com:8000", "http"},
+		{"dns 53", "1.1.1.1:53", "dns"},
+		{"dns 853", "1.1.1.1:853", "dns"},
+		{"irc 6667", "irc.example.com:6667", "irc"},
+		{"irc 6697", "irc.example.com:6697", "irc"},
+		{"irc range 6601", "irc.example.com:6601", "irc"},
+		{"other 21 ftp", "ftp.example.com:21", "other"},
+		{"other 22 ssh", "ssh.example.com:22", "other"},
+		{"other unknown high", "example.com:54321", "other"},
+		{"empty destination", "", "other"},
+		{"hostname only no port", "example.com", "other"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, classifyPort(tc.dest))
+		})
+	}
+}
+
+func TestStripPort(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "10.0.0.1", stripPort("10.0.0.1:443"))
+	assert.Equal(t, "::1", stripPort("[::1]:443"))
+	// best-effort: no port → return input unchanged
+	assert.Equal(t, "10.0.0.1", stripPort("10.0.0.1"))
+	assert.Equal(t, "", stripPort(""))
+}
+
+func TestAbuseAggregator_NoteAndFlush(t *testing.T) {
+	t.Parallel()
+	a := newAbuseAggregator(time.Hour) // long flush; we'll call flush manually
+
+	a.note("10.0.0.1:5555", "smtp.botnet.example:25")
+	a.note("10.0.0.1:5556", "smtp.botnet.example:25")
+	a.note("10.0.0.1:5557", "example.com:443")
+	a.note("203.0.113.99:5555", "example.com:443")
+
+	evt := a.flush()
+	require.NotNil(t, evt, "flush with activity should return an event")
+	require.Len(t, evt.Sources, 2, "expected one bucket per unique source IP")
+
+	// Sources are alphabetically sorted; 10.x < 203.x.
+	assert.Equal(t, "10.0.0.1", evt.Sources[0].SourceIP)
+	assert.Equal(t, 3, evt.Sources[0].TotalAccepts)
+	assert.Equal(t, 2, evt.Sources[0].PortClassCounts["smtp"])
+	assert.Equal(t, 1, evt.Sources[0].PortClassCounts["https"])
+
+	assert.Equal(t, "203.0.113.99", evt.Sources[1].SourceIP)
+	assert.Equal(t, 1, evt.Sources[1].TotalAccepts)
+	assert.Equal(t, 1, evt.Sources[1].PortClassCounts["https"])
+}
+
+func TestAbuseAggregator_FlushIsIdempotentRoll(t *testing.T) {
+	t.Parallel()
+	a := newAbuseAggregator(time.Hour)
+	a.note("10.0.0.1:5555", "smtp.example:25")
+
+	first := a.flush()
+	require.NotNil(t, first)
+	// Second flush with no activity since: nil event so we don't pollute
+	// the event stream with empties.
+	second := a.flush()
+	assert.Nil(t, second, "flush with no activity since last flush should be nil")
+}
+
+func TestAbuseAggregator_EmptyFlushReturnsNil(t *testing.T) {
+	t.Parallel()
+	a := newAbuseAggregator(time.Hour)
+	assert.Nil(t, a.flush(), "fresh aggregator with no notes flushes nil")
+}
+
+func TestAbuseAggregator_NoteIgnoresBadInput(t *testing.T) {
+	t.Parallel()
+	a := newAbuseAggregator(time.Hour)
+	// Empty source: no signal, must not produce a bucket.
+	a.note("", "example.com:443")
+	assert.Nil(t, a.flush(), "empty source should be dropped, not emitted")
+}
+
+func TestAbuseAggregator_RunFlushLoopEmitsViaEventBus(t *testing.T) {
+	// Subscribe to AbuseSummaryEvent before starting the loop.
+	got := make(chan AbuseSummaryEvent, 4)
+	sub := events.Subscribe(func(evt AbuseSummaryEvent) {
+		got <- evt
+	})
+	defer sub.Unsubscribe()
+
+	a := newAbuseAggregator(50 * time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		a.runFlushLoop(ctx)
+	}()
+
+	a.note("10.0.0.1:5555", "smtp.example:25")
+	a.note("10.0.0.1:5556", "irc.example:6667")
+
+	select {
+	case evt := <-got:
+		require.Len(t, evt.Sources, 1)
+		assert.Equal(t, "10.0.0.1", evt.Sources[0].SourceIP)
+		assert.Equal(t, 2, evt.Sources[0].TotalAccepts)
+		assert.Equal(t, 1, evt.Sources[0].PortClassCounts["smtp"])
+		assert.Equal(t, 1, evt.Sources[0].PortClassCounts["irc"])
+	case <-time.After(time.Second):
+		t.Fatal("no AbuseSummaryEvent within 1s")
+	}
+
+	cancel()
+	wg.Wait()
+}
+
+func TestAbuseAggregator_FlushLoopEmitsFinalSummaryOnCancel(t *testing.T) {
+	got := make(chan AbuseSummaryEvent, 4)
+	sub := events.Subscribe(func(evt AbuseSummaryEvent) {
+		got <- evt
+	})
+	defer sub.Unsubscribe()
+
+	// Long interval — only the cancel-time final flush should fire.
+	a := newAbuseAggregator(time.Hour)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		a.runFlushLoop(ctx)
+	}()
+
+	a.note("10.0.0.1:5555", "example.com:443")
+	cancel()
+	wg.Wait()
+
+	// events.Emit delivers asynchronously (one goroutine per subscriber)
+	// so wg.Wait returning doesn't guarantee the event has landed in
+	// our channel yet. Brief wait covers the dispatch goroutine.
+	select {
+	case evt := <-got:
+		require.Len(t, evt.Sources, 1)
+		assert.Equal(t, "10.0.0.1", evt.Sources[0].SourceIP)
+	case <-time.After(time.Second):
+		t.Fatal("expected a final summary on cancel within 1s; got none")
+	}
+}

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sagernet/sing-box/experimental/libbox"
 
+	"github.com/getlantern/lantern-box/tracker/peerconn"
 	"github.com/getlantern/radiance/events"
 	"github.com/getlantern/radiance/portforward"
 )
@@ -54,8 +55,9 @@ type Status struct {
 }
 
 // Config plumbs in dependencies. Zero-valued fields fall back to production
-// defaults; HeartbeatInterval, HeartbeatTimeout, and CredRotationInterval
-// exist so tests can drive the loops without sleeping a full minute / hour.
+// defaults; HeartbeatInterval, HeartbeatTimeout, CredRotationInterval, and
+// AbuseFlushInterval exist so tests can drive the loops without sleeping a
+// full minute / hour.
 type Config struct {
 	API                  *API
 	NewForwarder         func(ctx context.Context) (portForwarder, error)
@@ -63,6 +65,7 @@ type Config struct {
 	HeartbeatInterval    time.Duration
 	HeartbeatTimeout     time.Duration
 	CredRotationInterval time.Duration
+	AbuseFlushInterval   time.Duration
 }
 
 // Client orchestrates one peer-proxy session: open UPnP port → register with
@@ -119,6 +122,13 @@ type Client struct {
 // reconnect via the bandit. Acceptable trade-off vs. holding the same
 // cred for the full peer process lifetime.
 const peerCredRotationInterval = 1 * time.Hour
+
+// peerAbuseFlushInterval is how often the abuse aggregator drains its
+// in-memory bucket and emits an AbuseSummaryEvent. Long enough that
+// the aggregation actually does meaningful summarization (vs. just
+// ferrying every connection); short enough that lantern-cloud sees
+// abuse signals well within the cred-rotation window.
+const peerAbuseFlushInterval = 5 * time.Minute
 
 // peerCleanupTimeout caps how long Start's rollback path waits for
 // Deregister / UnmapPort. Cleanup uses a fresh Background context (not the
@@ -187,6 +197,11 @@ func (c *Client) Start(ctx context.Context) error {
 		// registered route + router rule.
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), peerCleanupTimeout)
 		defer cancel()
+		// Always clear the connection listener on rollback. The
+		// listener is registered on the success path; this is cheap
+		// insurance against a future re-order that registers earlier
+		// than expected.
+		peerconn.SetListener(nil)
 		if box != nil {
 			_ = box.Close()
 		}
@@ -285,6 +300,24 @@ func (c *Client) Start(ctx context.Context) error {
 		rotation = peerCredRotationInterval
 	}
 
+	// Wire the peer-share connection lifecycle hook to an in-memory
+	// abuse aggregator that buckets per-(source IP, destination port-
+	// class) and flushes a summary on the radiance event bus every
+	// flushInterval. Cleared on Stop / rollback so post-teardown
+	// callbacks land on a no-op rather than into a torn-down channel.
+	flushInterval := c.cfg.AbuseFlushInterval
+	if flushInterval == 0 {
+		flushInterval = peerAbuseFlushInterval
+	}
+	agg := newAbuseAggregator(flushInterval)
+	peerconn.SetListener(func(evt peerconn.Event) {
+		if evt.State != +1 {
+			return // only +1 carries destination; close events are no-op
+		}
+		agg.note(evt.Source, evt.Destination)
+	})
+	go agg.runFlushLoop(runCtx)
+
 	fwd.StartRenewal(runCtx)
 	go c.heartbeatLoop(runCtx, heartbeat, runDone)
 	go c.credRotationLoop(runCtx, rotation)
@@ -327,6 +360,13 @@ func (c *Client) Stop(ctx context.Context) error {
 	c.runCtx = nil
 	c.status = Status{}
 	c.mu.Unlock()
+
+	// Clear the connection listener BEFORE the box close so any
+	// in-flight accept callbacks land on a no-op rather than feed
+	// the (about-to-be-torn-down) abuse aggregator. The aggregator's
+	// flush goroutine exits when runCtx cancels via the cancel() call
+	// just below.
+	peerconn.SetListener(nil)
 
 	cancel()
 	<-done


### PR DESCRIPTION
## Summary

C3a of the Share My Connection security review (engineering#3438). Peer-side instrumentation that buckets per-(source IP, destination port-class) and flushes a summary every 5 minutes on the radiance event bus. Foundation for the lantern-cloud aggregation endpoint and bandit blocklist (C3b) that follows.

## What gets bucketed

| Field | Granularity |
|---|---|
| Source | Client connecting IP, port stripped (multiple connections from same client roll up) |
| Port class | smtp / irc / https / http / dns / other |

Coarse port-class buckets on purpose — finer would leak the destination tail, which is both noisy (long HTTPS tail) and privacy-sensitive (effectively the user's browsing history of the people using their connection).

**Full destination hostnames are not carried in the summary** — highest privacy cost, lowest abuse-detection value beyond the port-class signal.

## Wiring

\`\`\`mermaid
sequenceDiagram
    autonumber
    participant Box as lantern-box samizdat
    participant Listener as peerconn registry
    participant Agg as abuseAggregator
    participant Bus as radiance/events
    participant Core as lantern-core (future)

    Box->>Listener: NotifyAccept("ip:port", "host:port")
    Listener->>Agg: agg.note(source, destination)
    Note over Agg: bucket per (source IP, port class)
    loop every flushInterval (default 5m)
        Agg->>Bus: events.Emit(AbuseSummaryEvent{...})
        Bus->>Core: subscribers (Flutter diagnostic, lantern-cloud reporter — C3b)
    end
\`\`\`

Listener is registered on \`peer.Client.Start\` and cleared on \`Stop\` / rollback so post-teardown callbacks land on a no-op rather than into a torn-down channel.

## Test plan

- [x] \`TestClassifyPort\` — port → class mapping for SMTP / HTTPS / HTTP / DNS / IRC / other (16 cases)
- [x] \`TestStripPort\` — IPv4 / IPv6 / no-port edge cases
- [x] \`TestAbuseAggregator_NoteAndFlush\` — multiple sources / destinations bucket correctly
- [x] \`TestAbuseAggregator_FlushIsIdempotentRoll\` — second flush with no new activity returns nil
- [x] \`TestAbuseAggregator_NoteIgnoresBadInput\` — empty source dropped
- [x] \`TestAbuseAggregator_RunFlushLoopEmitsViaEventBus\` — end-to-end via the actual events.Subscribe path
- [x] \`TestAbuseAggregator_FlushLoopEmitsFinalSummaryOnCancel\` — graceful shutdown emits the last window
- [x] All existing peer tests pass under \`-race\`

## Caveats

- Local \`replace github.com/getlantern/lantern-box => ../lantern-box\` for the matching peerconn API change (lantern-box#256). Remove once that PR merges and lantern-box tags a release.
- Builds on \`fisk/peer-cred-rotation\` (C2 PR, in flight). Stack: peer-localbackend → peer-cred-rotation → peer-abuse-aggregator.

## Related

Part of the Share My Connection security review series:
- ✅ engineering#3436 / lantern-cloud#2705 — egress filter (C1)
- ✅ engineering#3437 / radiance#472 — cred rotation (C2)
- 🔄 engineering#3438 / lantern-box#256 + this PR — abuse aggregation peer-side (C3a)
- 🔜 engineering#3438 — lantern-cloud aggregation + bandit blocklist (C3b)
- 🔜 engineering#3438 — external abuse-report ingestion (C3c)

🤖 Generated with [Claude Code](https://claude.com/claude-code)