### PR TITLE
vpn: reduce throughputTracker per-tick allocations on mobile

### DIFF
--- a/vpn/clash.go
+++ b/vpn/clash.go
@@ -9,7 +9,6 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"time"
 
 	N "github.com/sagernet/sing/common/network"
 	"github.com/sagernet/sing/service"
@@ -61,16 +60,16 @@ func newClashServer(ctx context.Context, _ log.ObservableFactory, options option
 	runCtx, cancel := context.WithCancel(ctx)
 	trafficManager := trafficontrol.NewManager()
 	return &clashServer{
-		ctx:            runCtx,
-		cancel:         cancel,
-		dnsRouter:      service.FromContext[adapter.DNSRouter](ctx),
-		outbound:       service.FromContext[adapter.OutboundManager](ctx),
-		endpoint:       service.FromContext[adapter.EndpointManager](ctx),
-		urlTestHistory: service.FromContext[adapter.URLTestHistoryStorage](ctx),
+		ctx:               runCtx,
+		cancel:            cancel,
+		dnsRouter:         service.FromContext[adapter.DNSRouter](ctx),
+		outbound:          service.FromContext[adapter.OutboundManager](ctx),
+		endpoint:          service.FromContext[adapter.EndpointManager](ctx),
+		urlTestHistory:    service.FromContext[adapter.URLTestHistoryStorage](ctx),
 		trafficManager:    trafficManager,
-		throughputTracker: newThroughputTracker(trafficManager, time.Second),
-		modeList:       modeList,
-		mode:           initial,
+		throughputTracker: newThroughputTracker(trafficManager, 0),
+		modeList:          modeList,
+		mode:              initial,
 	}, nil
 }
 

--- a/vpn/throughput_tracker.go
+++ b/vpn/throughput_tracker.go
@@ -53,6 +53,8 @@ type throughputTracker struct {
 	deltas          map[string]byteTotals
 }
 
