### PR TITLE
set max compressed size for issue report to 19.5

### DIFF
--- a/issue/issue.go
+++ b/issue/issue.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	maxCompressedSize = 19 * 1024 * 1024 // 19 MB
+	maxCompressedSize = int64(19.5 * 1024 * 1024) // 19.5 MB - 20 MB is the max size so allow some buffer for overhead
 	tracerName        = "github.com/getlantern/radiance/issue"
 )
 

--- a/issue/issue.go
+++ b/issue/issue.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	maxCompressedSize = 20 * 1024 * 1024 // 20 MB
+	maxCompressedSize = 19 * 1024 * 1024 // 19 MB
 	tracerName        = "github.com/getlantern/radiance/issue"
 )
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the `maxCompressedSize` constant in the `issue/issue.go` file, reducing the maximum allowed compressed size from 20 MB to 19.5 MB to provide a buffer for overhead.