### PR TITLE
settings: migrate v9.0.x Windows Pro state across cross-dir move

### DIFF
--- a/common/settings/legacy_crossdir.go
+++ b/common/settings/legacy_crossdir.go
@@ -1,0 +1,89 @@
+package settings
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// windowsCrossDirCandidatesFn is overridable so tests can redirect the
+// lookup to a temp dir without touching the host's %PUBLIC%.
+var windowsCrossDirCandidatesFn = windowsCrossDirCandidates
+
+// windowsCrossDirCandidates returns settings candidates from the v9.0.x
+// Windows data directory (${PUBLIC}\Lantern\data), which is no longer
+// scanned by the same-dir migration after PR #370 moved the lanternd
+// daemon to ${ProgramData}\Lantern.
+//
+// On v9.0.x Windows, radiance was embedded in the Flutter app via FFI
+// and used the Dart-supplied data dir at C:\Users\Public\Lantern\data
+// (see lantern/lib/core/utils/storage_utils.dart). PR #370 (the same
+// commit that introduced cmd/lanternd/lanternd_windows.go) split radiance
+// off into a standalone Windows service that reads/writes under
+// internal.DefaultDataPath() = ${ProgramData}\Lantern. The two directories
+// don't share a parent, so the same-dir candidates in
+// migrateLegacySettingsIfNeeded never see the v9.0.x file and the user's
+// Pro state is lost on upgrade. See getlantern/engineering#3460 and
+// Freshdesk #174606.
+//
+// Returns nil on non-Windows hosts or when %PUBLIC% is unset. Both
+// known v9.0.x filenames are tried (local.json — the original — and
+// settings.json — what the file was renamed to in PR #370 for users who
+// upgraded through an intermediate build) so the recovery works
+// regardless of which v9.0.x release the user is coming from.
+func windowsCrossDirCandidates(fileDir string) []candidateSource {
+	if runtime.GOOS != "windows" {
+		return nil
+	}
+	pub := os.Getenv("PUBLIC")
+	if pub == "" {
+		return nil
+	}
+	v90xDir := filepath.Join(pub, "Lantern", "data")
+	// If the caller's fileDir already IS the v9.0.x dir (e.g. someone
+	// manually pointed lanternd at ${PUBLIC}\Lantern\data), the same-dir
+	// candidates already cover it — no need to also list it here.
+	if filepath.Clean(fileDir) == filepath.Clean(v90xDir) {
+		return nil
+	}
+	return readWindowsCrossDirCandidates(v90xDir)
+}
+
+// readWindowsCrossDirCandidates is split out so tests can drive the path
+// resolution directly without needing to spoof %PUBLIC% / GOOS.
+func readWindowsCrossDirCandidates(v90xDir string) []candidateSource {
+	// legacySettingsFileName is tried first because it's the actual
+	// v9.0.x name; settingsFileName is included as a defensive
+	// fallback for users whose v9.0.x file got renamed by a partial /
+	// failed earlier upgrade attempt.
+	specs := []struct {
+		name, label string
+	}{
+		{legacySettingsFileName, fmt.Sprintf("v9.0.x Windows %s", filepath.Join(v90xDir, legacySettingsFileName))},
+		{settingsFileName, fmt.Sprintf("v9.0.x Windows %s", filepath.Join(v90xDir, settingsFileName))},
+	}
+	var out []candidateSource
+	for _, s := range specs {
+		full := filepath.Join(v90xDir, s.name)
+		b, err := os.ReadFile(full)
+		switch {
+		case err == nil:
+			out = append(out, candidateSource{
+				path:     full,
+				contents: b,
+				exists:   true,
+				label:    s.label,
+			})
+		case errors.Is(err, fs.ErrNotExist):
+			// Expected — fresh install or that filename never existed for this user.
+		default:
+			slog.Warn("v9.0.x Windows cross-dir read failed",
+				"path", full, "error", err)
+		}
+	}
+	return out
+}

