### PR TITLE
backend: clear selected server when it's removed

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -569,15 +569,7 @@ func (r *LocalBackend) RemoveServers(tags []string) error {
 		removedTags = append(removedTags, srv.Tag)
 	}
 	if len(removedTags) > 0 {
-		var selected servers.Server
-		if err := settings.GetStruct(settings.SelectedServerKey, &selected); err == nil {
-			if slices.Contains(removedTags, selected.Tag) {
-				// clear selected server from settings if it's being removed
-				if err := settings.Set(settings.SelectedServerKey, nil); err != nil {
-					slog.Warn("Failed to clear selected server from settings after it was removed", "error", err)
-				}
-			}
-		}
+		r.clearSelectedIfMissing()
 		if err := r.vpnClient.RemoveOutbounds(removedTags); err != nil && !errors.Is(err, vpn.ErrTunnelNotConnected) {
 			return fmt.Errorf("failed to remove outbounds: %w", err)
 		}
@@ -593,7 +585,26 @@ func (r *LocalBackend) setServers(list servers.ServerList, isLantern bool) error
 	if err != nil && !errors.Is(err, vpn.ErrTunnelNotConnected) {
 		slog.Error("Failed to update VPN outbounds after config change", "error", err)
 	}
+	r.clearSelectedIfMissing()
 	return nil
+}
+
+// clearSelectedIfMissing reverts the persisted selection to auto-select when
+// the selected server is no longer present in the manager.
+func (r *LocalBackend) clearSelectedIfMissing() {
+	var selected servers.Server
+	if err := settings.GetStruct(settings.SelectedServerKey, &selected); err != nil {
+		return
+	}
+	if _, found := r.srvManager.GetServerByTag(selected.Tag); found {
+		return
+	}
+	// Persist before notifying the VPN client so the auto-select choice
+	// survives even if the tunnel isn't running to accept the switch.
+	r.persistSelection(vpn.AutoSelectTag)
+	if err := r.vpnClient.SelectServer(vpn.AutoSelectTag); err != nil && !errors.Is(err, vpn.ErrTunnelNotConnected) {
+		slog.Warn("Failed to switch to auto-select after selected server was removed", "error", err)
+	}
 }
 
 func (r *LocalBackend) AddServersByJSON(config string) ([]string, error) {
@@ -837,12 +848,6 @@ func (r *LocalBackend) ActiveVPNConnections() ([]vpn.Connection, error) {
 	return connections, nil
 }
 
-// TODO: handle case where selected server is no longer available (e.g. removed from manager) more
-// gracefully, currently we just return that the server is no longer available but maybe we should
-// also clear the selected server from settings and select a new server in the VPN client.
-// should we not remove a lantern server if it's currently selected in the VPN client and instead
-// mark it as unavailable in the manager until it's no longer selected in the VPN client?
-
 // SelectedServer returns the currently selected server and whether the server is still available.
 // The server may no longer be available if it was removed from the manager since it was selected.
 func (r *LocalBackend) SelectedServer() (*servers.Server, bool, error) {
@@ -855,7 +860,15 @@ func (r *LocalBackend) SelectedServer() (*servers.Server, bool, error) {
 		return server, found, nil
 	}
 	if !settings.Exists(settings.SelectedServerKey) {
-		return nil, false, fmt.Errorf("no selected server")
+		tag, err := r.vpnClient.CurrentSelectedServer()
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to get current selected server: %w", err)
+		}
+		if tag == "" {
+			return nil, false, fmt.Errorf("no selected server")
+		}
+		server, found := r.srvManager.GetServerByTag(tag)
+		return server, found, nil
 	}
 	var selected servers.Server
 	if err := settings.GetStruct(settings.SelectedServerKey, &selected); err != nil {

--- a/cmd/lantern/monitor.go
+++ b/cmd/lantern/monitor.go
@@ -51,6 +51,7 @@ type monitorSnapshot struct {
 	UserID           string                 `json:"user_id,omitempty"`
 	Pro              bool                   `json:"pro"`
 	Status           statusSnapshot         `json:"status"`
+	Mode             string                 `json:"mode"`
 	Throughput       vpn.ThroughputSnapshot `json:"throughput"`
 	DataCap          *account.DataCapInfo   `json:"data_cap,omitempty"`
 	DataCapStreaming bool                   `json:"data_cap_streaming"`
@@ -202,6 +203,7 @@ func fetchMonitor(ctx context.Context, c *ipc.Client, cmd *MonitorCmd, snap *mon
 		snap.DeviceID = fmt.Sprintf("%v", did)
 	}
 	snap.Pro = strings.EqualFold(fmt.Sprintf("%v", cfg[settings.UserLevelKey]), "pro")
+	snap.Mode = selectionMode(cfg)
 
 	if cmd.History > 0 {
 		h, err := c.VPNSessions(ctx, cmd.History)
@@ -264,6 +266,9 @@ func renderMonitor(w io.Writer, snap *monitorSnapshot, width int) {
 		status = strings.ToUpper(status[:1]) + status[1:]
 	}
 	fmt.Fprintf(w, "Status: %s%s", status, eol)
+	if snap.Mode != "" {
+		fmt.Fprintf(w, "  Mode: %s%s", snap.Mode, eol)
+	}
 	if snap.Status.Server != "" {
 		line := "  Server: " + formatTag(snap.Status.Server)
 		if snap.Status.Location != "" {

--- a/cmd/lantern/settings.go
+++ b/cmd/lantern/settings.go
@@ -145,6 +145,16 @@ func orString(v any) any {
 	return v
 }
 
+func selectionMode(s settings.Settings) string {
+	if toBool(s[settings.AutoConnectKey]) {
+		return "auto"
+	}
+	if s[settings.SelectedServerKey] != nil {
+		return "manual"
+	}
+	return "auto"
+}
+
 func toBool(v any) bool {
 	if v == nil {
 		return false

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -418,6 +418,26 @@ func (c *VPNClient) CurrentAutoSelectedServer() (string, error) {
 	return outbound.(adapter.OutboundGroup).Now(), nil
 }
 
+// CurrentSelectedServer returns the tag of the currently selected outbound in
+// whichever selector mode (auto or manual) the tunnel is in. Returns an empty
+// string with a nil error when the tunnel is not running.
+func (c *VPNClient) CurrentSelectedServer() (string, error) {
+	if !c.isOpen() {
+		return "", nil
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.tunnel == nil {
+		return "", ErrTunnelNotConnected
+	}
+	mode := c.tunnel.clashServer.Mode()
+	outbound, loaded := c.tunnel.outboundMgr.Outbound(mode)
+	if !loaded {
+		return "", fmt.Errorf("%s group not found", mode)
+	}
+	return outbound.(adapter.OutboundGroup).Now(), nil
+}
+
 const (
 	rapidPollInterval  = 500 * time.Millisecond
 	rapidPollWindow    = 15 * time.Second


### PR DESCRIPTION
This pull request improves how the application manages the selected VPN server, especially when servers are removed or unavailable, and enhances the monitoring output with clearer information about server selection mode. The changes ensure that the system gracefully handles cases where the selected server is no longer present and provides better visibility into the current selection mode for users.

**Server selection management:**

* Introduced the `clearSelectedIfMissing` method in `LocalBackend` to automatically revert to auto-select mode and update both settings and the VPN client if the selected server is removed or missing. This logic is now invoked after server removal and server list updates. [[1]](diffhunk://#diff-d7a5115ab346da59601a056266b297ad60b2db8ce5434ba7cd67023d47d5097bL572-R572) [[2]](diffhunk://#diff-d7a5115ab346da59601a056266b297ad60b2db8ce5434ba7cd67023d47d5097bR588-R609)
* Enhanced the `SelectedServer` method to attempt retrieving the currently selected server from the VPN client if no selection is found in settings, improving robustness when the persisted selection is missing.
* Removed outdated TODO comments about handling unavailable selected servers, as this case is now handled directly in code.
* Added a new method `CurrentSelectedServer` to `VPNClient`, which returns the tag of the currently selected server regardless of selection mode, supporting the above improvements.

**Monitoring and user interface:**

* Added a `Mode` field to the monitor snapshot, displaying whether server selection is in "auto" or "manual" mode. This is determined using the new `selectionMode` function and shown in the monitor output for better user clarity. [[1]](diffhunk://#diff-ae7bff7af58e4da3f4bd1d723f192d5389f776bc4769bcd01addf894c206f11dR54) [[2]](diffhunk://#diff-ae7bff7af58e4da3f4bd1d723f192d5389f776bc4769bcd01addf894c206f11dR206) [[3]](diffhunk://#diff-ae7bff7af58e4da3f4bd1d723f192d5389f776bc4769bcd01addf894c206f11dR269-R271) [[4]](diffhunk://#diff-79db8cf46c4beaaf9cbb8def239b3578602ffb6a12a4ef18c159bb771352ea1dR148-R157)