### PR TITLE
set base defaultdomainresolver, overwrite with server returned value

### DIFF
--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -244,6 +244,9 @@ func baseOpts(basePath string) O.Options {
 					Format: C.RuleSetFormatSource,
 				},
 			},
+			DefaultDomainResolver: &O.DomainResolveOptions{
+				Server: "dns_local",
+			},
 		},
 		Experimental: &O.ExperimentalOptions{
 			ClashAPI: &O.ClashAPIOptions{
@@ -533,6 +536,7 @@ func mergeAndCollectTags(dst, src *O.Options) []string {
 	if src.Route != nil {
 		dst.Route.Rules = append(dst.Route.Rules, src.Route.Rules...)
 		dst.Route.RuleSet = append(dst.Route.RuleSet, src.Route.RuleSet...)
+		dst.Route.DefaultDomainResolver = src.Route.DefaultDomainResolver
 	}
 	// overwrite base DNS options with config from src (server)
 	if src.DNS != nil {


### PR DESCRIPTION
This pull request updates the VPN options configuration to improve DNS resolution handling. The main changes introduce a default domain resolver setting and ensure this setting is properly merged when combining option sets.

DNS resolver improvements:

* Added a `DefaultDomainResolver` field to the `Route` options, defaulting to a local DNS server (`dns_local`).
* Updated the `mergeAndCollectTags` function to copy the `DefaultDomainResolver` from the source options when merging, ensuring consistent resolver configuration.