### PR TITLE
backend, vpn: preserve user state on config refresh

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -324,7 +324,8 @@ func (r *LocalBackend) startVPNStatusListeners() {
 		r.updateURLTestListener(evt.Status)
 	})
 	events.SubscribeContext(r.ctx, func(evt vpn.StatusUpdateEvent) {
-		if evt.Status == vpn.Disconnected || evt.Status == vpn.ErrorStatus {
+		switch evt.Status {
+		case vpn.Disconnected, vpn.ErrorStatus, vpn.Restarting:
 			r.clearSelectedIfMissing()
 		}
 	})

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -590,16 +590,6 @@ func (r *LocalBackend) setServers(list servers.ServerList, isLantern bool) error
 	// updateOutbounds evicts any outbound absent from the list; include all
 	// servers so user-added outbounds aren't removed on a Lantern config update.
 	allList := servers.ServerList{Servers: r.srvManager.AllServers(), URLOverrides: list.URLOverrides}
-
-	var selected servers.Server
-	manual := settings.GetStruct(settings.SelectedServerKey, &selected) == nil && selected.Tag != ""
-	if manual && selected.IsLantern == isLantern && !slices.Contains(allList.Tags(), selected.Tag) {
-		// Keep the user's manually-chosen server alive in the tunnel pool
-		// even though it's gone from the manager, so the connection survives
-		// backend rotations until the user switches.
-		allList.Servers = append(allList.Servers, &selected)
-	}
-
 	if err := r.vpnClient.UpdateOutbounds(allList); err != nil && !errors.Is(err, vpn.ErrTunnelNotConnected) {
 		return fmt.Errorf("failed to update VPN outbounds: %w", err)
 	}

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -183,6 +183,7 @@ func NewLocalBackend(ctx context.Context, opts Options) (*LocalBackend, error) {
 	}
 	r.sessionHistory = vpn.NewSessionHistory(slog.Default().With("service", "session_history"), r.sessionInfo())
 	r.shutdownFuncs = append(r.shutdownFuncs, func() error { r.sessionHistory.Close(); return nil })
+	r.clearSelectedIfMissing()
 	return r, nil
 }
 
@@ -321,6 +322,11 @@ func (r *LocalBackend) startVPNStatusListeners() {
 	})
 	events.SubscribeContext(r.ctx, func(evt vpn.StatusUpdateEvent) {
 		r.updateURLTestListener(evt.Status)
+	})
+	events.SubscribeContext(r.ctx, func(evt vpn.StatusUpdateEvent) {
+		if evt.Status == vpn.Disconnected || evt.Status == vpn.ErrorStatus {
+			r.clearSelectedIfMissing()
+		}
 	})
 }
 
@@ -472,8 +478,7 @@ func (r *LocalBackend) maybeRestartVPN(updates settings.Settings) {
 	_, smartRoutingChanged := updates[settings.SmartRoutingKey]
 	if (adBlockChanged || smartRoutingChanged) && r.vpnClient.Status() == vpn.Connected {
 		slog.Info("Restarting VPN to apply new settings", "ad_block_changed", adBlockChanged, "smart_routing_changed", smartRoutingChanged)
-		bOptions := r.getBoxOptions()
-		go r.vpnClient.Restart(bOptions)
+		go r.RestartVPN()
 	}
 }
 
@@ -584,11 +589,19 @@ func (r *LocalBackend) setServers(list servers.ServerList, isLantern bool) error
 	// updateOutbounds evicts any outbound absent from the list; include all
 	// servers so user-added outbounds aren't removed on a Lantern config update.
 	allList := servers.ServerList{Servers: r.srvManager.AllServers(), URLOverrides: list.URLOverrides}
