### PR TITLE
fix: returning *net.TCPConn if available

### DIFF
--- a/bypass/bypass_test.go
+++ b/bypass/bypass_test.go
@@ -118,6 +118,17 @@ func TestDialContext_FallbackWhenProxyDown(t *testing.T) {
 	assert.Equal(t, string(msg), string(buf[:n]))
 }
 
+func TestStreamDialer_DirectReturnsTCPConn(t *testing.T) {
+	echoAddr := newEchoServer(t)
+
+	conn, err := StreamDialer().DialStream(context.Background(), echoAddr)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, ok := conn.(*net.TCPConn)
+	assert.True(t, ok, "direct dial should return *net.TCPConn so disorder strategy can type-assert it")
+}
+
 func TestDialContext_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/bypass/streamdialer.go
+++ b/bypass/streamdialer.go
@@ -20,6 +20,13 @@ func StreamDialer() transport.StreamDialer {
 		if err != nil {
 			return nil, err
 		}
+		// Preserve *net.TCPConn identity so strategies that require it (e.g. disorder,
+		// which sets per-packet TTL via socket options) can type-assert it back.
+		// The proxy path returns a bufferedConn to the local proxy—not the target—so
+		// unwrapping it would expose the wrong socket; fall through to halfCloseConn.
+		if tcpConn, ok := conn.(*net.TCPConn); ok {
+			return tcpConn, nil
+		}
 		return halfCloseConn{Conn: conn}, nil
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/getlantern/dnstt v0.0.0-20260112160750-05100563bd0d
 	github.com/getlantern/domainfront v0.0.0-20260419161617-0bff0b2169f4
 	github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694
-	github.com/getlantern/kindling v0.0.0-20260516120759-a9712f95df03
+	github.com/getlantern/kindling v0.0.0-20260529141244-21f8b144afab
 	github.com/getlantern/lantern-box v0.0.84
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b

--- a/go.sum
+++ b/go.sum
@@ -246,10 +246,8 @@ github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 h1:cSrD9ryDfTV2y
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770/go.mod h1:GOQsoDnEHl6ZmNIL+5uVo+JWRFWozMEp18Izcb++H+A=
 github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694 h1:iLWm6S/47Hfk7FjW6yaD+1h6kO7C/iauV0DkVia/bXU=
 github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
-github.com/getlantern/kindling v0.0.0-20260516120759-a9712f95df03 h1:dUTN7mnTTBcSvsURNs1rTlyKrD1uXUEPqxEZDfl+hb4=
-github.com/getlantern/kindling v0.0.0-20260516120759-a9712f95df03/go.mod h1:TGTxpoNVwc8Be4qkBNtf5oj2psJaEIZEq47GOPS7zkA=
-github.com/getlantern/lantern-box v0.0.83 h1:8DO/24pGilGfqEjWHEF4M/iqI/IVdR3XIu5gCyA6iN0=
-github.com/getlantern/lantern-box v0.0.83/go.mod h1:6SO1p22tAq9y8JLjNnAbr4/GZ4VjmlcQGYn0qF4aD/k=
+github.com/getlantern/kindling v0.0.0-20260529141244-21f8b144afab h1:PitYhTvo3oHRKYl4pVAoOIN8bhM+Bw+JBWncMglvHSg=
+github.com/getlantern/kindling v0.0.0-20260529141244-21f8b144afab/go.mod h1:TGTxpoNVwc8Be4qkBNtf5oj2psJaEIZEq47GOPS7zkA=
 github.com/getlantern/lantern-box v0.0.84 h1:y+nezmu0LZDlzcS2A4oKDu3f1UTFAgA24vT1htvEiX0=
 github.com/getlantern/lantern-box v0.0.84/go.mod h1:6SO1p22tAq9y8JLjNnAbr4/GZ4VjmlcQGYn0qF4aD/k=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=


### PR DESCRIPTION
disorder proxyless method expects a *net.TCPConn but we're returning a different response type so if that conn type is available we will be returning it