### PR TITLE
Added support for restore purchase

### DIFF
--- a/account/subscription.go
+++ b/account/subscription.go
@@ -141,8 +141,9 @@ type RestoreSubscriptionResponse struct {
 }
 
 // RestoreSubscription restores a previously purchased subscription for the given service.
-// For [GoogleService], data must contain "purchaseToken"; for [AppleService], it must contain
-// "receipt". Other services are rejected.
+// data should contain the fields required by the backend for the chosen service (e.g.
+// "purchaseToken" for Google, "receipt" for Apple); callers are responsible for populating
+// it. Services other than [GoogleService] and [AppleService] are rejected.
 func (a *Client) RestoreSubscription(ctx context.Context, service SubscriptionService, data map[string]string) (*RestoreSubscriptionResponse, error) {
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "restore_subscription")
 	defer span.End()

--- a/account/subscription.go
+++ b/account/subscription.go
@@ -131,6 +131,42 @@ func (a *Client) VerifySubscription(ctx context.Context, service SubscriptionSer
 
 }
 
+type RestoreSubscriptionResponse struct {
+	Status          string                         `json:"status"`
+	ActualUserID    int64                          `json:"actualUserId,omitempty"`
+	ActualUserToken string                         `json:"actualUserToken,omitempty"`
+	Devices         []*protos.LoginResponse_Device `json:"devices,omitempty"`
+}
+
+// RestoreSubscription restores a previously purchased subscription for the given service.
+// For [GoogleService], data must contain "purchaseToken"; for [AppleService], it must contain
+// "receipt". Other services are rejected.
+func (a *Client) RestoreSubscription(ctx context.Context, service SubscriptionService, data map[string]string) (*RestoreSubscriptionResponse, error) {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "restore_subscription")
+	defer span.End()
+
+	var path string
+	switch service {
+	case GoogleService:
+		path = "/restore-googleplay-subscription"
+	case AppleService:
+		path = "/restore-apple-subscription"
+	default:
+		return nil, traces.RecordError(ctx, fmt.Errorf("unsupported service: %s", service))
+	}
+
+	resp, err := a.sendProRequest(ctx, "POST", path, nil, nil, data)
+	if err != nil {
+		slog.Error("restoring subscription", "error", err)
+		return nil, traces.RecordError(ctx, fmt.Errorf("restoring subscription: %w", err))
+	}
+	var result RestoreSubscriptionResponse
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return nil, traces.RecordError(ctx, fmt.Errorf("unmarshaling restore subscription response: %w", err))
+	}
+	return &result, nil
+}
+
 // StripeBillingPortalURL generates the Stripe billing portal URL for the given user ID.
 // baseURL = common.GetProServerURL
 func (a *Client) StripeBillingPortalURL(ctx context.Context, baseURL, userID, proToken string) (string, error) {

--- a/account/subscription_test.go
+++ b/account/subscription_test.go
@@ -90,6 +90,33 @@ func TestVerifySubscription(t *testing.T) {
 	assert.NotEmpty(t, resp)
 }
 
+func TestRestoreSubscription(t *testing.T) {
+	t.Run("apple", func(t *testing.T) {
+		ac, _ := newTestClient(t)
+		resp, err := ac.RestoreSubscription(context.Background(), AppleService, map[string]string{"receipt": "r"})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "active", resp.Status)
+		assert.Equal(t, int64(1234), resp.ActualUserID)
+		assert.Equal(t, "token", resp.ActualUserToken)
+	})
+
+	t.Run("google", func(t *testing.T) {
+		ac, _ := newTestClient(t)
+		resp, err := ac.RestoreSubscription(context.Background(), GoogleService, map[string]string{"purchaseToken": "t"})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "active", resp.Status)
+	})
+
+	t.Run("unsupported", func(t *testing.T) {
+		ac, _ := newTestClient(t)
+		resp, err := ac.RestoreSubscription(context.Background(), StripeService, nil)
+		require.Error(t, err)
+		assert.Nil(t, resp)
+	})
+}
+
 func TestPlans(t *testing.T) {
 	ac, _ := newTestClient(t)
 	resp, err := ac.SubscriptionPlans(context.Background(), "store")

--- a/account/user_test.go
+++ b/account/user_test.go
@@ -217,6 +217,16 @@ func newTestServer(t *testing.T) (*httptest.Server, *testServer) {
 		})
 	})
 