-	err := r.vpnClient.UpdateOutbounds(allList)
-	if err != nil && !errors.Is(err, vpn.ErrTunnelNotConnected) {
-		slog.Error("Failed to update VPN outbounds after config change", "error", err)
+
+	var selected servers.Server
+	manual := settings.GetStruct(settings.SelectedServerKey, &selected) == nil && selected.Tag != ""
+	if manual && selected.IsLantern == isLantern && !slices.Contains(allList.Tags(), selected.Tag) {
+		// Keep the user's manually-chosen server alive in the tunnel pool
+		// even though it's gone from the manager, so the connection survives
+		// backend rotations until the user switches.
+		allList.Servers = append(allList.Servers, &selected)
 	}
-	r.clearSelectedIfMissing()
+
+	if err := r.vpnClient.UpdateOutbounds(allList); err != nil && !errors.Is(err, vpn.ErrTunnelNotConnected) {
+		return fmt.Errorf("failed to update VPN outbounds: %w", err)
+	}
 	return nil
 }
 

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -581,7 +581,10 @@ func (r *LocalBackend) setServers(list servers.ServerList, isLantern bool) error
 	if err := r.srvManager.SetServers(list, isLantern); err != nil {
 		return fmt.Errorf("failed to set servers in ServerManager: %w", err)
 	}
-	err := r.vpnClient.UpdateOutbounds(list)
+	// updateOutbounds evicts any outbound absent from the list; include all
+	// servers so user-added outbounds aren't removed on a Lantern config update.
+	allList := servers.ServerList{Servers: r.srvManager.AllServers(), URLOverrides: list.URLOverrides}
+	err := r.vpnClient.UpdateOutbounds(allList)
 	if err != nil && !errors.Is(err, vpn.ErrTunnelNotConnected) {
 		slog.Error("Failed to update VPN outbounds after config change", "error", err)
 	}

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -519,9 +519,21 @@ func (t *tunnel) updateOutbounds(list servers.ServerList) error {
 		return t.ctx.Err()
 	}
 
+	// collect tags present in the current group but absent from the new config
 	newTags := list.Tags()
+	// In manual mode, keep the selected outbound alive across config
+	// refreshes so the user doesn't get redialed when the bandit excludes
+	// it. Gated on mode because selector.Now() defaults to the first
+	// outbound even with no manual selection.
+	var pinnedTag string
+	if t.clashServer != nil && t.clashServer.Mode() == ManualSelectTag {
+		pinnedTag = selector.Now()
+	}
 	var toRemove []string
 	for _, tag := range selector.All() {
+		if tag == pinnedTag {
+			continue
+		}
 		if !slices.Contains(newTags, tag) {
 			toRemove = append(toRemove, tag)
 		}

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -519,21 +519,9 @@ func (t *tunnel) updateOutbounds(list servers.ServerList) error {
 		return t.ctx.Err()
 	}
 
-	// collect tags present in the current group but absent from the new config
 	newTags := list.Tags()
-	// In manual mode, keep the selected outbound alive across config
-	// refreshes so the user doesn't get redialed when the bandit excludes
-	// it. Gated on mode because selector.Now() defaults to the first
-	// outbound even with no manual selection.
-	var pinnedTag string
-	if t.clashServer != nil && t.clashServer.Mode() == ManualSelectTag {
-		pinnedTag = selector.Now()
-	}
 	var toRemove []string
 	for _, tag := range selector.All() {
-		if tag == pinnedTag {
-			continue
-		}
 		if !slices.Contains(newTags, tag) {
 			toRemove = append(toRemove, tag)
 		}


### PR DESCRIPTION
## Summary

Three related fixes that prevent a Lantern config refresh from destroying the user's VPN state:

- **Non-Lantern outbounds were being evicted.** `setServers` was pushing only the Lantern list to `UpdateOutbounds`, so any user-added (private/custom) outbound that wasn't in the new config got removed from the tunnel. Now the full server list (Lantern + custom) is included.
- **Manual server selection was lost on every config rotation.** `setServers` was unconditionally calling `clearSelectedIfMissing`, immediately flipping the user to auto-select whenever the backend rotated their pinned server out of the new list. That call has been removed; the manual-mode pin in `tunnel.updateOutbounds` (introduced in #480) already keeps the outbound alive in the selector pool across the refresh.
- **The pin is bounded to the current tunnel session.** `clearSelectedIfMissing` now runs at startup (`NewLocalBackend`), on `Disconnected` / `ErrorStatus` / `Restarting` events, and on explicit `RemoveServers`. Any teardown drops a stale pin to auto-select, so the user can't reconnect to a server the backend has retired.

Other changes:
- `setServers` now propagates `UpdateOutbounds` errors instead of swallowing them.
- `maybeRestartVPN` routed through `RestartVPN` instead of inlining `getBoxOptions` + `vpnClient.Restart`.