### PR TITLE
Fix IOS crash with new updates

### DIFF
--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -545,16 +544,12 @@ func (c *VPNClient) RunOfflineURLTests(basePath string, outbounds []option.Outbo
 		tags = append(tags, ob.Tag)
 	}
 	outbounds = append(outbounds, urlTestOutbound("offline-test", tags, banditURLs))
+	// CacheFile must stay disabled: enabling it holds an exclusive flock on
+	// a file in the iOS App Group container, which the OS kills across
+	// suspend with 0xdead10cc.
 	options := option.Options{
 		Log:       &option.LogOptions{Disabled: true},
 		Outbounds: outbounds,
-		Experimental: &option.ExperimentalOptions{
-			CacheFile: &option.CacheFileOptions{
-				Enabled: true,
-				Path:    filepath.Join(basePath, cacheFileName),
-				CacheID: cacheID,
-			},
-		},
 	}
 
 	// create offlineed box instance. we just use the standard box since we don't need a


### PR DESCRIPTION
## Summary

`RunOfflineURLTests` was creating its sing-box test instance with `CacheFile.Enabled: true` pointing at `<dataDir>/lantern.cache`. On iOS the data dir is the App Group container, and the bbolt-backed cache file is opened with an exclusive `flock(LOCK_EX)` for the lifetime of the instance (~5 s per probe). If iOS suspends the host app inside that window, RunningBoard terminates the process with `0xdead10cc` ("app held a file lock in a shared container at suspend").

This PR removes `CacheFile` from the offline-test options. The offline probe is short-lived and none of its code paths actually consume cache-file state, so removing it loses no functionality.

## The crash

- `EXC_CRASH (SIGKILL)`, `Termination Reason: RUNNINGBOARD 0xdead10cc`
- iOS 26.4.2, Lantern 9.1.9 (557)
- Thread 0 idle in `mach_msg2_trap` inside the standard CFRunLoop — no code-level fault site; the OS killed the process externally
- Empty Go panic log (`lantern-crash.log`)
- Reproducible live in lldb: trigger a config fetch, background the app within the offline-test window, `SIGKILL` lands within seconds at `mach_msg2_trap`

The on-device `lantern.log` shows every crashing session ending either mid-`"Performing offline URL tests"` or seconds after `"offline URL test complete"`, with no graceful shutdown.

## Root cause — full call chain

| # | Where | What happens |
|---|---|---|
| 1 | `backend/radiance.go:285` | config-handler event handler fires `r.RunOfflineURLTests()` on every config refresh |
| 2 | `vpn/vpn.go` (this PR) | builds sing-box `option.Options` with `Experimental.CacheFile.Enabled: true`, path = `<basePath>/lantern.cache` |
| 3 | sing-box `box.go:134-135` | `experimentalOptions.CacheFile.Enabled` ⇒ `needCacheFile = true` |
| 4 | sing-box `box.go:345-347` | `cachefile.New(...)` registered as internal service |
| 5 | `vpn/vpn.go` | `instance.PreStart()` |
| 6 | sing-box `box.go:451` | `adapter.StartNamed(StartStateInitialize, s.internalService)` runs the cachefile service |
| 7 | sing-box `experimental/cachefile/cache.go:115` | `bbolt.Open(c.path, fileMode, &bbolt.Options{Timeout: time.Second})` |
| 8 | bbolt `db.go:230` | `flock(db, !readOnly, timeout)` |
| 9 | bbolt `bolt_unix.go:23-29` | `syscall.Flock(fd, LOCK_EX \| LOCK_NB)` on Darwin/iOS — process-exclusive POSIX advisory lock held until `db.Close()` |

Lock release happens on `defer instance.Close()` once the URL test completes (≤5 s ctx timeout). Any iOS suspend that lands inside that window triggers the kill.

The config-handler log line `"Using server-recommended poll interval" interval=3m0s default=10m0s` shows the server is recommending a 3-minute poll cadence — so every ~3 minutes there is a 5-second vulnerable window. Multiple short-lived (~2 s) sessions in the captured logs die within seconds of `"Performing offline URL tests"`, with the app never reaching a graceful shutdown.

## When the regression was introduced

Before PR #370 (commit `e312570`, merged 2026-04-28), the predecessor `preTest` function built its options without `Experimental.CacheFile`:

```go
options := option.Options{
    Log:       &option.LogOptions{Disabled: true},
    Outbounds: outbounds,
}
```

