### PR TITLE
peer: route the peer-box sing-box logger into radiance's slog

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -13,8 +13,11 @@ import (
 	"time"
 
 	"github.com/sagernet/sing-box/experimental/libbox"
+	sblog "github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing/service"
 
 	box "github.com/getlantern/lantern-box"
+	lblog "github.com/getlantern/lantern-box/log"
 	"github.com/getlantern/lantern-box/tracker/peerconn"
 	"github.com/getlantern/radiance/common/settings"
 	"github.com/getlantern/radiance/events"
@@ -613,7 +616,17 @@ func pickInternalPort() uint16 {
 // here are scoped to this peer's box instance so the two coexist
 // without stomping on each other.
 func defaultBuildBoxService(_ context.Context, options string) (boxService, error) {
-	bs, err := libbox.NewServiceWithContext(box.BaseContext(), options, nil)
+	// Wire the peer's sing-box logger into radiance's slog so router /
+	// dial / outbound errors from this second box instance reach the
+	// same lantern.log as everything else. Without this the box's
+	// default stderr-only logger silently swallows the most useful
+	// signal — e.g. "why did api.iantem.io fail to dial?" during a
+	// peer-share verify failure — which made FD #174614 unnecessarily
+	// hard to triage. Mirrors vpn/tunnel.go's registration for the
+	// main tunnel's box.
+	ctx := box.BaseContext()
+	service.MustRegister[sblog.Factory](ctx, lblog.NewFactory(slog.Default().Handler()))
+	bs, err := libbox.NewServiceWithContext(ctx, options, nil)
 	if err != nil {
 		return nil, fmt.Errorf("libbox.NewServiceWithContext: %w", err)
 	}


### PR DESCRIPTION
## Summary

The second sing-box instance the peer client spins up was constructed with a plain \`box.BaseContext()\` and no sing-box log factory registered. That means router / dial / outbound errors from the peer-box landed on the box's default stderr logger and never reached \`lantern.log\` — which made the SmC verify-failure incident triaged today unnecessarily hard.

We had:
- \`[samizdat] CONNECT api.iantem.io:443: handler started\` at \`20:41:35.079\`
- \`[samizdat] CONNECT api.iantem.io:443: handler returned, starting drain\` at \`20:41:35.096\` — 17 ms later
- Then 5 s of drain timeout and 1475 bytes of the verifier's TLS ClientHello discarded
- Server-side: \`peer verify failed: verify round-trip through peer: Get \"https://api.iantem.io/v1/peer/verify-callback?token=...\": EOF\`

The peer's sing-box outbound dial to \`api.iantem.io\` failed almost instantly — but with **zero error log anywhere** in either \`lantern.log\` or \`lantern_macos.log\`. The \`i.logger.ErrorContext(ctx, err)\` at \`lantern-box/protocol/samizdat/inbound.go:178\` would have caught the underlying error, but the peer-box's logger output goes to a default stderr destination instead of slog.

## Change

Mirror what \`vpn/tunnel.go:141-142\` already does for the main tunnel's box — register \`lblog.NewFactory(slog.Default().Handler())\` as the \`sblog.Factory\` on the peer-box's context before \`NewServiceWithContext\`. sing-box logger output now flows through radiance's slog and into \`lantern.log\` alongside everything else.

## Test plan

- [x] \`go build ./peer/...\` passes
- [x] \`go test -count=1 ./peer/...\` passes (existing peer tests still green)
- [ ] Next SmC toggle that triggers a verify failure should now produce a sing-box-side error log line in \`lantern.log\` explaining the actual dial failure — that's the signal we were missing today.

## Stack note

Branched off \`fisk/peer-connection-events\` because the peer module lives there. Will rebase onto main once the peer module merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)