### PR TITLE
vpn: preserve manually-selected outbound across config refreshes

### DIFF
--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -521,28 +521,10 @@ func (t *tunnel) updateOutbounds(list servers.ServerList) error {
 
 	// collect tags present in the current group but absent from the new config
 	newTags := list.Tags()
-	// Preserve the manual-selector's currently-selected outbound across
-	// config refreshes — but only when the user is actually in manual
-	// mode. The bandit re-picks routes on every /v1/config-new poll
-	// (60s..15min adaptive interval); without this preservation, a Pro
-	// user who manually selected a specific server would lose that
-	// outbound the moment the bandit's next pick excluded it and have to
-	// redial. Keeping the underlying outbound loaded in the outbound
-	// manager lets the manual selector stay pointing at the same TLS
-	// materials / keypair / masquerade origin the user is mid-session on.
-	//
-	// Gating on manual mode (rather than always preserving selector.Now())
-	// matters because the selector's Now() defaults to the first outbound
-	// in the group even when the user hasn't manually selected anything.
-	// Preserving that "default first" across refreshes when the user is
-	// in auto mode would slowly accumulate stale outbounds the bandit
-	// never asked for.
-	//
-	// Self-healing: if the underlying VPS is eventually destroyed by
-	// autoreplace, sing-box's dial fails and the tunnel's reconnect path
-	// surfaces the failure. The UI is expected to detect repeated
-	// connection failures on a manually selected server and prompt the
-	// user to re-select.
+	// In manual mode, keep the selected outbound alive across config
+	// refreshes so the user doesn't get redialed when the bandit excludes
+	// it. Gated on mode because selector.Now() defaults to the first
+	// outbound even with no manual selection.
 	var pinnedTag string
 	if t.clashServer != nil && t.clashServer.Mode() == ManualSelectTag {
 		pinnedTag = selector.Now()

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -547,19 +547,9 @@ func (t *tunnel) updateOutbounds(list servers.ServerList) error {
 	if t.clashServer != nil && t.clashServer.Mode() == ManualSelectTag {
 		pinnedTag = selector.Now()
 	}
-	// pinnedStale: the pinned tag is currently loaded but the server's
-	// latest config doesn't include it. We keep the outbound itself
-	// loaded (and in the manual-selector group) but still want to remove
-	// it from the AutoSelectTag urltest pool — otherwise an outbound the
-	// server explicitly excluded this cycle would still be a candidate
-	// if the user switches to auto before the next refresh.
-	var pinnedStale bool
 	var toRemove []string
 	for _, tag := range selector.All() {
 		if tag == pinnedTag {
-			if !slices.Contains(newTags, tag) {
-				pinnedStale = true
-			}
 			continue
 		}
 		if !slices.Contains(newTags, tag) {
@@ -592,24 +582,6 @@ func (t *tunnel) updateOutbounds(list servers.ServerList) error {
 			return err
 		} else if err != nil {
 			errs = append(errs, err)
-		}
-		// Auto-pool cleanup for a stale pinned tag: the underlying outbound
-		// stays loaded (so the manual selector keeps a live config) but it
-		// leaves the auto urltest group so the bandit's exclusion this
-		// cycle is honored if the user flips to auto. Gated on
-		// hasNewOutbound so we don't shrink the auto pool when all the
-		// bandit's new picks failed to load — in that branch the old pool
-		// is what's keeping the tunnel alive.
-		if pinnedStale {
-			if err := t.mutGrpMgr.RemoveFromGroup(AutoSelectTag, pinnedTag); errors.Is(err, groups.ErrIsClosed) {
-				return errLibboxClosed
-			} else if err != nil {
-				errs = append(errs, fmt.Errorf("removing pinned tag %q from auto group: %w", pinnedTag, err))
-			} else {
-				slog.Debug("Removed pinned tag from auto group; kept in manual",
-					"pinned_tag", pinnedTag,
-				)
-			}
 		}
 	} else {
 		slog.Warn("All new outbounds failed to load, keeping old outbounds",

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -521,8 +521,37 @@ func (t *tunnel) updateOutbounds(list servers.ServerList) error {
 
 	// collect tags present in the current group but absent from the new config
 	newTags := list.Tags()
+	// Preserve the manual-selector's currently-selected outbound across
+	// config refreshes — but only when the user is actually in manual
+	// mode. The bandit re-picks routes on every /v1/config-new poll
+	// (60s..15min adaptive interval); without this preservation, a Pro
+	// user who manually selected a specific server would lose that
+	// outbound the moment the bandit's next pick excluded it and have to
+	// redial. Keeping the underlying outbound loaded in the outbound
+	// manager lets the manual selector stay pointing at the same TLS
+	// materials / keypair / masquerade origin the user is mid-session on.
+	//
+	// Gating on manual mode (rather than always preserving selector.Now())
+	// matters because the selector's Now() defaults to the first outbound
+	// in the group even when the user hasn't manually selected anything.
+	// Preserving that "default first" across refreshes when the user is
+	// in auto mode would slowly accumulate stale outbounds the bandit
+	// never asked for.
+	//
+	// Self-healing: if the underlying VPS is eventually destroyed by
+	// autoreplace, sing-box's dial fails and the tunnel's reconnect path
+	// surfaces the failure. The UI is expected to detect repeated
+	// connection failures on a manually selected server and prompt the
+	// user to re-select.
+	var pinnedTag string
+	if t.clashServer != nil && t.clashServer.Mode() == ManualSelectTag {
+		pinnedTag = selector.Now()
+	}
 	var toRemove []string
 	for _, tag := range selector.All() {
+		if tag == pinnedTag {
+			continue
+		}
 		if !slices.Contains(newTags, tag) {
 			toRemove = append(toRemove, tag)
 		}

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -547,9 +547,19 @@ func (t *tunnel) updateOutbounds(list servers.ServerList) error {
 	if t.clashServer != nil && t.clashServer.Mode() == ManualSelectTag {
 		pinnedTag = selector.Now()
 	}
+	// pinnedStale: the pinned tag is currently loaded but the server's
+	// latest config doesn't include it. We keep the outbound itself
+	// loaded (and in the manual-selector group) but still want to remove
+	// it from the AutoSelectTag urltest pool — otherwise an outbound the
+	// server explicitly excluded this cycle would still be a candidate
+	// if the user switches to auto before the next refresh.
+	var pinnedStale bool
 	var toRemove []string
 	for _, tag := range selector.All() {
 		if tag == pinnedTag {
+			if !slices.Contains(newTags, tag) {
+				pinnedStale = true
+			}
 			continue
 		}
 		if !slices.Contains(newTags, tag) {
@@ -582,6 +592,24 @@ func (t *tunnel) updateOutbounds(list servers.ServerList) error {
 			return err
 		} else if err != nil {
 			errs = append(errs, err)
+		}
+		// Auto-pool cleanup for a stale pinned tag: the underlying outbound
+		// stays loaded (so the manual selector keeps a live config) but it
+		// leaves the auto urltest group so the bandit's exclusion this
+		// cycle is honored if the user flips to auto. Gated on
+		// hasNewOutbound so we don't shrink the auto pool when all the
+		// bandit's new picks failed to load — in that branch the old pool
+		// is what's keeping the tunnel alive.
+		if pinnedStale {
+			if err := t.mutGrpMgr.RemoveFromGroup(AutoSelectTag, pinnedTag); errors.Is(err, groups.ErrIsClosed) {
+				return errLibboxClosed
+			} else if err != nil {
+				errs = append(errs, fmt.Errorf("removing pinned tag %q from auto group: %w", pinnedTag, err))
+			} else {
+				slog.Debug("Removed pinned tag from auto group; kept in manual",
+					"pinned_tag", pinnedTag,
+				)
+			}
 		}
 	} else {
 		slog.Warn("All new outbounds failed to load, keeping old outbounds",


### PR DESCRIPTION
## Summary

The bandit re-picks routes on every \`/v1/config-new\` poll (60s..15min adaptive interval). \`updateOutbounds\` previously computed \`toRemove = current_tags - new_tags\` and dropped anything the server didn't return — so a Pro user who manually selected a specific server would lose that outbound the moment the bandit's next pick excluded it and have to redial. Patrick flagged this: best case 15min of stable manual selection, worst case 60s.

## Fix

Client-side, at the sing-box layer where the selector lives. When the user is in manual mode, exclude the selector's currently-selected tag from \`toRemove\`:

\`\`\`go
var pinnedTag string
if t.clashServer != nil && t.clashServer.Mode() == ManualSelectTag {
    pinnedTag = selector.Now()
}
var toRemove []string
for _, tag := range selector.All() {
    if tag == pinnedTag {
        continue
    }
    if !slices.Contains(newTags, tag) {
        toRemove = append(toRemove, tag)
    }
}
\`\`\`

The underlying outbound (TLS materials, keypair, masquerade origin) stays loaded in the outbound manager across refreshes, so the manual selector keeps pointing at a live config and no redial is needed.

## Why gate on \`clashServer.Mode() == ManualSelectTag\`?

The selector's \`Now()\` defaults to the first outbound in the group even when the user hasn't manually selected anything. Preserving that "default first" across refreshes when the user is in auto mode would slowly accumulate stale outbounds the bandit never asked for.

## Self-healing

If the underlying VPS is autoreplaced/destroyed by lantern-cloud, sing-box's dial fails and the tunnel's reconnect path surfaces it. The UI is expected to detect repeated connection failures on a manually selected server and prompt the user to re-select. Until then, the cost of carrying a stale outbound in the manager is one entry in a hash map.

## Sequence

\`\`\`mermaid
sequenceDiagram
    autonumber
    participant U as User
    participant T as tunnel<br/>vpn/tunnel.go
    participant S as ManualSelector<br/>(sing-box)
    participant F as ConfigFetcher
    participant API as lantern-cloud api

    U->>T: SelectServer(\"São Paulo\")
    T->>S: SelectOutbound(\"sp-route-uuid\")
    Note over S: Now() == \"sp-route-uuid\"<br/>Mode == ManualSelectTag

    rect rgba(200, 255, 200, 0.3)
        F->>API: /v1/config-new (next poll)
        API-->>F: { configs: [eu, jp, us] } (bandit-picked, no SP)
        F->>T: updateOutbounds(eu, jp, us)
        Note over T: pinnedTag = \"sp-route-uuid\"<br/>(mode == manual)<br/>SP stays in outbound manager ✓
    end

    U->>U: still connected via SP, no redial
\`\`\`

Without the change, step 4 would have computed \`toRemove = [sp-route-uuid]\` and dropped the user's selection.

## Replaces

This replaces an earlier server-side pin design ([getlantern/lantern-cloud#2739](https://github.com/getlantern/lantern-cloud/pull/2739) + [getlantern/common#24](https://github.com/getlantern/common/pull/24)) that was closed in favor of this client-side approach. The server-side model worked but the wire-format change was unnecessary — every \"server-pin wins\" failure mode (route deprecated, launch_cfg rotated, tier downgrade) reduces to a connection failure the client already handles via fallback. Net result: zero wire-format change, zero server complexity, smaller blast radius.

## Test plan

- [x] \`go build ./vpn/...\` clean
- [x] \`go vet ./vpn/\` clean
- [x] \`go test -count=1 ./vpn/\` — 0 failures
- [ ] Manual smoke test: connect to a manually-selected server, wait through 2-3 config-new poll cycles, confirm the connection stays stable without redial events in the logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)