### PR TITLE
config: fix silently dropped triggered config refetch when already in-flight

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -294,7 +294,7 @@ func (r *LocalBackend) Start() {
 			slog.Error("Failed to run offline URL tests after config update", "error", err)
 		}
 	})
-	go r.confHandler.Start()
+	r.confHandler.Start()
 }
 
 func (r *LocalBackend) Close() {

--- a/config/config.go
+++ b/config/config.go
@@ -68,15 +68,24 @@ type Options struct {
 // to the most recent configuration.
 type ConfigHandler struct {
 	// config holds a configResult.
-	config   atomic.Pointer[Config]
-	ftr      Fetcher
-	started  atomic.Bool
-	fetching atomic.Bool
-	logger   *slog.Logger
-	options  Options
+	config  atomic.Pointer[Config]
+	ftr     Fetcher
+	logger  *slog.Logger
+	options Options
 
-	ctx          context.Context
-	cancel       context.CancelFunc
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	started atomic.Bool
+
+	// fetchMu guards fetching/pending. A caller arriving while a fetch is
+	// in flight sets pending; the in-flight fetch re-runs once to pick up
+	// state that changed mid-fetch (e.g. a user identity refreshed by an
+	// email login that completed after the request was already on the wire).
+	fetchMu  sync.Mutex
+	fetching bool
+	pending  bool
+
 	pollInterval time.Duration
 	configPath   string
 	wgKeyPath    string
@@ -152,12 +161,32 @@ func (ch *ConfigHandler) fetchConfig() error {
 	if ch.isClosed() {
 		return fmt.Errorf("config handler is closed")
 	}
-	if !ch.fetching.CompareAndSwap(false, true) {
-		ch.logger.Info("config fetch already in flight, skipping")
+
+	ch.fetchMu.Lock()
+	if ch.fetching {
+		ch.pending = true
+		ch.fetchMu.Unlock()
+		ch.logger.Info("config fetch already in flight, scheduling another after it completes")
 		return nil
 	}
-	defer ch.fetching.Store(false)
+	ch.fetching = true
+	ch.fetchMu.Unlock()
 
+	var lastErr error
+	for {
+		lastErr = ch.doFetchConfig()
+		ch.fetchMu.Lock()
+		if !ch.pending {
+			ch.fetching = false
+			ch.fetchMu.Unlock()
+			return lastErr
+		}
+		ch.pending = false
+		ch.fetchMu.Unlock()
+	}
+}
+
+func (ch *ConfigHandler) doFetchConfig() error {
 	privateKey, err := ch.loadWGKey()
 	if err != nil && !errors.Is(err, ErrNoWGKey) {
 		return fmt.Errorf("loading wg key: %w", err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	C "github.com/getlantern/common"
 	"github.com/stretchr/testify/assert"
@@ -164,6 +166,54 @@ func TestHandlerFetchConfig(t *testing.T) {
 	})
 }
 
+// TestFetchConfigCoalescesConcurrentRequest verifies that a fetchConfig call
+// arriving while another fetch is in flight returns immediately and causes
+// the in-flight fetch to re-run exactly once after it completes.
+func TestFetchConfigCoalescesConcurrentRequest(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, internal.ConfigFileName)
+
+	release := make(chan struct{})
+	bf := &BlockingFetcher{
+		response: []byte(`{"Servers":[{"Country":"US","City":"New York"}]}`),
+		entered:  make(chan struct{}, 2),
+		release:  release,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := &ConfigHandler{
+		configPath: configPath,
+		ftr:        bf,
+		wgKeyPath:  filepath.Join(tempDir, "wg.key"),
+		ctx:        ctx,
+		cancel:     cancel,
+		logger:     log.NoOpLogger(),
+	}
+
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- ch.fetchConfig() }()
+
+	select {
+	case <-bf.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first fetch never started")
+	}
+
+	require.NoError(t, ch.fetchConfig(), "concurrent call should return nil while a fetch is in flight")
+
+	close(release)
+	require.NoError(t, <-firstDone, "first fetch should complete cleanly")
+
+	select {
+	case <-bf.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("coalesced follow-up fetch never started")
+	}
+
+	assert.Equal(t, int32(2), bf.calls.Load(), "expected exactly two fetches: original + coalesced follow-up")
+}
+
 // Make sure MockFetcher implements the Fetcher interface
 var _ Fetcher = (*MockFetcher)(nil)
 
@@ -176,3 +226,26 @@ type MockFetcher struct {
 func (mf *MockFetcher) fetchConfig(ctx context.Context, preferred C.ServerLocation, wgPublicKey string) ([]byte, error) {
 	return mf.response, mf.err
 }
+
+var _ Fetcher = (*BlockingFetcher)(nil)
+
+// BlockingFetcher is a test Fetcher that signals entry into each fetchConfig
+// call and blocks until release is closed.
+type BlockingFetcher struct {
+	response []byte
+	err      error
+	entered  chan struct{}
+	release  <-chan struct{}
+	calls    atomic.Int32
+}
+
+func (bf *BlockingFetcher) fetchConfig(ctx context.Context, preferred C.ServerLocation, wgPublicKey string) ([]byte, error) {
+	bf.calls.Add(1)
+	select {
+	case bf.entered <- struct{}{}:
+	default:
+	}
+	<-bf.release
+	return bf.response, bf.err
+}
+


### PR DESCRIPTION
## Summary

A `UserChangeEvent` firing while a poll-driven fetch was in flight could race the atomic dedup guard, be silently skipped, and leave the handler on stale config until the next ~10-minute poll tick — so after a login, the user could remain on pre-login config for up to ten minutes.

Replaces the `atomic.Bool` dedup with a mutex-protected `fetching`/`pending` pair. A caller arriving during an in-flight fetch sets `pending` and returns immediately; the in-flight loop re-runs `doFetchConfig` once after the current one returns, picking up the freshest identity for the second request. Worst case after an event storm: one extra HTTP round-trip on the stale-identity fetch, then a fresh one.