### PR TITLE
peer: manual port-forward override for UPnP-less networks

### DIFF
--- a/common/settings/settings.go
+++ b/common/settings/settings.go
@@ -56,6 +56,13 @@ const (
 	AdBlockKey          _key = "ad_block"           // bool
 	AutoConnectKey      _key = "auto_connect"       // bool
 	PeerShareEnabledKey _key = "peer_share_enabled" // bool
+	// PeerManualPortKey is the TCP port number the user has manually
+	// forwarded on their router (single-port 1:1 NAT). When non-zero,
+	// peer.Client.Start uses portforward.ManualForwarder with this port
+	// instead of probing UPnP. Surfaced as an Advanced setting in the
+	// Share My Connection UI for users on networks where UPnP is
+	// disabled or unavailable.
+	PeerManualPortKey _key = "peer_manual_port" // int (0 = use UPnP)
 	SelectedServerKey   _key = "selected_server"    // [servers.Server] Server.Options is not stored
 
 	PreferredLocationKey _key = "preferred_location" // [common.PreferredLocation]

--- a/common/settings/settings.go
+++ b/common/settings/settings.go
@@ -57,12 +57,14 @@ const (
 	AutoConnectKey      _key = "auto_connect"       // bool
 	PeerShareEnabledKey _key = "peer_share_enabled" // bool
 	// PeerManualPortKey is the TCP port number the user has manually
-	// forwarded on their router (single-port 1:1 NAT). When non-zero,
-	// peer.Client.Start uses portforward.ManualForwarder with this port
-	// instead of probing UPnP. Surfaced as an Advanced setting in the
-	// Share My Connection UI for users on networks where UPnP is
-	// disabled or unavailable.
-	PeerManualPortKey _key = "peer_manual_port" // int (0 = use UPnP)
+	// forwarded on their router for the peer-proxy inbound (single-
+	// port 1:1 NAT). Valid range is 1..65535; 0 means unset, in which
+	// case the peer falls back to UPnP discovery. Out-of-range values
+	// (negative, > 65535) are logged on read and treated as unset
+	// rather than silently wrapping to a wrong port. Surfaced as an
+	// Advanced setting in the Share My Connection UI for users on
+	// networks where UPnP is disabled or unavailable.
+	PeerManualPortKey _key = "peer_manual_port" // int (0 = unset; 1..65535 = manual port)
 	SelectedServerKey   _key = "selected_server"    // [servers.Server] Server.Options is not stored
 
 	PreferredLocationKey _key = "preferred_location" // [common.PreferredLocation]

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -17,6 +17,7 @@ import (
 	box "github.com/getlantern/lantern-box"
 	"github.com/getlantern/lantern-box/tracker/peerconn"
 	"github.com/getlantern/radiance/common/env"
+	"github.com/getlantern/radiance/common/settings"
 	"github.com/getlantern/radiance/events"
 	"github.com/getlantern/radiance/portforward"
 )
@@ -209,9 +210,28 @@ func NewClient(cfg Config) (*Client, error) {
 	}
 	if cfg.NewForwarder == nil {
 		cfg.NewForwarder = func(ctx context.Context) (portForwarder, error) {
+			// Manual port-forward override. Use case: networks where
+			// UPnP is disabled or unavailable (router has UPnP off for
+			// security, ISP-provided gateways without IGD, networks
+			// behind double-NAT) but the user has manually configured
+			// a port forward on their router. We trust the user's
+			// config — no UPnP roundtrip — and report the configured
+			// port as both the external and internal port (the 1:1
+			// case every consumer router exposes).
+			//
+			// Resolution order:
+			//   1. settings.PeerManualPortKey (Advanced UI)
+			//   2. RADIANCE_PEER_EXTERNAL_PORT env var (developer /
+			//      power-user override)
+			//   3. fall through to UPnP discovery
+			if port := uint16(settings.GetInt(settings.PeerManualPortKey)); port != 0 {
+				slog.Info("peer client using manual port forward",
+					"port", port, "source", "setting")
+				return &manualPortForwarder{port: port}, nil
+			}
 			if p := manualPort(); p != 0 {
 				slog.Info("peer client using manual port forward",
-					"port", p, "env", env.PeerExternalPort.String())
+					"port", p, "source", env.PeerExternalPort.String())
 				return &manualPortForwarder{port: p}, nil
 			}
 			// Explicitly return a nil interface on error — `return

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand/v2"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -21,41 +20,6 @@ import (
 	"github.com/getlantern/radiance/events"
 	"github.com/getlantern/radiance/portforward"
 )
-
-// manualPortForwarder satisfies the portForwarder interface without doing
-// any UPnP work. Used when env.PeerExternalPort is set.
-type manualPortForwarder struct{ port uint16 }
-
-func (m *manualPortForwarder) MapPort(_ context.Context, _ uint16, _ string) (*portforward.Mapping, error) {
-	return &portforward.Mapping{
-		ExternalPort: m.port,
-		InternalPort: m.port,
-		Method:       "manual-env",
-	}, nil
-}
-func (m *manualPortForwarder) UnmapPort(_ context.Context) error { return nil }
-func (m *manualPortForwarder) StartRenewal(_ context.Context)    {}
-func (m *manualPortForwarder) ExternalIP(_ context.Context) (string, error) {
-	// An empty external IP signals the server to use the address it
-	// observed on the inbound request — when the user has supplied a
-	// manual port but no WAN IP, the server's view is the right answer.
-	return "", nil
-}
-
-// manualPort returns the parsed env.PeerExternalPort value, or 0 if unset
-// or invalid.
-func manualPort() uint16 {
-	raw := env.GetString(env.PeerExternalPort)
-	if raw == "" {
-		return 0
-	}
-	p, err := strconv.Atoi(raw)
-	if err != nil || p < 1 || p > 65535 {
-		slog.Warn("ignoring invalid "+env.PeerExternalPort.String(), "value", raw)
-		return 0
-	}
-	return uint16(p)
-}
 
 // StatusEvent fires whenever the Client's session state changes — successful
 // Start, user Stop, or auto-Stop on a 404 heartbeat.
@@ -227,12 +191,18 @@ func NewClient(cfg Config) (*Client, error) {
 			if port := uint16(settings.GetInt(settings.PeerManualPortKey)); port != 0 {
 				slog.Info("peer client using manual port forward",
 					"port", port, "source", "setting")
-				return &manualPortForwarder{port: port}, nil
+				return portforward.NewManualForwarder(port), nil
 			}
-			if p := manualPort(); p != 0 {
-				slog.Info("peer client using manual port forward",
-					"port", p, "source", env.PeerExternalPort.String())
-				return &manualPortForwarder{port: p}, nil
+			if raw := env.GetString(env.PeerExternalPort); raw != "" {
+				port, err := portforward.ParseManualPort(raw)
+				if err != nil {
+					slog.Warn("ignoring invalid "+env.PeerExternalPort.String(),
+						"value", raw, "error", err)
+				} else {
+					slog.Info("peer client using manual port forward",
+						"port", port, "source", env.PeerExternalPort.String())
+					return portforward.NewManualForwarder(port), nil
+				}
 			}
 			// Explicitly return a nil interface on error — `return
 			// portforward.NewForwarder(ctx)` collapses the (*Forwarder, error)

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -184,10 +184,13 @@ func NewClient(cfg Config) (*Client, error) {
 			// case every consumer router exposes).
 			//
 			// Resolution order:
-			//   1. settings.PeerManualPortKey (Advanced UI)
+			//   1. "peer_manual_port" setting (Advanced UI)
 			//   2. RADIANCE_PEER_EXTERNAL_PORT env var (developer /
 			//      power-user override)
 			//   3. fall through to UPnP discovery
+			//
+			// Persisted names are quoted so the comment stays accurate
+			// if Go identifiers move or rename.
 			//
 			// Range-check the setting before casting to uint16 — a raw
 			// uint16 cast silently wraps negative values (-5 → 65531)

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -188,10 +188,24 @@ func NewClient(cfg Config) (*Client, error) {
 			//   2. RADIANCE_PEER_EXTERNAL_PORT env var (developer /
 			//      power-user override)
 			//   3. fall through to UPnP discovery
-			if port := uint16(settings.GetInt(settings.PeerManualPortKey)); port != 0 {
-				slog.Info("peer client using manual port forward",
-					"port", port, "source", "setting")
-				return portforward.NewManualForwarder(port), nil
+			//
+			// Range-check the setting before casting to uint16 — a raw
+			// uint16 cast silently wraps negative values (-5 → 65531)
+			// and values above the port space (70000 → 4464), which
+			// would register a port we don't listen on (or, worse, one
+			// we do listen on for a different service). Out-of-range
+			// values fall through to env-var and then UPnP as if the
+			// setting were unset.
+			if raw := settings.GetInt(settings.PeerManualPortKey); raw != 0 {
+				if raw < 1 || raw > 65535 {
+					slog.Warn("ignoring out-of-range peer_manual_port setting; falling through to env / UPnP",
+						"value", raw)
+				} else {
+					port := uint16(raw)
+					slog.Info("peer client using manual port forward",
+						"port", port, "source", "setting")
+					return portforward.NewManualForwarder(port), nil
+				}
 			}
 			if raw := env.GetString(env.PeerExternalPort); raw != "" {
 				port, err := portforward.ParseManualPort(raw)

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -627,58 +627,6 @@ func TestPickInternalPort_InRange(t *testing.T) {
 	}
 }
 
-// manualPort parses the RADIANCE_PEER_EXTERNAL_PORT env var. Unset, empty,
-// non-numeric, and out-of-range values all collapse to 0, which the
-// NewClient default factory treats as "no override → use UPnP discovery".
-// Only a 1..65535 value selects the manual path.
-func TestManualPort(t *testing.T) {
-	tests := []struct {
-		name string
-		env  string
-		want uint16
-	}{
-		{"unset", "", 0},
-		{"valid mid-range", "5698", 5698},
-		{"valid low boundary", "1", 1},
-		{"valid high boundary", "65535", 65535},
-		{"non-numeric", "abc", 0},
-		{"zero", "0", 0},
-		{"negative", "-5", 0},
-		{"above uint16", "65536", 0},
-		{"way above uint16", "99999", 0},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("RADIANCE_PEER_EXTERNAL_PORT", tc.env)
-			assert.Equal(t, tc.want, manualPort())
-		})
-	}
-}
-
-// manualPortForwarder must satisfy the portForwarder contract: MapPort
-// returns a Mapping using the configured port for both internal and
-// external (no rewrite — that's the user's responsibility), UnmapPort
-// and StartRenewal are no-ops, and ExternalIP returns "" so the server
-// substitutes the IP it observed on the request.
-func TestManualPortForwarder(t *testing.T) {
-	f := &manualPortForwarder{port: 5698}
-
-	m, err := f.MapPort(context.Background(), 30001, "ignored")
-	require.NoError(t, err)
-	assert.Equal(t, uint16(5698), m.ExternalPort)
-	assert.Equal(t, uint16(5698), m.InternalPort, "external==internal — user mapped them themselves")
-	assert.Equal(t, "manual-env", m.Method)
-
-	require.NoError(t, f.UnmapPort(context.Background()), "UnmapPort is a no-op for manual forwarders")
-
-	// StartRenewal must not panic or block.
-	f.StartRenewal(context.Background())
-
-	ip, err := f.ExternalIP(context.Background())
-	require.NoError(t, err)
-	assert.Empty(t, ip, "empty ip signals server to use observed source address")
-}
-
 func TestAPIError_StringFormat(t *testing.T) {
 	e := &APIError{Status: 422, Body: "could not connect to peer port"}
 	assert.Contains(t, e.Error(), "422")

--- a/portforward/manual.go
+++ b/portforward/manual.go
@@ -1,0 +1,71 @@
+package portforward
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+)
+
+// ManualForwarder satisfies the portForwarder contract without talking
+// to a UPnP gateway. The user is expected to have configured a port
+// forward on their router by hand (single-port 1:1 NAT — every consumer
+// router exposes port forwarding as a single port number) and pointed
+// peer.Client at it via setting or env var.
+//
+// Use case: networks where UPnP is disabled or unavailable (router has
+// UPnP off for security, ISP-provided gateways without IGD, networks
+// behind double-NAT). UPnP-based Forwarder fails in those environments.
+type ManualForwarder struct {
+	port uint16
+}
+
+// NewManualForwarder builds a ManualForwarder for a pre-configured router
+// port forward. port must be a valid TCP port; callers should obtain it
+// from ParseManualPort (env-var path) or from a setting that already
+// constrains the value to uint16.
+func NewManualForwarder(port uint16) *ManualForwarder {
+	return &ManualForwarder{port: port}
+}
+
+// ParseManualPort parses a string into a TCP port number. Values outside
+// 1..65535 return an error so callers can log and fall through to UPnP
+// discovery rather than register a non-listening port with the server.
+func ParseManualPort(s string) (uint16, error) {
+	p, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("parse %q: %w", s, err)
+	}
+	if p < 1 || p > 65535 {
+		return 0, fmt.Errorf("port %d out of range (1..65535)", p)
+	}
+	return uint16(p), nil
+}
+
+// MapPort reports the configured port as both external and internal. The
+// router-side rule is already in place; nothing to do at the protocol
+// layer.
+func (m *ManualForwarder) MapPort(_ context.Context, _ uint16, _ string) (*Mapping, error) {
+	return &Mapping{
+		ExternalPort: m.port,
+		InternalPort: m.port,
+		Method:       "manual",
+	}, nil
+}
+
+// UnmapPort is a no-op: the user owns the router rule and is responsible
+// for removing it.
+func (m *ManualForwarder) UnmapPort(_ context.Context) error { return nil }
+
+// StartRenewal is a no-op: manually-configured rules don't carry a UPnP
+// lease and don't need refreshing.
+func (m *ManualForwarder) StartRenewal(_ context.Context) {}
+
+// ExternalIP returns the empty string deliberately. With a manual port
+// forward we have no UPnP gateway to ask for the WAN address, and
+// probing a public IP service from the client adds a network roundtrip
+// for information lantern-cloud already has — the server observes the
+// peer's source address on the register call and uses that as the
+// canonical external IP when this field is empty.
+func (m *ManualForwarder) ExternalIP(_ context.Context) (string, error) {
+	return "", nil
+}

--- a/portforward/manual.go
+++ b/portforward/manual.go
@@ -6,15 +6,16 @@ import (
 	"strconv"
 )
 
-// ManualForwarder satisfies the portForwarder contract without talking
-// to a UPnP gateway. The user is expected to have configured a port
-// forward on their router by hand (single-port 1:1 NAT — every consumer
-// router exposes port forwarding as a single port number) and pointed
-// peer.Client at it via setting or env var.
+// ManualForwarder exposes the same Map/Unmap/StartRenewal/ExternalIP
+// surface as Forwarder but does no UPnP work. The user is expected to
+// have configured a port forward on their router by hand (single-port
+// 1:1 NAT — every consumer router exposes port forwarding as a single
+// port number) and supplied the port number out-of-band.
 //
 // Use case: networks where UPnP is disabled or unavailable (router has
 // UPnP off for security, ISP-provided gateways without IGD, networks
-// behind double-NAT). UPnP-based Forwarder fails in those environments.
+// behind double-NAT). The UPnP-based Forwarder fails in those
+// environments; this type lets callers bypass discovery entirely.
 type ManualForwarder struct {
 	port uint16
 }

--- a/portforward/manual.go
+++ b/portforward/manual.go
@@ -19,10 +19,9 @@ type ManualForwarder struct {
 	port uint16
 }
 
-// NewManualForwarder builds a ManualForwarder for a pre-configured router
-// port forward. port must be a valid TCP port; callers should obtain it
-// from ParseManualPort (env-var path) or from a setting that already
-// constrains the value to uint16.
+// NewManualForwarder builds a ManualForwarder for a pre-configured
+// router port forward. port must be in 1..65535; the caller is
+// responsible for validating its input before calling.
 func NewManualForwarder(port uint16) *ManualForwarder {
 	return &ManualForwarder{port: port}
 }

--- a/portforward/manual_test.go
+++ b/portforward/manual_test.go
@@ -1,0 +1,66 @@
+package portforward
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ParseManualPort accepts 1..65535 verbatim and rejects everything else
+// with an error so callers can log + fall through to UPnP discovery
+// rather than register a non-listening port with lantern-cloud.
+func TestParseManualPort(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    uint16
+		wantErr bool
+	}{
+		{"valid mid-range", "5698", 5698, false},
+		{"valid low boundary", "1", 1, false},
+		{"valid high boundary", "65535", 65535, false},
+		{"empty", "", 0, true},
+		{"non-numeric", "abc", 0, true},
+		{"zero", "0", 0, true},
+		{"negative", "-5", 0, true},
+		{"above uint16", "65536", 0, true},
+		{"way above uint16", "99999", 0, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseManualPort(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+				assert.Equal(t, uint16(0), got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// ManualForwarder satisfies the portForwarder contract: MapPort returns
+// a Mapping with external==internal port and the "manual" method tag,
+// UnmapPort and StartRenewal are no-ops, ExternalIP returns "" so the
+// server substitutes the IP it observed on the register call.
+func TestManualForwarder(t *testing.T) {
+	f := NewManualForwarder(5698)
+
+	m, err := f.MapPort(context.Background(), 30001, "ignored")
+	require.NoError(t, err)
+	assert.Equal(t, uint16(5698), m.ExternalPort)
+	assert.Equal(t, uint16(5698), m.InternalPort, "external==internal — user mapped them themselves")
+	assert.Equal(t, "manual", m.Method)
+
+	require.NoError(t, f.UnmapPort(context.Background()), "UnmapPort is a no-op for manual forwarders")
+
+	// StartRenewal must not panic or block.
+	f.StartRenewal(context.Background())
+
+	ip, err := f.ExternalIP(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, ip, "empty IP signals server to use observed source address")
+}


### PR DESCRIPTION
## Summary

Two related changes to the manual-port-forward path that ship together:

1. **Consolidates** the implementation into the `portforward` package. The manual forwarder landed in `peer/peer.go` via #466 to keep that PR's review surface small, but architecturally it belongs alongside the UPnP-based `Forwarder` — same interface, same package. This PR's first commit (`22d1533`) is a net-zero relocation: `peer.manualPortForwarder` → `portforward.ManualForwarder`, `peer.manualPort` → `portforward.ParseManualPort`, tests follow.

2. **Adds** the `PeerManualPortKey` setting so the Advanced UI in the Share My Connection screen can configure the port without an env var. The env-var path stays for developer / power-user use.

After both commits, the resolution order in `peer.Client.Start`'s `NewForwarder`:

1. `settings.PeerManualPortKey` if non-zero (UI),
2. else `RADIANCE_PEER_EXTERNAL_PORT` if set + parseable (developer override),
3. else fall back to UPnP discovery (existing behavior).

A non-positive or malformed env-var value is logged and the resolution falls through to UPnP discovery rather than registering a non-listening port with lantern-cloud.

## Why two configuration paths

- **Setting (`PeerManualPortKey`)** — for users on networks where UPnP is unavailable (ISP gateways with UPnP off, double-NAT, residential routers with the feature disabled). The Advanced section in the Share My Connection Flutter screen sets it; persists across restarts. Cleared by setting the value to 0.
- **Env var (`RADIANCE_PEER_EXTERNAL_PORT`)** — developer override for testing on macOS / CLI without a UI build. Same parser, same forwarder.

## What's in this PR

**Consolidation (commit `22d1533`):**
- `portforward/manual.go` (new) — `ManualForwarder`, `NewManualForwarder(port uint16)`, `ParseManualPort(s string) (uint16, error)`.
- `portforward/manual_test.go` (new) — `TestParseManualPort` (9 input cases including boundaries + invalid), `TestManualForwarder` (full `portForwarder` contract).
- `peer/peer.go` — drops `manualPortForwarder` + `manualPort()`; `NewForwarder` now calls `portforward.NewManualForwarder` / `portforward.ParseManualPort`. Drops the `strconv` import.
- `peer/peer_test.go` — drops the now-moved tests.
- `ManualForwarder.MapPort` reports `"manual"` as the method tag (was `"manual-env"` when it only served the env path; the suffix is wrong now that both paths feed in).

**Setting integration (commit `0c84c5a`):**
- `common/settings/settings.go` — adds `PeerManualPortKey` (int; 0 = use UPnP).
- `peer/peer.go` — `NewForwarder` resolution order now checks the setting first, then the env var, then falls through.

## `ManualForwarder` contract

- `MapPort` returns a `Mapping` with `External == Internal == configured port` and `Method = "manual"`. No network roundtrip — the router rule is already in place.
- `UnmapPort` is a no-op (user owns the router rule and removes it manually).
- `StartRenewal` is a no-op (manually-configured rules don't carry a UPnP lease).
- `ExternalIP` returns the empty string deliberately. With a manual port forward we have no UPnP gateway to ask for the WAN address, and probing a public-IP service from the client adds a network roundtrip for information lantern-cloud already has — the server observes the peer's source address on the register call and uses that as the canonical external IP when this field is empty.

## How this was sliced

Stacked on radiance #499 (`fisk/peer-connection-events-A`), itself stacked on #466 → #460 → #458. After cascade rebases through the stack, conflicts on `peer/peer.go` resolve cleanly — the consolidation commit moves code that other commits in the chain don't touch.

## Test plan

- [x] `go test -race -count=1 ./peer/... ./portforward/... ./backend/...` clean on the branch.
- [ ] **Manual smoke** (after build):
  - `RADIANCE_PEER_EXTERNAL_PORT=5698 ./lantern-cli …` → `peer.Client` binds 5698, skips UPnP probe, log line `peer client using manual port forward port=5698 source=RADIANCE_PEER_EXTERNAL_PORT`.
  - From Flutter Advanced → manual port = 5698 → toggle SmC on → same outcome with `source=setting`.
  - Empty setting + missing env var → falls back to UPnP discovery (regression check).
  - Malformed env var (`RADIANCE_PEER_EXTERNAL_PORT=abc`) → warning logged, falls through to UPnP rather than failing Start.

## Dependencies

- radiance #499 (`fisk/peer-connection-events-A`) — this PR's base.
- Foundation chain: #458 → #460 → #466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)