--- a/common/settings/legacy_crossdir.go
+++ b/common/settings/legacy_crossdir.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 // windowsCrossDirCandidatesFn is overridable so tests can redirect the
@@ -47,10 +48,24 @@ func windowsCrossDirCandidates(fileDir string) []candidateSource {
 	// If the caller's fileDir already IS the v9.0.x dir (e.g. someone
 	// manually pointed lanternd at ${PUBLIC}\Lantern\data), the same-dir
 	// candidates already cover it — no need to also list it here.
-	if filepath.Clean(fileDir) == filepath.Clean(v90xDir) {
+	// NTFS is case-insensitive by default, so a caller that supplies an
+	// equivalent path with different casing or separators should also
+	// hit this guard.
+	if samePathWindows(fileDir, v90xDir) {
 		return nil
 	}
 	return readWindowsCrossDirCandidates(v90xDir)
+}
+
+// samePathWindows reports whether two paths refer to the same directory
+// on Windows. Cleans both sides (collapsing `.` / `..` and normalizing
+// separators) and compares case-insensitively because NTFS is
+// case-insensitive by default. Not a substitute for filepath.EvalSymlinks
+// or device-id comparison — it only handles the common "user passed the
+// same dir written differently" case, which is the only one the
+// duplicate-scan guard needs to defend against.
+func samePathWindows(a, b string) bool {
+	return strings.EqualFold(filepath.Clean(a), filepath.Clean(b))
 }
 
 // readWindowsCrossDirCandidates is split out so tests can drive the path

--- a/common/settings/settings.go
+++ b/common/settings/settings.go
@@ -125,12 +125,14 @@ type candidateSource struct {
 // migrateLegacySettingsIfNeeded recovers persisted user state written
 // by older client versions. Candidates in priority order:
 //
-//  1. <fileDir>/settings.json       — canonical
-//  2. <fileDir>/local.json          — v9.0.x (renamed in #370)
-//  3. pre-9.x platform-specific YAML (legacy_yaml.go); spliced in below
-//  4. <fileDir>/data/settings.json  — v9.1.x (bugged: #370's
-//                                     setupDirectories appended an
-//                                     unconditional "/data" suffix)
+//  1. <fileDir>/settings.json                 — canonical
+//  2. <fileDir>/local.json                    — v9.0.x (renamed in #370)
+//  3. Windows ${PUBLIC}\Lantern\data\*        — v9.0.x cross-dir (#3460);
+//                                               spliced in below, Windows only
+//  4. pre-9.x platform-specific YAML (legacy_yaml.go); spliced in below
+//  5. <fileDir>/data/settings.json            — v9.1.x (bugged: #370's
+//                                               setupDirectories appended an
+//                                               unconditional "/data" suffix)
 //
 // Pick the highest-priority candidate with user_level=="pro"; if none
 // is pro, the highest-priority candidate that exists. Losing Pro is
@@ -167,6 +169,13 @@ func migrateLegacySettingsIfNeeded(fileDir, canonicalPath string) {
 	// priority is canonical > local.json > pre-9.x > nested.
 	if yc := legacyYAMLCandidate(fileDir); yc.exists {
 		candidates = append(candidates[:2], append([]candidateSource{yc}, candidates[2:]...)...)
+	}
+	// Splice Windows v9.0.x cross-dir candidates (${PUBLIC}\Lantern\data)
+	// right after the v9.0.x same-dir local.json — they're the same
+	// generation of state, just stored under a different filesystem root.
+	// On every other GOOS / when the env is unset this is a no-op.
+	if winExtras := windowsCrossDirCandidatesFn(fileDir); len(winExtras) > 0 {
+		candidates = append(candidates[:2], append(winExtras, candidates[2:]...)...)
 	}
 
 	// Pick: highest-priority file with user_level=="pro"; if none has pro,

--- a/common/settings/settings.go
+++ b/common/settings/settings.go
@@ -165,15 +165,26 @@ func migrateLegacySettingsIfNeeded(fileDir, canonicalPath string) {
 			}
 		}
 	}
-	// Splice the pre-9.x YAML candidate before the v9.1.x nested file so
-	// priority is canonical > local.json > pre-9.x > nested.
+	// Splice optional candidates in. Each splice inserts at index 2 (right
+	// after canonical and same-dir local.json), so doing them in order
+	// from oldest-priority to newest-priority gives the final ordering:
+	//
+	//   canonical > same-dir local.json
+	//     > Windows cross-dir (newest of the optional candidates)
+	//       > pre-9.x YAML (older than v9.0.x)
+	//         > v9.1.x nested (always last, the bug-victim case)
+	//
+	// Insert pre-9.x YAML first, then Windows cross-dir, so the Windows
+	// candidate ends up *before* (higher priority than) the YAML.
 	if yc := legacyYAMLCandidate(fileDir); yc.exists {
 		candidates = append(candidates[:2], append([]candidateSource{yc}, candidates[2:]...)...)
 	}
-	// Splice Windows v9.0.x cross-dir candidates (${PUBLIC}\Lantern\data)
-	// right after the v9.0.x same-dir local.json — they're the same
-	// generation of state, just stored under a different filesystem root.
-	// On every other GOOS / when the env is unset this is a no-op.
+	// Windows v9.0.x cross-dir candidates (${PUBLIC}\Lantern\data) are the
+	// same generation of state as the same-dir local.json, just stored
+	// under a different filesystem root because PR #370 moved lanternd's
+	// data dir to ${ProgramData}\Lantern. On every other GOOS / when the
+	// env is unset windowsCrossDirCandidatesFn returns nil and this is a
+	// no-op.
 	if winExtras := windowsCrossDirCandidatesFn(fileDir); len(winExtras) > 0 {
 		candidates = append(candidates[:2], append(winExtras, candidates[2:]...)...)
 	}

--- a/common/settings/settings_test.go
+++ b/common/settings/settings_test.go
@@ -12,6 +12,56 @@ import (
 	_ "github.com/getlantern/radiance/common/env"
 )
 
+func TestWindowsCrossDirCandidates(t *testing.T) {
+	t.Run("returns nil on non-Windows", func(t *testing.T) {
+		// On macOS/Linux the function must short-circuit regardless of
+		// %PUBLIC% being set — this is the implicit GOOS gate that keeps
+		// the cross-dir scan from misfiring elsewhere.
+		if runtime.GOOS == "windows" {
+			t.Skip("test only meaningful on non-Windows hosts")
+		}
+		t.Setenv("PUBLIC", t.TempDir())
+		assert.Nil(t, windowsCrossDirCandidates("/some/dir"))
+	})
+
+	t.Run("returns nil when %PUBLIC% is unset", func(t *testing.T) {
+		t.Setenv("PUBLIC", "")
+		assert.Nil(t, windowsCrossDirCandidates("/some/dir"))
+	})
+
+	t.Run("readWindowsCrossDirCandidates picks up local.json", func(t *testing.T) {
+		dir := t.TempDir()
+		body := []byte(`{"user_level":"pro","user_id":1}`)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, legacySettingsFileName), body, 0o644))
+
+		cs := readWindowsCrossDirCandidates(dir)
+		require.Len(t, cs, 1, "expected one candidate when only local.json exists")
+		assert.True(t, cs[0].exists)
+		assert.Equal(t, body, cs[0].contents)
+		assert.Contains(t, cs[0].label, "v9.0.x Windows", "label must identify the cross-dir source")
+	})
+
+	t.Run("readWindowsCrossDirCandidates picks up both local.json and settings.json", func(t *testing.T) {
+		dir := t.TempDir()
+		local := []byte(`{"user_level":"pro","user_id":1}`)
+		canon := []byte(`{"user_level":"expired","user_id":2}`)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, legacySettingsFileName), local, 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, settingsFileName), canon, 0o644))
+
+		cs := readWindowsCrossDirCandidates(dir)
+		require.Len(t, cs, 2, "both filenames should be returned when both exist")
+		// local.json must come first — it's the actual v9.0.x name; the
+		// settings.json fallback is for users who got renamed by a
+		// partial earlier upgrade.
+		assert.Equal(t, local, cs[0].contents, "local.json must be first")
+		assert.Equal(t, canon, cs[1].contents, "settings.json fallback must be second")
+	})
+
+	t.Run("readWindowsCrossDirCandidates returns empty when dir is empty", func(t *testing.T) {
+		assert.Empty(t, readWindowsCrossDirCandidates(t.TempDir()))
+	})
+}
+
 func TestInitSettings(t *testing.T) {
 	t.Run("existing valid config file", func(t *testing.T) {
 		tempDir := t.TempDir()
@@ -41,6 +91,14 @@ func TestMigrateLegacySettingsIfNeeded(t *testing.T) {
 	prevYAMLPath := legacyYAMLPathFn
 	legacyYAMLPathFn = func(string) (string, string) { return "", "" }
 	t.Cleanup(func() { legacyYAMLPathFn = prevYAMLPath })
+
+	// Same treatment for the Windows v9.0.x cross-dir lookup: default
+	// to nothing so tests don't accidentally pick up a real
+	// %PUBLIC%\Lantern\data on a developer's Windows machine. Tests that
+	// exercise this path opt in.
+	prevWinCrossDir := windowsCrossDirCandidatesFn
+	windowsCrossDirCandidatesFn = func(string) []candidateSource { return nil }
+	t.Cleanup(func() { windowsCrossDirCandidatesFn = prevWinCrossDir })
 
 	writeNested := func(t *testing.T, dir string, contents []byte) {
 		t.Helper()
@@ -269,6 +327,113 @@ Token: tok
 		require.NoError(t, err)
 		assert.Contains(t, string(got), `"user_id":7777`)
 		assert.Contains(t, string(got), `"device_id":"ios-device"`)
+	})
+
+	t.Run("Windows v9.0.x cross-dir local.json recovered when canonical/same-dir/nested all missing", func(t *testing.T) {
+		// FD #174606 / engineering#3460: PR #370 moved the Windows daemon
+		// from <PUBLIC>\Lantern\data (where v9.0.x Flutter+FFI wrote
+		// local.json) to <ProgramData>\Lantern. The same-dir scan can't
+		// see across that filesystem boundary, so cross-dir candidates
+		// are spliced in by windowsCrossDirCandidatesFn. Verify recovery.
+		tempDir := t.TempDir()
+		v90xDir := filepath.Join(tempDir, "windows-v90x")
+		require.NoError(t, os.MkdirAll(v90xDir, 0o755))
+		want := []byte(`{"user_id": 195646669, "user_level": "pro", "token": "preserved"}`)
+		require.NoError(t, os.WriteFile(filepath.Join(v90xDir, legacySettingsFileName), want, 0o644))
+
+		windowsCrossDirCandidatesFn = func(string) []candidateSource {
+			return readWindowsCrossDirCandidates(v90xDir)
+		}
+		t.Cleanup(func() {
+			windowsCrossDirCandidatesFn = func(string) []candidateSource { return nil }
+		})
+
+		canonical := filepath.Join(tempDir, settingsFileName)
+		migrateLegacySettingsIfNeeded(tempDir, canonical)
+
+		got, err := os.ReadFile(canonical)
+		require.NoError(t, err)
+		assert.Equal(t, want, got, "v9.0.x cross-dir local.json must be migrated to canonical")
+	})
+
+	t.Run("Windows v9.0.x cross-dir falls back to settings.json when local.json missing", func(t *testing.T) {
+		// Defensive case: a user whose v9.0.x file got renamed by an
+		// earlier partial upgrade attempt. The cross-dir scan should
+		// still pick up settings.json under ${PUBLIC}\Lantern\data.
+		tempDir := t.TempDir()
+		v90xDir := filepath.Join(tempDir, "windows-v90x")
+		require.NoError(t, os.MkdirAll(v90xDir, 0o755))
+		want := []byte(`{"user_id": 42, "user_level": "pro"}`)
+		require.NoError(t, os.WriteFile(filepath.Join(v90xDir, settingsFileName), want, 0o644))
+
+		windowsCrossDirCandidatesFn = func(string) []candidateSource {
+			return readWindowsCrossDirCandidates(v90xDir)
+		}
+		t.Cleanup(func() {
+			windowsCrossDirCandidatesFn = func(string) []candidateSource { return nil }
+		})
+
+		canonical := filepath.Join(tempDir, settingsFileName)
+		migrateLegacySettingsIfNeeded(tempDir, canonical)
+
+		got, err := os.ReadFile(canonical)
+		require.NoError(t, err)
+		assert.Equal(t, want, got, "v9.0.x cross-dir settings.json must be migrated when local.json absent")
+	})
+
+	t.Run("Windows v9.0.x cross-dir loses to same-dir v9.0.x local.json", func(t *testing.T) {
+		// If both exist, same-dir wins — it's strictly more recent state.
+		// (Cross-dir is only a thing because Windows users skipped through
+		// the v9.0.x → v9.1.x transition; same-dir local.json means the
+		// daemon already migrated once and the cross-dir copy is stale.)
+		tempDir := t.TempDir()
+		v90xDir := filepath.Join(tempDir, "windows-v90x")
+		require.NoError(t, os.MkdirAll(v90xDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(v90xDir, legacySettingsFileName),
+			[]byte(`{"user_id": 999, "user_level": "pro"}`), 0o644))
+		sameDirPro := []byte(`{"user_id": 1, "user_level": "pro", "token": "same-dir"}`)
+		require.NoError(t, os.WriteFile(filepath.Join(tempDir, legacySettingsFileName), sameDirPro, 0o644))
+
+		windowsCrossDirCandidatesFn = func(string) []candidateSource {
+			return readWindowsCrossDirCandidates(v90xDir)
+		}
+		t.Cleanup(func() {
+			windowsCrossDirCandidatesFn = func(string) []candidateSource { return nil }
+		})
+
+		canonical := filepath.Join(tempDir, settingsFileName)
+		migrateLegacySettingsIfNeeded(tempDir, canonical)
+
+		got, err := os.ReadFile(canonical)
+		require.NoError(t, err)
+		assert.Equal(t, sameDirPro, got, "same-dir v9.0.x must outrank cross-dir v9.0.x")
+	})
+
+	t.Run("Windows v9.0.x cross-dir-pro beats v9.1.x nested-expired", func(t *testing.T) {
+		// The headline case: user upgrades from v9.0.x Windows (Pro state
+		// at ${PUBLIC}\Lantern\data\local.json) through a buggy v9.1.x
+		// build (which wrote an expired record at <ProgramData>\Lantern\data\settings.json)
+		// to the fix. The cross-dir Pro must win over the nested expired.
+		tempDir := t.TempDir()
+		v90xDir := filepath.Join(tempDir, "windows-v90x")
+		require.NoError(t, os.MkdirAll(v90xDir, 0o755))
+		crossDirPro := []byte(`{"user_id": 195646669, "user_level": "pro"}`)
+		require.NoError(t, os.WriteFile(filepath.Join(v90xDir, legacySettingsFileName), crossDirPro, 0o644))
+		writeNested(t, tempDir, []byte(`{"user_id": 99, "user_level": "expired"}`))
+
+		windowsCrossDirCandidatesFn = func(string) []candidateSource {
+			return readWindowsCrossDirCandidates(v90xDir)
+		}
+		t.Cleanup(func() {
+			windowsCrossDirCandidatesFn = func(string) []candidateSource { return nil }
+		})
+
+		canonical := filepath.Join(tempDir, settingsFileName)
+		migrateLegacySettingsIfNeeded(tempDir, canonical)
+
+		got, err := os.ReadFile(canonical)
+		require.NoError(t, err)
+		assert.Equal(t, crossDirPro, got, "cross-dir pro must beat nested expired (engineering#3460)")
 	})
 
 	t.Run("unreadable canonical (non-ENOENT) skips migration", func(t *testing.T) {

--- a/common/settings/settings_test.go
+++ b/common/settings/settings_test.go
@@ -60,6 +60,31 @@ func TestWindowsCrossDirCandidates(t *testing.T) {
 	t.Run("readWindowsCrossDirCandidates returns empty when dir is empty", func(t *testing.T) {
 		assert.Empty(t, readWindowsCrossDirCandidates(t.TempDir()))
 	})
+
+	t.Run("samePathWindows is case-insensitive", func(t *testing.T) {
+		// This is the load-bearing property of the guard — NTFS is
+		// case-insensitive by default, so callers may supply equivalent
+		// paths with different casing. Portable across OSes.
+		assert.True(t, samePathWindows("/tmp/foo", "/tmp/FOO"))
+		assert.True(t, samePathWindows(`C:\Users\Public`, `c:\users\public`))
+		assert.False(t, samePathWindows("/tmp/foo", "/tmp/bar"))
+	})
+
+	t.Run("samePathWindows normalizes Windows separators (Windows only)", func(t *testing.T) {
+		// On Windows, filepath.Clean folds `\` and `/` into the native
+		// separator and strips trailing slashes. On Unix-style hosts
+		// these characters are treated literally, so the assertion is
+		// meaningless off-Windows. The function itself is only called
+		// from windowsCrossDirCandidates, which short-circuits unless
+		// GOOS=="windows" — i.e. the cases below only matter in the
+		// environment they're exercised.
+		if runtime.GOOS != "windows" {
+			t.Skip("Windows-only path-cleaning semantics")
+		}
+		assert.True(t, samePathWindows(`C:\Users\Public\Lantern\data`, `C:/Users/Public/Lantern/data`))
+		assert.True(t, samePathWindows(`C:\Users\Public\Lantern\data\`, `C:\Users\Public\Lantern\data`))
+		assert.False(t, samePathWindows(`C:\Users\Public\Lantern\data`, `C:\Users\Public\Lantern\other`))
+	})
 }
 
 func TestInitSettings(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes a Windows-specific gap left open by [#463](https://github.com/getlantern/radiance/pull/463) — `migrateLegacySettingsIfNeeded` only scans within `<fileDir>`, but on Windows the **entire data-dir root moved** in #370, not just the filename or a subdir.
- Adds a Windows v9.0.x cross-dir candidate (`${PUBLIC}\Lantern\data\local.json`) so Pro state survives the upgrade.
- Surfaced from FD [#174606](https://lantern.freshdesk.com/a/tickets/174606): Windows 9.1.7-beta Pro user (China Mobile AS24400, user_id `195646669`) opens the new build and the daemon immediately logs `Created new user` because `settings.UserIDKey == 0`. Tracked in [getlantern/engineering#3460](https://github.com/getlantern/engineering/issues/3460).

## Why the existing migration missed this

PR #463's recovery path scans three siblings of `<fileDir>`:

```
<fileDir>/settings.json         — canonical
<fileDir>/local.json            — v9.0.x (renamed in #370)
<fileDir>/data/settings.json    — v9.1.x bug-victim
```

That's correct for Android (Mobile passes `<app.dataDir>/.lantern` and v9.0.x always wrote within it). But on Windows, PR #370 is also the commit that introduced `cmd/lanternd/lanternd_windows.go` — i.e. it simultaneously:

1. Split radiance off the in-process Flutter+FFI host into a standalone `LanternSvc` daemon
2. Switched the daemon's data-dir resolution from "the path Dart hands us" to `internal.DefaultDataPath()` (`${ProgramData}\Lantern`)

So the v9.0.x → v9.1.x picture on Windows is:

| Build | radiance host | data dir |
|---|---|---|
| **v9.0.x** | embedded in Flutter via FFI | `C:\Users\Public\Lantern\data` ([`storage_utils.dart:48-51`](https://github.com/getlantern/lantern/blob/main/lib/core/utils/storage_utils.dart#L48-L51)) |
| **v9.1.x** | standalone `LanternSvc` | `C:\ProgramData\Lantern` ([`internal/paths.go:20-21`](https://github.com/getlantern/radiance/blob/main/internal/paths.go#L20-L21)) |

The roots don't share a parent, so the same-dir scan inside `<fileDir> = C:\ProgramData\Lantern` never sees the v9.0.x file. Daemon logs `Created new user`, the user's Pro identity (`user_id`, `token`) is lost, and the client registers a fresh anonymous account.

## What this PR does

Adds a new file `common/settings/legacy_crossdir.go` with `windowsCrossDirCandidates(fileDir)`:

- On non-Windows hosts: returns nil (the runtime.GOOS guard).
- On Windows with `%PUBLIC%` set: reads `${PUBLIC}\Lantern\data\local.json` and `${PUBLIC}\Lantern\data\settings.json`, returning candidateSources for whichever exist.
- Guards against the degenerate case where the caller already passed `${PUBLIC}\Lantern\data` as `fileDir` (the same-dir scan already covers that).
- `windowsCrossDirCandidatesFn` is an override hook so the migration tests can drive the path resolution from a temp dir on any GOOS — mirrors the existing `legacyYAMLPathFn` pattern.

Splices the result into `migrateLegacySettingsIfNeeded` right after the same-dir v9.0.x candidate. Final priority order:

```
canonical settings.json
  > same-dir v9.0.x local.json
    > Windows ${PUBLIC}\Lantern\data\local.json   ← new
      > Windows ${PUBLIC}\Lantern\data\settings.json ← new (defensive)
        > pre-9.x platform YAML
          > v9.1.x data/settings.json (bug-victim)
```

`dns_remote`'s privacy guarantee isn't touched — this is settings-recovery only, no DNS routing changes.

## Test plan

5 new unit tests on `TestWindowsCrossDirCandidates` plus 4 new integration sub-cases on `TestMigrateLegacySettingsIfNeeded`. All green; no regressions in the 12 existing migration tests:

```
=== RUN   TestWindowsCrossDirCandidates
--- PASS: TestWindowsCrossDirCandidates (0.00s)
    --- PASS: TestWindowsCrossDirCandidates/returns_nil_on_non-Windows
    --- PASS: TestWindowsCrossDirCandidates/returns_nil_when_%PUBLIC%_is_unset
    --- PASS: TestWindowsCrossDirCandidates/readWindowsCrossDirCandidates_picks_up_local.json
    --- PASS: TestWindowsCrossDirCandidates/readWindowsCrossDirCandidates_picks_up_both_local.json_and_settings.json
    --- PASS: TestWindowsCrossDirCandidates/readWindowsCrossDirCandidates_returns_empty_when_dir_is_empty
=== RUN   TestMigrateLegacySettingsIfNeeded
--- PASS: TestMigrateLegacySettingsIfNeeded (0.09s)
    --- PASS: …/Windows_v9.0.x_cross-dir_local.json_recovered_when_canonical/same-dir/nested_all_missing
    --- PASS: …/Windows_v9.0.x_cross-dir_falls_back_to_settings.json_when_local.json_missing
    --- PASS: …/Windows_v9.0.x_cross-dir_loses_to_same-dir_v9.0.x_local.json
    --- PASS: …/Windows_v9.0.x_cross-dir-pro_beats_v9.1.x_nested-expired
    [… all 12 pre-existing sub-cases still pass …]
PASS
ok  	github.com/getlantern/radiance/common/settings	0.433s
```

The four new integration scenarios cover:
1. **Plain recovery** — cross-dir local.json picked up when nothing else exists
2. **Filename fallback** — cross-dir settings.json picked up when local.json absent (defensive case)
3. **Priority** — cross-dir loses to same-dir v9.0.x local.json (same-dir is strictly more recent)
4. **Headline case** — cross-dir-pro beats v9.1.x nested-expired (the exact FD #174606 scenario)

## Manual repro to validate end-to-end

1. Install Lantern v9.0.x on Windows. Log into a Pro account. Verify `C:\Users\Public\Lantern\data\local.json` contains `user_id`, `token`, `user_level=pro`.
2. Quit Lantern. Install v9.1.7+ over the top (or a build off this PR).
3. **Before this PR**: daemon logs `Created new user`; Pro state is lost.
4. **After this PR**: daemon logs `legacy settings migration: recovered persisted state … source=v9.0.x Windows C:\Users\Public\Lantern\data\local.json`; Pro state preserved.

## Related

- [#463](https://github.com/getlantern/radiance/pull/463) — the original v9.0.x → v9.1.x migration. Handles the same-dir/Android case. This PR extends it for Windows' cross-dir case.
- [#370](https://github.com/getlantern/radiance/pull/370) — the restructure that simultaneously introduced cmd/lanternd and the data-dir suffix bug. Where the regression originally lives.
- [getlantern/engineering#3460](https://github.com/getlantern/engineering/issues/3460) — root issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)