+	restoreHandler := func(w http.ResponseWriter, r *http.Request) {
+		writeJSONResponse(w, RestoreSubscriptionResponse{
+			Status:          "active",
+			ActualUserID:    1234,
+			ActualUserToken: "token",
+		})
+	}
+	mux.HandleFunc("/restore-googleplay-subscription", restoreHandler)
+	mux.HandleFunc("/restore-apple-subscription", restoreHandler)
+
 	mux.HandleFunc("/purchase", func(w http.ResponseWriter, r *http.Request) {
 		writeJSONResponse(w, PurchaseResponse{
 			BaseResponse:  &protos.BaseResponse{},

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -1119,3 +1119,7 @@ func (r *LocalBackend) SubscriptionPlans(ctx context.Context, channel string) (s
 func (r *LocalBackend) VerifySubscription(ctx context.Context, service account.SubscriptionService, data map[string]string) (string, error) {
 	return r.accountClient.VerifySubscription(ctx, service, data)
 }
+
+func (r *LocalBackend) RestoreSubscription(ctx context.Context, service account.SubscriptionService, data map[string]string) (*account.RestoreSubscriptionResponse, error) {
+	return r.accountClient.RestoreSubscription(ctx, service, data)
+}

--- a/ipc/client.go
+++ b/ipc/client.go
@@ -640,6 +640,18 @@ func (c *Client) VerifySubscription(ctx context.Context, service account.Subscri
 	return resp.Result, err
 }
 
+// RestoreSubscription restores a previously purchased subscription.
+// For Apple and Google services, data must contain the appropriate purchase information.
+func (c *Client) RestoreSubscription(ctx context.Context, service account.SubscriptionService, data map[string]string) (*account.RestoreSubscriptionResponse, error) {
+	var resp account.RestoreSubscriptionResponse
+	err := c.doJSON(ctx, http.MethodPost, subscriptionRestoreEndpoint,
+		RestoreSubscriptionRequest{Service: service, Data: data}, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 ///////////
 // Issue //
 ///////////

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -89,6 +89,7 @@ const (
 	subscriptionPaymentRedirectURLEndpoint = "/subscription/payment-redirect-url"
 	subscriptionPlansEndpoint              = "/subscription/plans"
 	subscriptionVerifyEndpoint             = "/subscription/verify"
+	subscriptionRestoreEndpoint            = "/subscription/restore"
 
 	// Issue endpoint
 	issueEndpoint = "/issue"
@@ -252,6 +253,7 @@ func newLocalAPI(b *backend.LocalBackend, withAuth bool) *localapi {
 	mux.HandleFunc("POST "+subscriptionPaymentRedirectURLEndpoint, traced(s.subscriptionPaymentRedirectURLHandler))
 	mux.HandleFunc("GET "+subscriptionPlansEndpoint, traced(s.subscriptionPlansHandler))
 	mux.HandleFunc("POST "+subscriptionVerifyEndpoint, traced(s.subscriptionVerifyHandler))
+	mux.HandleFunc("POST "+subscriptionRestoreEndpoint, traced(s.subscriptionRestoreHandler))
 
 	// Issue
 	mux.HandleFunc("POST "+issueEndpoint, traced(s.issueReportHandler))
@@ -1113,6 +1115,20 @@ func (s *localapi) subscriptionVerifyHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	writeJSON(w, http.StatusOK, ResultResponse{Result: result})
+}
+
+func (s *localapi) subscriptionRestoreHandler(w http.ResponseWriter, r *http.Request) {
+	var req RestoreSubscriptionRequest
+	if err := decodeJSON(r, &req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	resp, err := s.backend(r.Context()).RestoreSubscription(r.Context(), req.Service, req.Data)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 ///////////

--- a/ipc/types.go
+++ b/ipc/types.go
@@ -101,6 +101,11 @@ type VerifySubscriptionRequest struct {
 	Data    map[string]string           `json:"data"`
 }
 
+type RestoreSubscriptionRequest struct {
+	Service account.SubscriptionService `json:"service"`
+	Data    map[string]string           `json:"data"`
+}
+
 type IssueReportRequest struct {
 	IssueType             issue.IssueType     `json:"issueType"`
 	Description           string              `json:"description"`


### PR DESCRIPTION
Lantern Cloud PR-:https://github.com/getlantern/lantern-cloud/pull/2712
Lantern-:https://github.com/getlantern/lantern/pull/8737

This pull request introduces support for restoring previously purchased subscriptions for Apple and Google services across the backend, IPC server/client, and account layers. The changes add a new API endpoint and corresponding data types to handle subscription restoration requests and responses.

**Subscription Restoration Support**

* Added a new `RestoreSubscription` method to the `account.Client`, including a `RestoreSubscriptionResponse` type, to handle restoration of subscriptions for Apple and Google services. This method validates the service, sends the appropriate request, and parses the response.
* Implemented the `RestoreSubscription` method in the `backend.LocalBackend` layer, delegating to the `accountClient`.

**IPC Layer Updates**

* Introduced a new IPC endpoint `/subscription/restore`, with corresponding request/response types (`RestoreSubscriptionRequest` and `RestoreSubscriptionResponse`), and added server and client handlers to process subscription restoration requests. [[1]](diffhunk://#diff-dc406fc743858a2874d0cebfbc7c0be932056c3a247189aca780ca5ac3342c64R92) [[2]](diffhunk://#diff-dc406fc743858a2874d0cebfbc7c0be932056c3a247189aca780ca5ac3342c64R256) [[3]](diffhunk://#diff-dc406fc743858a2874d0cebfbc7c0be932056c3a247189aca780ca5ac3342c64R1120-R1133) [[4]](diffhunk://#diff-723ed8d6367bbe37956df2f99440a2d76f0944e58e1fc8a4e01a699000f8ca55R643-R654) [[5]](diffhunk://#diff-2595f1a228bf29b3533d6fcb91dced0f7044775210fed61c914671d2f192cd27R104-R108)