### PR TITLE
fix: synchronize VPN restart on settings change

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -467,20 +467,25 @@ func (r *LocalBackend) PatchSettings(updates settings.Settings) error {
 	if _, ok := diff[k]; ok {
 		r.splitTunnelMgr.SetEnabled(settings.GetBool(k))
 	}
-	r.maybeRestartVPN(diff)
-
-	return nil
+	return r.maybeRestartVPN(diff)
 }
 
 // maybeRestartVPN restarts the VPN connection if either the ad block or smart routing settings
-// were changed and the VPN is currently connected.
-func (r *LocalBackend) maybeRestartVPN(updates settings.Settings) {
+// were changed and the VPN is currently connected. Returns an error if the VPN restart fails;
+// otherwise returns nil.
+func (r *LocalBackend) maybeRestartVPN(updates settings.Settings) error {
 	_, adBlockChanged := updates[settings.AdBlockKey]
 	_, smartRoutingChanged := updates[settings.SmartRoutingKey]
 	if (adBlockChanged || smartRoutingChanged) && r.vpnClient.Status() == vpn.Connected {
 		slog.Info("Restarting VPN to apply new settings", "ad_block_changed", adBlockChanged, "smart_routing_changed", smartRoutingChanged)
-		go r.RestartVPN()
+		if err := r.RestartVPN(); err != nil {
+			return fmt.Errorf(
+				"failed to restart VPN (ad_block_changed=%v, smart_routing_changed=%v): %w",
+				adBlockChanged, smartRoutingChanged, err,
+			)
+		}
 	}
+	return nil
 }
 
 /////////////////

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -290,8 +290,8 @@ func (c *VPNClient) HistoryStorage() adapter.URLTestHistoryStorage {
 // AutoSelectTag or the empty string, the tunnel will switch to auto-select mode and automatically
 // choose the best server.
 func (c *VPNClient) SelectServer(tag string) error {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.tunnel == nil || c.Status() != Connected {
 		return ErrTunnelNotConnected
 	}


### PR DESCRIPTION
This pull request introduces improvements to the VPN backend's error handling and thread safety. The main changes focus on ensuring that errors during VPN restarts are properly propagated and that server selection is thread-safe.

**Error handling improvements:**

* Modified `LocalBackend.PatchSettings` and `maybeRestartVPN` in `radiance.go` to ensure that errors from VPN restarts are returned and not silently ignored. Now, if restarting the VPN fails due to settings changes, the error will propagate to the caller.

**Thread safety enhancements:**

* Updated `VPNClient.SelectServer` in `vpn.go` to use a write lock (`mu.Lock`) instead of a read lock (`mu.RLock`), ensuring thread-safe modification when selecting a server.