### PR TITLE
feat(vpn): cap idle relay buffer pool with platform byte budget

### DIFF
--- a/common/env/env.go
+++ b/common/env/env.go
@@ -29,6 +29,7 @@ var (
 	Country          _key = "RADIANCE_COUNTRY"
 	FeatureOverrides _key = "RADIANCE_FEATURE_OVERRIDES"
 	AppVersion       _key = "RADIANCE_VERSION"
+	BufPoolBudgetMB  _key = "RADIANCE_BUF_POOL_BUDGET_MB"
 
 	Testing _key = "RADIANCE_TESTING"
 

--- a/vpn/bufpool.go
+++ b/vpn/bufpool.go
@@ -2,6 +2,7 @@ package vpn
 
 import (
 	"math/bits"
+	"strconv"
 	"sync"
 	"sync/atomic"
 
@@ -169,8 +170,10 @@ func configureBufPool() {
 	// tunnel must not re-run it against live relay buffers.
 	bufBudgetOnce.Do(func() {
 		budget := defaultBufPoolBudget()
-		if v := env.GetInt(env.BufPoolBudgetMB); v != 0 {
-			budget = v * 1024 * 1024
+		if v, ok := env.Get(env.BufPoolBudgetMB); ok {
+			mb, _ := strconv.Atoi(v)
+			mb = max(0, mb)
+			budget = mb * 1024 * 1024
 		}
 		bufPool.setByteBudget(budget)
 	})

--- a/vpn/bufpool.go
+++ b/vpn/bufpool.go
@@ -1,0 +1,177 @@
+package vpn
+
+import (
+	"math/bits"
+	"sync"
+	"sync/atomic"
+
+	"github.com/getlantern/radiance/common"
+	"github.com/getlantern/radiance/common/env"
+
+	"github.com/sagernet/sing/common/buf"
+)
+
+// bufPool is the process-wide buffer allocator.
+var bufPool *bufAlloc
+
+func init() {
+	// Swapping buf.DefaultAllocator once relay goroutines are calling it would race, so
+	// install at init, before any tunnel starts.
+	bufPool = &bufAlloc{inner: buf.DefaultAllocator}
+	buf.DefaultAllocator = bufPool
+}
+
+// sing-box's allocator pools power-of-two buffers from 64 B to 64 KB across these size
+// classes; bufAlloc mirrors that geometry when bounding.
+const (
+	bufPoolMinShift = 6                                           // 1<<6 = 64 B, smallest class
+	bufPoolClasses  = 11                                          // 64 B .. 64 KB
+	minBufSize      = 1 << bufPoolMinShift                        // 64
+	maxBufSize      = 1 << (bufPoolMinShift + bufPoolClasses - 1) // 65536
+)
+
+// relayClassLo and relayClassHi bracket the size classes holding sing-box's relay
+// buffers (buf.BufferSize for TCP, buf.UDPBufferSize for UDP — both build-tag
+// dependent). Only these classes are pooled under the byte budget.
+var (
+	relayClassLo = bufClass(min(buf.UDPBufferSize, buf.BufferSize))
+	relayClassHi = bufClass(max(buf.UDPBufferSize, buf.BufferSize))
+)
+
+// bufAlloc wraps a buf.Allocator and, when setByteBudget is given a positive budget,
+// bounds the total bytes of idle relay buffers it retains for reuse — dropping excess to
+// GC so the pool can't grow without limit. Only the relay size classes are pooled; other
+// sizes delegate to inner.
+type bufAlloc struct {
+	inner  buf.Allocator
+	budget atomic.Int64
+	pools  [bufPoolClasses]chan []byte
+
+	retainedBytes atomic.Int64
+}
+
+// setByteBudget sets the cap on total bytes of idle relay buffers retained for reuse (0
+// disables bounding). It must be called before any relay traffic begins.
+func (a *bufAlloc) setByteBudget(budget int) {
+	if budget > 0 {
+		for idx := relayClassLo; idx <= relayClassHi; idx++ {
+			// Size each free-list so the byte budget, not the channel, is the binding constraint.
+			depth := budget / classSize(idx)
+			if depth < 1 {
+				depth = 1
+			}
+			a.pools[idx] = make(chan []byte, depth)
+		}
+	}
+	// Store the budget last: Get/Put read it atomically, so publishing the free-lists first
+	// keeps them from ever observing a non-zero budget with a half-built pool.
+	a.budget.Store(int64(budget))
+}
+
+func (a *bufAlloc) Get(size int) []byte {
+	if a.budget.Load() == 0 {
+		return a.inner.Get(size)
+	}
+	idx, ok := relayClassForSize(size)
+	if !ok {
+		return a.inner.Get(size)
+	}
+	select {
+	case b := <-a.pools[idx]:
+		a.retainedBytes.Add(-int64(cap(b)))
+		return b[:size]
+	default:
+		return make([]byte, size, classSize(idx))
+	}
+}
+
+func (a *bufAlloc) Put(b []byte) error {
+	if a.budget.Load() == 0 {
+		return a.inner.Put(b)
+	}
+	c := cap(b)
+	idx, ok := relayClassForCap(c)
+	if !ok {
+		return a.inner.Put(b)
+	}
+	// Reserve before the budget check and roll back if b isn't pooled, so concurrent Puts
+	// can't collectively retain more than the budget.
+	if a.retainedBytes.Add(int64(c)) > a.budget.Load() {
+		a.retainedBytes.Add(-int64(c))
+		return nil
+	}
+	select {
+	case a.pools[idx] <- b[:c]:
+	default:
+		a.retainedBytes.Add(-int64(c))
+	}
+	return nil
+}
+
+// bufClass returns the size-class index for size: the smallest power-of-two class
+// >= max(size, 64). It does not range-check, so callers must bound size to
+// (0, maxBufSize] first.
+func bufClass(size int) int {
+	if size <= minBufSize {
+		return 0
+	}
+	i := bits.Len32(uint32(size)) - 1
+	if size != 1<<i {
+		i++
+	}
+	return i - bufPoolMinShift
+}
+
+func classSize(idx int) int { return 1 << (idx + bufPoolMinShift) }
+
+// relayClassForSize returns the relay class for size, with ok=false when size falls
+// outside the pooled classes.
+func relayClassForSize(size int) (int, bool) {
+	if size <= 0 || size > maxBufSize {
+		return 0, false
+	}
+	idx := bufClass(size)
+	return idx, idx >= relayClassLo && idx <= relayClassHi
+}
+
+// relayClassForCap returns the pooled relay class a Put maps to from a buffer's cap,
+// with ok=false unless cap is an exact relay-class size (an inexact cap delegates to
+// inner, which validates it).
+func relayClassForCap(c int) (int, bool) {
+	if c < minBufSize || c > maxBufSize || c != 1<<(bits.Len32(uint32(c))-1) {
+		return 0, false
+	}
+	idx := bits.Len32(uint32(c)) - 1 - bufPoolMinShift
+	return idx, idx >= relayClassLo && idx <= relayClassHi
+}
+
+// mobileBufPoolBudget is the idle-relay-buffer byte budget applied on mobile when no
+// explicit one is set. Mobile runs under a hard process-footprint cap (the iOS network
+// extension is killed past ~50 MB), so the idle pool is bounded well below it; the value
+// is a deliberate fraction of a measured relay working set, not the whole set, trading a
+// little allocation churn for a bounded footprint.
+const mobileBufPoolBudget = 4 * 1024 * 1024 // 4 MB
+
+func defaultBufPoolBudget() int {
+	if common.IsMobile() {
+		return mobileBufPoolBudget
+	}
+	return 0
+}
+
+var bufBudgetOnce sync.Once
+
+// configureBufPool resolves and applies the relay buffer-pool byte budget. It is safe to call
+// multiple times, but only the first call has an effect; subsequent calls are no-ops. It must be
+// called before any relay traffic begins.
+func configureBufPool() {
+	// setByteBudget rebuilds the pool free-lists, so a restart overlapping a still-draining
+	// tunnel must not re-run it against live relay buffers.
+	bufBudgetOnce.Do(func() {
+		budget := defaultBufPoolBudget()
+		if v := env.GetInt(env.BufPoolBudgetMB); v != 0 {
+			budget = v * 1024 * 1024
+		}
+		bufPool.setByteBudget(budget)
+	})
+}

--- a/vpn/bufpool_test.go
+++ b/vpn/bufpool_test.go
@@ -1,0 +1,120 @@
+package vpn
+
+import (
+	"testing"
+
+	"github.com/sagernet/sing/common/buf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubAllocator struct {
+	gets, puts int
+}
+
+func (s *stubAllocator) Get(size int) []byte { s.gets++; return make([]byte, size) }
+func (s *stubAllocator) Put([]byte) error    { s.puts++; return nil }
+
+func TestBufClass(t *testing.T) {
+	cases := []struct {
+		size, want int
+	}{
+		{1, 0}, {64, 0}, {65, 1}, {128, 1}, {129, 2},
+		{4096, 6}, {8192, 7}, {8193, 8}, {16384, 8}, {32768, 9}, {65536, 10},
+	}
+	for _, c := range cases {
+		assert.Equalf(t, c.want, bufClass(c.size), "bufClass(%d)", c.size)
+	}
+}
+
+func TestBufAllocUnbounded(t *testing.T) {
+	stub := &stubAllocator{}
+	a := &bufAlloc{inner: stub}
+	a.setByteBudget(0)
+
+	b := a.Get(buf.UDPBufferSize)
+	require.NoError(t, a.Put(b))
+
+	assert.Equal(t, 1, stub.gets, "inner.Get calls")
+	assert.Equal(t, 1, stub.puts, "inner.Put calls")
+}
+
+func TestBufAllocBoundedRetention(t *testing.T) {
+	relay := buf.UDPBufferSize
+	stub := &stubAllocator{}
+	a := &bufAlloc{inner: stub}
+	a.setByteBudget(2 * relay) // room for exactly two relay buffers
+
+	for i := 0; i < 4; i++ {
+		require.NoError(t, a.Put(make([]byte, relay)))
+	}
+	assert.Len(t, a.pools[bufClass(relay)], 2, "retained (budget)")
+	assert.Equal(t, int64(2*relay), a.retainedBytes.Load(), "retained bytes")
+	assert.Zero(t, stub.puts, "inner.Put must not be used for a relay class")
+
+	first := a.Get(relay)
+	assert.Equal(t, relay, cap(first), "reused buffer cap")
+	a.Get(relay)
+	a.Get(relay)
+	assert.Empty(t, a.pools[bufClass(relay)], "pool should be drained")
+	assert.Zero(t, a.retainedBytes.Load(), "retained bytes back to zero")
+	assert.Zero(t, stub.gets, "inner.Get must not be used for a relay class")
+}
+
+// The budget is shared across relay classes by total bytes, not per class: once the
+// retained bytes reach the budget, further puts of any class are dropped.
+func TestBufAllocByteBudgetAcrossClasses(t *testing.T) {
+	lo, hi := buf.UDPBufferSize, buf.BufferSize
+	require.NotEqual(t, lo, hi, "relay classes must differ")
+	a := &bufAlloc{inner: &stubAllocator{}}
+	a.setByteBudget(lo + hi)
+
+	require.NoError(t, a.Put(make([]byte, hi))) // retained: hi
+	require.NoError(t, a.Put(make([]byte, hi))) // hi+hi > budget -> dropped
+	require.NoError(t, a.Put(make([]byte, lo))) // hi+lo == budget -> retained
+	require.NoError(t, a.Put(make([]byte, lo))) // over budget -> dropped
+
+	assert.Len(t, a.pools[bufClass(hi)], 1, "one hi-class buffer retained")
+	assert.Len(t, a.pools[bufClass(lo)], 1, "one lo-class buffer retained")
+	assert.Equal(t, int64(lo+hi), a.retainedBytes.Load(), "retained bytes capped at budget")
+}
+
+// Only the relay classes are pooled; every other size delegates to inner in both
+// directions, leaving sing-box's allocator to handle it as before.
+func TestBufAllocPoolsRelayClassesOnly(t *testing.T) {
+	const nonRelay = 1024
+	stub := &stubAllocator{}
+	a := &bufAlloc{inner: stub}
+	a.setByteBudget(1 << 20)
+
+	a.Get(nonRelay)
+	assert.Equal(t, 1, stub.gets, "non-relay Get delegates to inner")
+	a.Get(buf.BufferSize)
+	assert.Equal(t, 1, stub.gets, "relay Get is served without inner")
+
+	require.NoError(t, a.Put(make([]byte, nonRelay)))
+	assert.Equal(t, 1, stub.puts, "non-relay Put delegates to inner")
+	require.NoError(t, a.Put(make([]byte, buf.BufferSize)))
+	assert.Equal(t, 1, stub.puts, "relay Put is pooled, not delegated")
+}
+
+// Guards against drift between bufAlloc's size classes and sing-box's: a relay buffer must
+// round-trip through Put into the pool and back out of Get at the same cap.
+func TestBufAllocRelayRoundTrip(t *testing.T) {
+	a := &bufAlloc{inner: &stubAllocator{}}
+	a.setByteBudget(1 << 20)
+	for _, size := range []int{buf.UDPBufferSize, buf.BufferSize} {
+		require.NoErrorf(t, a.Put(make([]byte, size)), "Put(cap=%d)", size)
+		got := a.Get(size)
+		assert.Equalf(t, size, cap(got), "Get(%d) cap", size)
+	}
+}
+
+// The mobile budget must stay well under the iOS network-extension footprint cap that
+// motivates it; desktop stays unbounded.
+func TestDefaultBufPoolBudget(t *testing.T) {
+	const iOSFootprintCap = 50 << 20
+	assert.Greater(t, mobileBufPoolBudget, 0, "mobile budget must bound the pool")
+	assert.Less(t, mobileBufPoolBudget, iOSFootprintCap, "mobile budget must stay under the iOS footprint cap")
+	assert.Zero(t, defaultBufPoolBudget(), "desktop test host defaults to unbounded")
+}

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -164,6 +164,7 @@ func (c *VPNClient) Disconnect() error {
 }
 
 func (c *VPNClient) start(ctx context.Context, path, options string, isRestart bool, urlTestSeed map[string]adapter.URLTestHistory) error {
+	configureBufPool()
 	c.logger.Debug("Starting tunnel", "options", options)
 	c.setStatus(Connecting, nil)
 	t := tunnel{dataPath: path, urlTestSeed: urlTestSeed}


### PR DESCRIPTION
## What

Wrap sing-box's `buf.DefaultAllocator` with a `bufAlloc` that bounds the total **bytes** of idle relay buffers retained for reuse, dropping excess to GC instead of letting the pool grow without limit. Only the relay size classes (the `buf.BufferSize`/`buf.UDPBufferSize` classes, build-tag dependent) are pooled; every other size delegates to the inner allocator unchanged.

## Why

The iOS network extension runs under a hard process-footprint cap (~50 MB) and gets OOM-killed past it. sing-box's default allocator pools idle buffers in unbounded `sync.Pool`s, so under load the idle retention adds to the footprint. Bounding the idle pool caps that contribution.

## Defaults & override

- **Mobile**: 4 MB — a deliberate fraction of a measured relay working set, bounded well under the footprint cap.
- **Desktop**: unbounded (`0`) — no footprint cap, and sing-box's `sync.Pool` self-limits across GC.
- Overridable via `RADIANCE_BUF_POOL_BUDGET_MB`. Resolved and applied once at tunnel start (after env overrides are in place, before any relay traffic) via a `sync.Once` — a restart can overlap a still-draining tunnel, and rebuilding the pool free-lists must not race live relay buffers.

relates to https://github.com/getlantern/engineering/issues/3542