### PR TITLE
kindling: route smart strategy probes through bypass dialer

### DIFF
--- a/bypass/streamdialer.go
+++ b/bypass/streamdialer.go
@@ -25,11 +25,10 @@ func StreamDialer() transport.StreamDialer {
 }
 
 // halfCloseConn adapts a net.Conn to transport.StreamConn by adding
-// CloseRead / CloseWrite. The direct-fallback path returns *net.TCPConn,
-// which already implements both; the proxy path returns *bufferedConn,
-// which doesn't expose half-close through its method set. Full Close on
-// the half-close intent is a safe approximation — the smart strategy only
-// uses these to probe paths, not to enforce HTTP/1.1 EOF semantics.
+// CloseRead / CloseWrite. Underlying conns that already implement
+// half-close are used as-is; the rest fall back to full Close, which is
+// a safe approximation for the smart strategy's probe paths (it does not
+// enforce HTTP/1.1 EOF semantics on probe streams).
 type halfCloseConn struct {
 	net.Conn
 }

--- a/bypass/streamdialer.go
+++ b/bypass/streamdialer.go
@@ -1,0 +1,49 @@
+package bypass
+
+import (
+	"context"
+	"net"
+
+	"github.com/Jigsaw-Code/outline-sdk/transport"
+)
+
+// StreamDialer returns a transport.StreamDialer that wraps DialContext.
+//
+// Use this when handing kindling (or any other Outline-SDK-shaped consumer)
+// a dialer that should route around the VPN tunnel radiance is serving.
+// The smart strategy's connection attempts go through the local bypass
+// proxy (and fall back to a direct dial when the proxy isn't listening),
+// so kindling traffic doesn't loop back through the tunnel.
+func StreamDialer() transport.StreamDialer {
+	return transport.FuncStreamDialer(func(ctx context.Context, addr string) (transport.StreamConn, error) {
+		conn, err := DialContext(ctx, "tcp", addr)
+		if err != nil {
+			return nil, err
+		}
+		return halfCloseConn{Conn: conn}, nil
+	})
+}
+
+// halfCloseConn adapts a net.Conn to transport.StreamConn by adding
+// CloseRead / CloseWrite. The direct-fallback path returns *net.TCPConn,
+// which already implements both; the proxy path returns *bufferedConn,
+// which doesn't expose half-close through its method set. Full Close on
+// the half-close intent is a safe approximation — the smart strategy only
+// uses these to probe paths, not to enforce HTTP/1.1 EOF semantics.
+type halfCloseConn struct {
+	net.Conn
+}
+
+func (c halfCloseConn) CloseRead() error {
+	if hc, ok := c.Conn.(interface{ CloseRead() error }); ok {
+		return hc.CloseRead()
+	}
+	return c.Conn.Close()
+}
+
+func (c halfCloseConn) CloseWrite() error {
+	if hc, ok := c.Conn.(interface{ CloseWrite() error }); ok {
+		return hc.CloseWrite()
+	}
+	return c.Conn.Close()
+}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ replace github.com/refraction-networking/water => github.com/getlantern/water v0
 
 require (
 	github.com/1Password/srp v0.2.0
+	github.com/Jigsaw-Code/outline-sdk v0.0.19
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/alexflint/go-arg v1.6.1
 	github.com/alitto/pond v1.9.2
@@ -30,7 +31,7 @@ require (
 	github.com/getlantern/dnstt v0.0.0-20260112160750-05100563bd0d
 	github.com/getlantern/domainfront v0.0.0-20260419161617-0bff0b2169f4
 	github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694
-	github.com/getlantern/kindling v0.0.0-20260507163327-92a44d03bdc5
+	github.com/getlantern/kindling v0.0.0-20260516120759-a9712f95df03
 	github.com/getlantern/lantern-box v0.0.82
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b
@@ -59,7 +60,6 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
-	github.com/Jigsaw-Code/outline-sdk v0.0.19 // indirect
 	github.com/Jigsaw-Code/outline-sdk/x v0.0.2 // indirect
 	github.com/RoaringBitmap/roaring v1.2.3 // indirect
 	github.com/STARRY-S/zip v0.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,8 @@ github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 h1:cSrD9ryDfTV2y
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770/go.mod h1:GOQsoDnEHl6ZmNIL+5uVo+JWRFWozMEp18Izcb++H+A=
 github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694 h1:iLWm6S/47Hfk7FjW6yaD+1h6kO7C/iauV0DkVia/bXU=
 github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
-github.com/getlantern/kindling v0.0.0-20260507163327-92a44d03bdc5 h1:ukTEQ2S16zMK2BJxIM0qKz+WiiyiPwvmLCWlK1EOvVU=
-github.com/getlantern/kindling v0.0.0-20260507163327-92a44d03bdc5/go.mod h1:TGTxpoNVwc8Be4qkBNtf5oj2psJaEIZEq47GOPS7zkA=
+github.com/getlantern/kindling v0.0.0-20260516120759-a9712f95df03 h1:dUTN7mnTTBcSvsURNs1rTlyKrD1uXUEPqxEZDfl+hb4=
+github.com/getlantern/kindling v0.0.0-20260516120759-a9712f95df03/go.mod h1:TGTxpoNVwc8Be4qkBNtf5oj2psJaEIZEq47GOPS7zkA=
 github.com/getlantern/lantern-box v0.0.82 h1:hCXqpCxLOQNxYtQZQDYVh3aj3t8NqSBqJjCn2mIBtK0=
 github.com/getlantern/lantern-box v0.0.82/go.mod h1:wJhPQKdnwD6qW/ghAfzsrj/IfHZbvFSAfr52+Tu6dbw=
 github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90 h1:P9JX1yAu2uq3b5YiT0sLtHkTrkZuttV8gPZh81nUuag=

--- a/kindling/client.go
+++ b/kindling/client.go
@@ -15,11 +15,13 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/getlantern/radiance/bypass"
 	"github.com/getlantern/radiance/common"
 	"github.com/getlantern/radiance/common/reporting"
 	"github.com/getlantern/radiance/common/settings"
 	"github.com/getlantern/radiance/kindling/dnstt"
 	"github.com/getlantern/radiance/kindling/fronted"
+	radiancesmart "github.com/getlantern/radiance/kindling/smart"
 	"github.com/getlantern/radiance/traces"
 )
 
@@ -108,6 +110,8 @@ func NewKindling(dataDir string) (kindling.Kindling, error) {
 		return kindling.NewKindling("radiance",
 			kindling.WithPanicListener(reporting.PanicListener),
 			kindling.WithLogWriter(logger),
+			kindling.WithStreamDialer(bypass.StreamDialer()),
+			kindling.WithSmartDialerConfig(radiancesmart.DialerConfig),
 			// "pro-server" calls still target api.getiantem.org; everything
 			// else uses df.iantem.io.
 			kindling.WithProxyless("df.iantem.io", "api.getiantem.org", "api.staging.iantem.io"),
@@ -118,6 +122,8 @@ func NewKindling(dataDir string) (kindling.Kindling, error) {
 	kindlingOptions := []kindling.Option{
 		kindling.WithPanicListener(reporting.PanicListener),
 		kindling.WithLogWriter(logger),
+		kindling.WithStreamDialer(bypass.StreamDialer()),
+		kindling.WithSmartDialerConfig(radiancesmart.DialerConfig),
 	}
 
 	updaterCtx, cancel := context.WithCancel(ctx)

--- a/kindling/smart/client.go
+++ b/kindling/smart/client.go
@@ -3,11 +3,10 @@
 package smart
 
 import (
-	"context"
+	_ "embed"
 	"fmt"
 	"io"
 	"log/slog"
-	"net"
 	"net/http"
 	"net/url"
 	"sync"
@@ -22,6 +21,19 @@ import (
 
 const tracerName = "github.com/getlantern/radiance/kindling/smart"
 
+// DialerConfig is a copy of kindling's smart_dialer_config.yml with the
+// `system: {}` DNS entry removed. The outline-sdk smart strategy enforces
+// a type check at smart/stream_dialer.go:350 that the base StreamDialer
+// is *transport.TCPDialer whenever the system resolver is selected; the
+// bypass StreamDialer doesn't satisfy that check, so the strategy errors
+// out at construction with "no fallback was specified". DoH entries route
+// every probe through the supplied StreamDialer instead, which is what we
+// want anyway — system DNS uses OS routing tables and would loop back
+// through the VPN TUN we're trying to bypass.
+//
+//go:embed smart_dialer_config.yml
+var DialerConfig []byte
+
 func NewHTTPClientWithSmartTransport(logWriter io.Writer, address string) (*http.Client, error) {
 	// Parse the domain from the URL.
 	u, err := url.Parse(address)
@@ -31,11 +43,10 @@ func NewHTTPClientWithSmartTransport(logWriter io.Writer, address string) (*http
 
 	// Extract the domain from the URL.
 	domain := u.Host
-	trans, err := kindling.NewSmartHTTPTransport(logWriter, domain)
+	trans, err := kindling.NewSmartHTTPTransportWithConfig(logWriter, DialerConfig, bypass.StreamDialer(), nil, domain)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create smart HTTP transport: %v", err)
 	}
-	wrapTransportWithBypass(trans)
 	lz := &lazyDialingRoundTripper{
 		smartTransportMu: sync.Mutex{},
 		logWriter:        logWriter,
@@ -71,13 +82,12 @@ func (lz *lazyDialingRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 
 	if lz.smartTransport == nil {
 		slog.Info("Smart transport is nil")
-		trans, err := kindling.NewSmartHTTPTransport(lz.logWriter, lz.domain)
+		trans, err := kindling.NewSmartHTTPTransportWithConfig(lz.logWriter, DialerConfig, bypass.StreamDialer(), nil, lz.domain)
 		if err != nil {
 			slog.Info("Error creating smart transport", "error", err)
 			lz.smartTransportMu.Unlock()
 			return nil, traces.RecordError(ctx, fmt.Errorf("could not create smart transport -- offline? %v", err))
 		}
-		wrapTransportWithBypass(trans)
 		lz.smartTransport = trans
 	}
 
@@ -87,13 +97,4 @@ func (lz *lazyDialingRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 		traces.RecordError(ctx, err, trace.WithStackTrace(true))
 	}
 	return res, err
-}
-
-func wrapTransportWithBypass(trans *http.Transport) {
-	if trans == nil {
-		return
-	}
-	trans.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-		return bypass.DialContext(ctx, network, addr)
-	}
 }

--- a/kindling/smart/client.go
+++ b/kindling/smart/client.go
@@ -22,14 +22,12 @@ import (
 const tracerName = "github.com/getlantern/radiance/kindling/smart"
 
 // DialerConfig is a copy of kindling's smart_dialer_config.yml with the
-// `system: {}` DNS entry removed. The outline-sdk smart strategy enforces
-// a type check at smart/stream_dialer.go:350 that the base StreamDialer
-// is *transport.TCPDialer whenever the system resolver is selected; the
-// bypass StreamDialer doesn't satisfy that check, so the strategy errors
-// out at construction with "no fallback was specified". DoH entries route
-// every probe through the supplied StreamDialer instead, which is what we
-// want anyway — system DNS uses OS routing tables and would loop back
-// through the VPN TUN we're trying to bypass.
+// `system: {}` DNS entry removed. The outline-sdk smart strategy rejects
+// any base StreamDialer that isn't *transport.TCPDialer when the system
+// resolver is selected, which the bypass dialer can't satisfy. DoH entries
+// route every probe through the supplied StreamDialer instead, which is
+// what we want anyway — system DNS uses OS routing tables and would loop
+// back through the VPN TUN we're trying to bypass.
 //
 //go:embed smart_dialer_config.yml
 var DialerConfig []byte

--- a/kindling/smart/smart_dialer_config.yml
+++ b/kindling/smart/smart_dialer_config.yml
@@ -1,0 +1,32 @@
+dns:
+  - https:
+      name: cloudflare-dns.com.
+      address: cloudflare.net.
+  - https:
+      name: doh.dns.sb
+      address: cloudflare.net:443
+  - https:
+      name: "2001:4860:4860::8844"
+  - https:
+      name: "8.8.4.4"
+  - https:
+      name: "1.0.0.1"
+  - https:
+      name: "2606:4700:4700::1001"
+  - https:
+      name: "223.5.5.5"
+  - https:
+      name: "2620:119:35::35"
+  - https:
+      name: "208.67.220.220"
+  - https:
+      name: "2620:119:53::53"
+  - https:
+      name: "208.67.222.222"
+
+tls:
+  - "" # Direct dialer
+  - split:1
+  - split:2,20*5
+  - split:200|disorder:1
+  - tlsfrag:1


### PR DESCRIPTION
## Summary

The smart strategy was paying for DNS/TLS strategy probes that the existing `wrapTransportWithBypass` call threw away by overwriting `http.Transport.DialContext` post-construction. After this change the strategy actually uses the bypass dialer end-to-end, so kindling traffic stays out of the VPN TUN even when the smart path wins the race.

Originated in [this Slack thread](https://wdynhnkxvsdx.slack.com/archives/C01K9DJ1ES2/p1778881001409919). Paired with [kindling#34](https://github.com/getlantern/kindling/pull/34) (already merged) which added `NewSmartHTTPTransportWithDialer` + `WithStreamDialer`/`WithPacketDialer`, and [kindling#35](https://github.com/getlantern/kindling/pull/35) (already merged) which added `WithSmartDialerConfig` so radiance can supply a `system`-less YAML.

## Why both pieces are needed

**Before (smart strategy compute wasted):**

```mermaid
sequenceDiagram
    autonumber
    participant R as radiance/smart
    participant K as kindling
    participant S as outline-sdk smart
    R->>K: NewSmartHTTPTransport(domain)
    K->>S: NewDialer with TCPDialer{}
    S-->>K: smart dialer (system DNS + chosen TLS strategy)
    K-->>R: http.Transport
    Note over R: wrapTransportWithBypass overwrites trans.DialContext
    Note over R: every request now goes via bypass.DialContext, smart strategy bypassed
```

**After (smart strategy actually uses bypass end-to-end):**

```mermaid
sequenceDiagram
    autonumber
    participant R as radiance/smart
    participant K as kindling
    participant S as outline-sdk smart
    participant B as radiance/bypass
    R->>K: NewSmartHTTPTransportWithConfig(systemLessYAML, bypass.StreamDialer(), domain)
    K->>S: NewDialer with bypass StreamDialer + DoH-only DNS
    S->>B: probe DoH resolvers via bypass dialer
    B-->>S: connections that avoid the VPN TUN
    S-->>K: smart dialer whose every probe used bypass
    K-->>R: http.Transport (DialContext goes through bypass + strategy)
```

The system-resolver constraint that made this two-piece is enforced at `outline-sdk/x/smart/stream_dialer.go:350`:

```go
if resolver == nil {  // resolver == nil means "system: {}" was selected
    if _, ok := f.StreamDialer.(*transport.TCPDialer); !ok {
        return nil, fmt.Errorf("cannot use system resolver with base dialer of type %T", f.StreamDialer)
    }
}
```

A custom `StreamDialer` (our bypass `FuncStreamDialer`) is incompatible with system DNS — semantically correct, since system DNS uses OS routing tables and would loop back through the VPN TUN we're trying to bypass. The system-less YAML uses DoH entries that get dialed through `bypass.StreamDialer()` instead.

## Changes

- `bypass/streamdialer.go`
  - `bypass.StreamDialer()` exposes `bypass.DialContext` as a `transport.StreamDialer` for outline-sdk consumers
  - `halfCloseConn` adapts `net.Conn → transport.StreamConn` (the `bufferedConn` returned on the proxy path doesn't expose `CloseRead`/`CloseWrite` via embedding; falls back to full `Close()` when the underlying conn doesn't support half-close)
- `kindling/smart/smart_dialer_config.yml`
  - Copy of kindling's embedded YAML with `system: {}` removed; same DoH/DoT resolver list. Embedded as exported `DialerConfig` for reuse
- `kindling/smart/client.go`
  - Replaces `wrapTransportWithBypass` with `NewSmartHTTPTransportWithConfig(logWriter, DialerConfig, bypass.StreamDialer(), nil, domain)`
- `kindling/client.go`
  - Adds `WithStreamDialer(bypass.StreamDialer())` + `WithSmartDialerConfig(radiancesmart.DialerConfig)` to both the staging and production `WithProxyless` paths
- `go.mod` / `go.sum`
  - Bump kindling to `v0.0.0-20260516120759-a9712f95df03` (squash-merge of #35)
  - Surfaces direct `github.com/Jigsaw-Code/outline-sdk` dep for the `transport.StreamDialer` / `transport.StreamConn` types

## Test plan

- [x] `go test ./kindling/...` — `TestNewClient/{smart,domainfront,amp}` all pass on this branch (smart/domainfront were failing on prior bypass-only attempts that didn't include the system-less YAML)
- [x] `go test ./bypass/...` passes
- [ ] Smoke against a live VPN session: confirm kindling config fetch traffic doesn't appear in the TUN's PCAP (separate manual verification)

Note: two preexisting failures on `main` are unrelated to this PR (`cmd/lantern/lantern.go:169` build error from a different in-flight change, and `TestUserIDFormatMatchesMain` tmpdir flake in `config/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)