bbolt was never opened, no flock was ever taken on a shared-container file from the host-app process. URL-test history was already persisted independently via plain JSON atomic writes (now handled in `LocalBackend.RunOfflineURLTests` by `srvManager.UpdateURLTestResults` → `manager.go saveServers`).

The `CacheFile` block was added during the LocalBackend refactor with no specific justification in the commit message — most likely copy-pasted from `baseOpts` in `boxoptions.go`, which legitimately needs `CacheFile` for the *main* tunnel.

The lantern mobile-app `go.mod` first picked up that regression on 2026-04-28 in commit `c0871a779` ("Garmr/radiance daemon refactor and clean-up #8578"). It has been present in every build since.

## Is anything lost?

No. CacheFile in `RunOfflineURLTests` was dead weight on every platform. The full set of CacheFile consumers in sing-box and whether the offline-test instance touches any of them:

| CacheFile consumer | Source | Used by offline-test? |
|---|---|---|
| `LoadSelected` / `StoreSelected` | `protocol/group/selector.go:84,131` | No — offline-test uses a `urltest`-type group, not `selector` |
| `LoadGroupExpand` / `StoreGroupExpand` | `experimental/libbox/command_group.go:127,192` | No — libbox UI state, no UI here |
| `LoadMode` / `StoreMode` | `experimental/clashapi/server.go:152,232` | No — offline-test instance has no ClashAPI options |
| `FakeIPReset` | `experimental/clashapi/cache.go:24` | No — clash API endpoint, no clash server |
| `StoreFakeIP` | `dns/transport/fakeip/store.go:37` | No — `StoreFakeIP` flag is false; also no DNS config |
| `StoreRDRC` | `dns/router.go:64` | No — `StoreRDRC` flag is false; also no DNS router |

URL-test history — the one piece of state you might expect the cache to hold — is **pure in-memory** in sing-box (`common/urltest/urltest.go:22-32`, a plain `map[string]*adapter.URLTestHistory`). The offline-test code already creates a fresh `urltest.NewHistoryStorage()` and registers it via `service.MustRegister[adapter.URLTestHistoryStorage]`, discarded on `instance.Close()`. None of it touches bbolt.

URL-test results from the offline probe continue to be persisted through the existing JSON path (`Manager.UpdateURLTestResults` → `<dataDir>/servers.json`). The on-device log confirms this — every `RunOfflineURLTests` cycle is followed by a `saveServers` line writing `servers.json` independently of `lantern.cache`.

## Why not platform-gate it (keep on non-iOS)?

Considered and rejected. CacheFile in the offline-test instance does nothing on any platform — it just opens and `flock`s a file none of the wired-up code reads from or writes to. Keeping it conditionally would mean carrying a `runtime.GOOS == "ios"` special-case for an option that is incidental cruft everywhere. There is also a latent non-iOS risk: both the offline-test instance and the main tunnel reference the same `<basePath>/lantern.cache` path, and bbolt's open-path retry can stall for up to ~11 seconds (`cachefile/cache.go:114-129`: 10 iterations × `bbolt.Options{Timeout: 1s}` + 100 ms sleeps) if the file is held elsewhere. The `c.tunnel != nil` early-return at `vpn.go:528` prevents that today, but it's a runtime gate, not a structural one. Removing CacheFile unconditionally is cleaner.

## Test plan

- [ ] Reproduce the previous crash on a stock build: connect VPN flow, wait for `"Performing offline URL tests"` log line, lock screen → confirm `RUNNINGBOARD 0xdead10cc` SIGKILL
- [ ] On this PR's build: same recipe, confirm app survives and resumes cleanly
- [ ] Verify `Manager.UpdateURLTestResults` still writes `servers.json` with the offline-test results (check `saveServers timing` log line after `"offline URL test complete"`)
- [ ] Smoke test main VPN connect/disconnect — `baseOpts` still uses `CacheFile.Enabled: true` for the tunnel itself, which is correct and unchanged
- [ ] Android: confirm no regression in offline URL test cycle on a Pro account

## References

- iOS TestFlight crash incident: `754BB178-DCF4-4BFE-83C8-234F77901248`
- Last good lantern pin (per QA): `lantern@b106b8eb1` → radiance `4445a20` (regression already latent here; bisect bound is approximate)
- Regression introduced: radiance `e312570` (PR #370), first pulled into lantern by `lantern@c0871a779` (2026-04-28)
- Apple termination code: `0xdead10cc` ("file lock held in shared container at suspend")