+// newThroughputTracker returns a tracker sampling at interval; a non-positive
+// interval selects defaultThroughputSampleInterval.
 func newThroughputTracker(manager *trafficontrol.Manager, interval time.Duration) *throughputTracker {
 	if interval <= 0 {
 		interval = defaultThroughputSampleInterval

--- a/vpn/throughput_tracker.go
+++ b/vpn/throughput_tracker.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/sagernet/sing-box/experimental/clashapi/trafficontrol"
+
+	"github.com/getlantern/radiance/common"
 )
 
 // Throughput reports network throughput in bits per second.
@@ -15,7 +17,15 @@ type Throughput struct {
 	Down int64 `json:"down"`
 }
 
-const defaultThroughputSampleInterval = time.Second
+// defaultThroughputSampleInterval is longer on mobile because each tick allocates
+// a snapshot slice of every live and recently-closed connection via the upstream
+// trafficontrol API; at 1s on a phone this dominates GC churn under heavy traffic.
+var defaultThroughputSampleInterval = func() time.Duration {
+	if common.IsMobile() {
+		return 3 * time.Second
+	}
+	return time.Second
+}()
 
 type byteTotals struct {
 	up   int64
@@ -36,6 +46,11 @@ type throughputTracker struct {
 	seen       map[uuid.UUID]byteTotals
 	lastGlobal byteTotals
 	lastTickAt time.Time
+
+	// Scratch maps reused across ticks to avoid excessive allocations
+	nextSeen        map[uuid.UUID]byteTotals
+	nextPerOutbound map[string]Throughput
+	deltas          map[string]byteTotals
 }
 
 func newThroughputTracker(manager *trafficontrol.Manager, interval time.Duration) *throughputTracker {
@@ -43,10 +58,13 @@ func newThroughputTracker(manager *trafficontrol.Manager, interval time.Duration
 		interval = defaultThroughputSampleInterval
 	}
 	return &throughputTracker{
-		manager:     manager,
-		interval:    interval,
-		perOutbound: make(map[string]Throughput),
-		seen:        make(map[uuid.UUID]byteTotals),
+		manager:         manager,
+		interval:        interval,
+		perOutbound:     make(map[string]Throughput),
+		seen:            make(map[uuid.UUID]byteTotals),
+		nextSeen:        make(map[uuid.UUID]byteTotals),
+		nextPerOutbound: make(map[string]Throughput),
+		deltas:          make(map[string]byteTotals),
 	}
 }
 
@@ -101,17 +119,17 @@ func (s *throughputTracker) sample(now time.Time) {
 	}
 	s.lastTickAt = now
 
-	deltas := make(map[string]byteTotals)
-	nextSeen := make(map[uuid.UUID]byteTotals, len(s.seen))
+	clear(s.deltas)
+	clear(s.nextSeen)
 	visit := func(m trafficontrol.TrackerMetadata) {
 		up := m.Upload.Load()
 		down := m.Download.Load()
 		prev := s.seen[m.ID]
-		d := deltas[m.Outbound]
+		d := s.deltas[m.Outbound]
 		d.up += up - prev.up
 		d.down += down - prev.down
-		deltas[m.Outbound] = d
-		nextSeen[m.ID] = byteTotals{up: up, down: down}
+		s.deltas[m.Outbound] = d
+		s.nextSeen[m.ID] = byteTotals{up: up, down: down}
 	}
 	for _, m := range s.manager.Connections() {
 		visit(m)
@@ -119,11 +137,11 @@ func (s *throughputTracker) sample(now time.Time) {
 	for _, m := range s.manager.ClosedConnections() {
 		visit(m)
 	}
-	s.seen = nextSeen
+	s.seen, s.nextSeen = s.nextSeen, s.seen
 
-	perOutbound := make(map[string]Throughput, len(deltas))
-	for tag, d := range deltas {
-		perOutbound[tag] = Throughput{
+	clear(s.nextPerOutbound)
+	for tag, d := range s.deltas {
+		s.nextPerOutbound[tag] = Throughput{
 			Up:   int64(float64(d.up*8) / elapsed),
 			Down: int64(float64(d.down*8) / elapsed),
 		}
@@ -137,7 +155,7 @@ func (s *throughputTracker) sample(now time.Time) {
 	s.lastGlobal = byteTotals{up: gUp, down: gDown}
 
 	s.mu.Lock()
-	s.perOutbound = perOutbound
+	s.perOutbound, s.nextPerOutbound = s.nextPerOutbound, s.perOutbound
 	s.globalThroughput = globalThroughput
 	s.mu.Unlock()
 }

--- a/vpn/throughput_tracker_test.go
+++ b/vpn/throughput_tracker_test.go
@@ -129,3 +129,11 @@ func TestThroughputTracker_OutboundUnknownTag(t *testing.T) {
 	tr := newThroughputTracker(trafficontrol.NewManager(), time.Second)
 	assert.Equal(t, Throughput{}, tr.Outbound("missing"))
 }
+
+func TestThroughputTracker_NonPositiveIntervalUsesDefault(t *testing.T) {
+	mgr := trafficontrol.NewManager()
+	for _, interval := range []time.Duration{0, -time.Second} {
+		tr := newThroughputTracker(mgr, interval)
+		assert.Equal(t, defaultThroughputSampleInterval, tr.interval)
+	}
+}


### PR DESCRIPTION
This pull request introduces optimizations to the throughput tracking logic in the VPN package, primarily to reduce memory allocations and garbage collection overhead, especially on mobile devices. The changes dynamically adjust the throughput sampling interval based on the platform and introduce scratch maps that are reused across sampling ticks to minimize allocations.

**Performance improvements for throughput tracking:**

* The default throughput sampling interval (`defaultThroughputSampleInterval`) is now longer on mobile devices (3 seconds instead of 1 second) to reduce GC pressure caused by frequent allocations during heavy traffic. This is determined using the new `common.IsMobile()` check.
* The `throughputTracker` struct now includes scratch maps (`nextSeen`, `nextPerOutbound`, and `deltas`) that are reused across sampling ticks, avoiding repeated allocations and reducing GC churn. [[1]](diffhunk://#diff-7e30deab69e444cec932ec73afb86171362a7903caa6b8a2ddd44b31f64ae885R49-R53) [[2]](diffhunk://#diff-7e30deab69e444cec932ec73afb86171362a7903caa6b8a2ddd44b31f64ae885R65-R67)

**Refactoring of sampling logic:**

* The `sample` method now clears and reuses the scratch maps instead of allocating new ones each tick. The method also swaps the maps after each sampling tick to maintain correct state while minimizing allocations. [[1]](diffhunk://#diff-7e30deab69e444cec932ec73afb86171362a7903caa6b8a2ddd44b31f64ae885L104-R144) [[2]](diffhunk://#diff-7e30deab69e444cec932ec73afb86171362a7903caa6b8a2ddd44b31f64ae885L140-R158)

**Other minor changes:**

* The `time` package import was removed from `vpn/clash.go` as it is no longer needed.
* The `newClashServer` function now passes `0` for the throughput tracker interval, delegating the interval selection to the tracker itself.
* Added import of `github.com/getlantern/radiance/common` to support platform detection.