### PR TITLE
fix: resolve event, lifecycle, and cleanup defects

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -63,7 +63,6 @@ type LocalBackend struct {
 
 	shutdownFuncs []func() error
 	closeOnce     sync.Once
-	stopChan      chan struct{}
 
 	deviceID string
 
@@ -178,7 +177,6 @@ func NewLocalBackend(ctx context.Context, opts Options) (*LocalBackend, error) {
 		shutdownFuncs: []func() error{
 			telemetry.Close, kindling.Close,
 		},
-		stopChan:  make(chan struct{}),
 		closeOnce: sync.Once{},
 		deviceID:  platformDeviceID,
 		dataCapCh: make(chan *account.DataCapInfo, 1),
@@ -306,14 +304,12 @@ func (r *LocalBackend) Close() {
 			slog.Error("Failed to disconnect VPN on shutdown", "error", err)
 		}
 		r.cancel() // cancels context, unsubscribes all event listeners and stops child goroutines
-		close(r.stopChan)
 		for _, shutdown := range r.shutdownFuncs {
 			if err := shutdown(); err != nil {
 				slog.Error("Failed to shutdown", "error", err)
 			}
 		}
 	})
-	<-r.stopChan
 }
 
 func (r *LocalBackend) startVPNStatusListeners() {
@@ -921,18 +917,20 @@ func (r *LocalBackend) startAutoSelectedListener() {
 	var (
 		mu     sync.Mutex
 		cancel context.CancelFunc
+		done   <-chan struct{}
 	)
 	events.SubscribeContext(r.ctx, func(evt vpn.StatusUpdateEvent) {
 		mu.Lock()
 		defer mu.Unlock()
 		if cancel != nil {
 			cancel()
+			<-done
 			cancel = nil
 		}
 		if evt.Status == vpn.Connected {
 			var ctx context.Context
 			ctx, cancel = context.WithCancel(r.ctx)
-			r.vpnClient.AutoSelectedChangeListener(ctx)
+			done = r.vpnClient.AutoSelectedChangeListener(ctx)
 		}
 	})
 }

--- a/cmd/kindling-tester/main.go
+++ b/cmd/kindling-tester/main.go
@@ -33,6 +33,7 @@ func performKindlingPing(urlToHit string, runID string, deviceID string, userID 
 		slog.Error("failed to initialize kindling", slog.Any("error", err))
 	}
 	if newK != nil {
+		defer newK.Close()
 		kindling.SetKindling(newK)
 	}
 	defer kindling.Close()

--- a/config/config.go
+++ b/config/config.go
@@ -127,7 +127,7 @@ func (ch *ConfigHandler) Start() {
 		ch.ftr = newFetcher(ch.options.Locale, ch.options.AccountClient, ch.options.HTTPClient)
 		ch.started.Store(true)
 		go ch.fetchLoop(ch.pollInterval)
-		events.Subscribe(func(evt account.UserChangeEvent) {
+		events.SubscribeContext(ch.ctx, func(evt account.UserChangeEvent) {
 			ch.logger.Debug("User change detected that requires config refetch")
 			if err := ch.fetchConfig(); err != nil {
 				ch.logger.Error("Failed to fetch config", "error", err)

--- a/events/events.go
+++ b/events/events.go
@@ -28,6 +28,7 @@ package events
 
 import (
 	"context"
+	"log/slog"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -122,7 +123,14 @@ func Emit[T Event](evt T) {
 	defer subscriptionsMu.RUnlock()
 	if subs, ok := subscriptions[reflect.TypeFor[T]()]; ok {
 		for _, cb := range subs {
-			go cb(evt)
+			go func() {
+				defer func() {
+					if r := recover(); r != nil {
+						slog.Error("Panic in event callback", "error", r)
+					}
+				}()
+				cb(evt)
+			}()
 		}
 	}
 }

--- a/ipc/client_events_mobile.go
+++ b/ipc/client_events_mobile.go
@@ -14,6 +14,8 @@ import (
 
 // AutoSelectedEvents streams auto-selection changes. Blocks until ctx is cancelled.
 func (c *Client) AutoSelectedEvents(ctx context.Context, handler func(vpn.AutoSelectedEvent)) error {
+	// The bus subscription is not redundant with SSE: when the tunnel process is down,
+	// the client's fallback LocalBackend emits these events on the in-process bus.
 	events.SubscribeContext(ctx, handler)
 	if c.localOnly {
 		<-ctx.Done()
@@ -30,6 +32,8 @@ func (c *Client) AutoSelectedEvents(ctx context.Context, handler func(vpn.AutoSe
 // ConfigEvents streams config-updated notifications. Payloads are empty — callers should treat each
 // call as a "refresh" signal. Blocks until ctx is cancelled.
 func (c *Client) ConfigEvents(ctx context.Context, handler func()) error {
+	// The bus subscription is not redundant with SSE: when the tunnel process is down,
+	// the client's fallback LocalBackend emits NewConfigEvents on the in-process bus.
 	events.SubscribeContext(ctx, func(config.NewConfigEvent) { handler() })
 	if c.localOnly {
 		<-ctx.Done()

--- a/ipc/client_mobile.go
+++ b/ipc/client_mobile.go
@@ -40,6 +40,8 @@ func NewClient(ctx context.Context, opts backend.Options) (*Client, error) {
 // NewLoopbackClient creates a Client that serves all requests in-process
 // through the given LocalBackend without attempting IPC socket connections.
 // The backend is NOT owned by this client — Close will not shut it down.
+// Event streams are not consumed on a loopback client; their localOnly
+// branches are defensive.
 func NewLoopbackClient(b *backend.LocalBackend) *Client {
 	c := newClient()
 	c.localapi = newLocalAPI(b, false)

--- a/kindling/client.go
+++ b/kindling/client.go
@@ -4,6 +4,7 @@ package kindling
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"path/filepath"
@@ -26,10 +27,9 @@ import (
 )
 
 var (
-	k               kindling.Kindling
-	initOnce        sync.Once
-	stopUpdater     func()
-	closeTransports []func() error
+	mu          sync.Mutex
+	initialized bool
+	k           *Client
 	// EnabledTransports gates which transports NewKindling wires up. Intended for tests; not a
 	// production toggle.
 	EnabledTransports = map[kindling.TransportName]bool{
@@ -58,7 +58,17 @@ func initKindling() {
 }
 
 func Init() {
-	go initOnce.Do(initKindling)
+	go ensureInit()
+}
+
+func ensureInit() http.RoundTripper {
+	mu.Lock()
+	defer mu.Unlock()
+	if !initialized {
+		initKindling()
+		initialized = true
+	}
+	return transport
 }
 
 // HTTPClient returns an HTTP client whose transport blocks on first use
@@ -73,28 +83,57 @@ func HTTPClient() *http.Client {
 type readyTransport struct{}
 
 func (readyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	initOnce.Do(initKindling)
-	return transport.RoundTrip(req)
+	return ensureInit().RoundTrip(req)
 }
 
-// Close stops any in-flight config fetches and releases kindling transports.
+// Close stops any in-flight config fetches, releases kindling transports, and
+// re-arms the package so the next Init or HTTPClient use rebuilds the stack.
 func Close() error {
-	if stopUpdater != nil {
-		stopUpdater()
-	}
-	for _, c := range closeTransports {
-		if err := c(); err != nil {
-			slog.Error("failed to close kindling transport", slog.Any("error", err))
+	// Mobile constructs a new LocalBackend in the same process after the system
+	// extension stops, so Close must not be terminal.
+	mu.Lock()
+	defer mu.Unlock()
+	if k != nil {
+		if err := k.Close(); err != nil {
+			slog.Error("failed to close kindling transports", slog.Any("error", err))
 		}
+		k = nil
 	}
+	transport = nil
+	initialized = false
 	return nil
 }
 
 const tracerName = "github.com/getlantern/radiance/kindling"
 
-// NewKindling builds a kindling client and registers package-level cleanup
-// hooks; call [Close] to release them.
-func NewKindling(dataDir string) (kindling.Kindling, error) {
+// Client is a kindling instance together with the transport resources its
+// construction created (config updaters, fronted/dnstt state).
+type Client struct {
+	kindling.Kindling
+	cancel    context.CancelFunc
+	closers   []func() error
+	closeOnce sync.Once
+}
+
+// Close cancels the transports' config updaters and releases their resources.
+func (c *Client) Close() error {
+	var err error
+	c.closeOnce.Do(func() {
+		if c.cancel != nil {
+			c.cancel()
+		}
+		var errs []error
+		for _, cl := range c.closers {
+			errs = append(errs, cl())
+		}
+		err = errors.Join(errs...)
+	})
+	return err
+}
+
+// NewKindling builds a kindling client. On error, any partially built
+// transport state is released before returning.
+func NewKindling(dataDir string) (*Client, error) {
 	logger := &slogWriter{Logger: slog.Default()}
 
 	ctx, span := otel.Tracer(tracerName).Start(
@@ -107,7 +146,7 @@ func NewKindling(dataDir string) (kindling.Kindling, error) {
 	if common.Stage() {
 		// Staging runs proxyless-only; fronted client failures against staging
 		// hosts otherwise obscure the backend behavior we want to test.
-		return kindling.NewKindling("radiance",
+		newK, err := kindling.NewKindling("radiance",
 			kindling.WithPanicListener(reporting.PanicListener),
 			kindling.WithLogWriter(logger),
 			kindling.WithStreamDialer(bypass.StreamDialer()),
@@ -116,9 +155,13 @@ func NewKindling(dataDir string) (kindling.Kindling, error) {
 			// else uses df.iantem.io.
 			kindling.WithProxyless("df.iantem.io", "api.getiantem.org", "api.staging.iantem.io"),
 		)
+		if err != nil {
+			return nil, err
+		}
+		return &Client{Kindling: newK}, nil
 	}
 
-	closeTransports = []func() error{}
+	var closers []func() error
 	kindlingOptions := []kindling.Option{
 		kindling.WithPanicListener(reporting.PanicListener),
 		kindling.WithLogWriter(logger),
@@ -134,7 +177,7 @@ func NewKindling(dataDir string) (kindling.Kindling, error) {
 			span.RecordError(err)
 		}
 		if f != nil {
-			closeTransports = append(closeTransports, func() error { f.Close(); return nil })
+			closers = append(closers, func() error { f.Close(); return nil })
 			kindlingOptions = append(kindlingOptions, kindling.WithDomainFronting(f))
 		}
 	}
@@ -157,7 +200,7 @@ func NewKindling(dataDir string) (kindling.Kindling, error) {
 			span.RecordError(err)
 		}
 		if dnsttOptions != nil {
-			closeTransports = append(closeTransports, dnsttOptions.Close)
+			closers = append(closers, dnsttOptions.Close)
 			kindlingOptions = append(kindlingOptions, kindling.WithDNSTunnel(dnsttOptions))
 		}
 	}
@@ -168,8 +211,16 @@ func NewKindling(dataDir string) (kindling.Kindling, error) {
 		kindlingOptions = append(kindlingOptions, kindling.WithProxyless("df.iantem.io", "api.getiantem.org"))
 	}
 
-	stopUpdater = cancel
-	return kindling.NewKindling("radiance", kindlingOptions...)
+	newK, err := kindling.NewKindling("radiance", kindlingOptions...)
+	if err != nil {
+		errs := []error{err}
+		cancel()
+		for _, cl := range closers {
+			errs = append(errs, cl())
+		}
+		return nil, errors.Join(errs...)
+	}
+	return &Client{Kindling: newK, cancel: cancel, closers: closers}, nil
 }
 
 type slogWriter struct {
@@ -182,16 +233,21 @@ func (w *slogWriter) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-// SetKindling installs a test-supplied kindling instance and consumes
-// initOnce, so it must be called before any Init or HTTPClient use or it
-// will silently no-op.
-func SetKindling(a kindling.Kindling) {
-	initOnce.Do(func() {
-		k = a
-		if a != nil {
-			transport = traces.NewRoundTripper(traces.NewHeaderAnnotatingRoundTripper(a.NewHTTPClient().Transport))
-		} else {
-			transport = traces.NewRoundTripper(traces.NewHeaderAnnotatingRoundTripper(defaultTransportClone))
-		}
-	})
+// SetKindling installs a test-supplied kindling instance and claims
+// initialization — call it before Init or the first request through
+// HTTPClient, or it will silently no-op. The package Close closes the
+// installed instance.
+func SetKindling(c *Client) {
+	mu.Lock()
+	defer mu.Unlock()
+	if initialized {
+		return
+	}
+	k = c
+	if c != nil {
+		transport = traces.NewRoundTripper(traces.NewHeaderAnnotatingRoundTripper(c.NewHTTPClient().Transport))
+	} else {
+		transport = traces.NewRoundTripper(traces.NewHeaderAnnotatingRoundTripper(defaultTransportClone))
+	}
+	initialized = true
 }

--- a/kindling/client_test.go
+++ b/kindling/client_test.go
@@ -2,7 +2,6 @@ package kindling
 
 import (
 	"net/http"
-	"sync"
 	"testing"
 
 	"github.com/getlantern/kindling"
@@ -25,21 +24,14 @@ func TestNewClient(t *testing.T) {
 			EnabledTransports[kindling.TransportDNSTunnel] = false
 			EnabledTransports[tr] = true
 
-			initOnce = sync.Once{}
-			k = nil
-			transport = nil
-			closeTransports = nil
+			Close()
 
 			newK, err := NewKindling(t.TempDir())
 			require.NoError(t, err)
 			require.NotNil(t, newK)
 			SetKindling(newK)
 
-			t.Cleanup(func() {
-				Close()
-				k = nil
-				initOnce = sync.Once{}
-			})
+			t.Cleanup(func() { Close() })
 
 			cli := HTTPClient()
 			require.NotNil(t, cli)

--- a/telemetry/otel.go
+++ b/telemetry/otel.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"reflect"
 	"runtime"
 	"sync"
 	"time"
@@ -30,7 +29,6 @@ import (
 
 	rcommon "github.com/getlantern/radiance/common"
 	"github.com/getlantern/radiance/common/env"
-	"github.com/getlantern/radiance/common/settings"
 	"github.com/getlantern/radiance/config"
 )
 
@@ -53,20 +51,6 @@ type Attributes struct {
 	OSVersion      string
 	Timezone       string
 	Pro            bool
-}
-
-// OnNewConfig handles OpenTelemetry re-initialization when the configuration changes.
-func OnNewConfig(oldConfig, newConfig *config.Config, deviceID string) error {
-	// Check if the old OTEL configuration is the same as the new one.
-	if oldConfig != nil && reflect.DeepEqual(oldConfig.OTEL, newConfig.OTEL) {
-		slog.Debug("OpenTelemetry configuration has not changed, skipping initialization")
-		return nil
-	}
-	if err := Initialize(deviceID, *newConfig, settings.IsPro()); err != nil {
-		slog.Error("Failed to initialize OpenTelemetry", "error", err)
-		return fmt.Errorf("failed to initialize OpenTelemetry: %w", err)
-	}
-	return nil
 }
 
 func Initialize(deviceID string, configResponse config.Config, pro bool) error {

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -346,7 +346,7 @@ func (t *tunnel) close() error {
 		t.cancel()
 	}
 
-	done := make(chan error)
+	done := make(chan error, 1)
 	go func() {
 		var errs []error
 		for _, closer := range t.closers {

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -453,7 +453,8 @@ const (
 // AutoSelectedEvent whenever the selection differs from the previous value.
 // It performs an initial rapid poll to catch the first selection soon after
 // tunnel connect, then settles into a slower steady-state interval.
-func (c *VPNClient) AutoSelectedChangeListener(ctx context.Context) {
+func (c *VPNClient) AutoSelectedChangeListener(ctx context.Context) <-chan struct{} {
+	done := make(chan struct{})
 	go func() {
 		var prev string
 
@@ -461,7 +462,10 @@ func (c *VPNClient) AutoSelectedChangeListener(ctx context.Context) {
 		initialDeadline := time.NewTimer(rapidPollWindow)
 		defer initialDeadline.Stop()
 		tick := time.NewTimer(rapidPollInterval)
-		defer tick.Stop()
+		defer func() {
+			tick.Stop()
+			close(done)
+		}()
 	initial:
 		for {
 			select {
@@ -514,6 +518,7 @@ func (c *VPNClient) AutoSelectedChangeListener(ctx context.Context) {
 			}
 		}
 	}()
+	return done
 }
 
 // RunOfflineURLTests will run URL tests for all outbounds if the tunnel is not currently connected.


### PR DESCRIPTION
## Summary

Independent lifecycle, event-delivery, and cleanup fixes, grouped because they were found together. Each stands alone.

## Changes

### kindling: re-initializable lifecycle + `Client` wrapper

- **Re-init after `Close`** (`sync.Once` → mutex + flag). Mobile builds a new `LocalBackend` after the system extension stops — once-at-a-time, but more than once per process. `kindling.Close` runs in the backend's shutdown funcs, so under `sync.Once` the package could never rebuild: the second backend's `Init()` no-op'd and its config/account/issue HTTP rode the closed transport stack. `Close` now resets package state, making its place in the shutdown funcs correct rather than terminal.
- **`Client` owns transport cleanup.** Cleanup state (updater-ctx cancel, fronted/dnstt closers) was package-global, mutated as a side effect of `NewKindling` — ownership held only by call order, and a direct caller wrote those globals outside the lock. `NewKindling` is now a pure constructor returning `(*Client, error)` that releases partial state on error; `Client.Close` is idempotent, so lifecycle is per-instance and call-order independent.

### events: recover from subscriber panics

`Emit` ran each callback as `go cb(evt)` with no recovery, so one panicking subscriber crashed the process. Each dispatch now recovers and logs. (Delivery ordering unchanged — still one goroutine per subscriber.)

### backend: remove dead `stopChan`; drain auto-selected poller before restart

- **Dead synchronization.** `close(r.stopChan)` sat inside `closeOnce.Do` and the following `<-r.stopChan` returned immediately; nothing else read it. `sync.Once.Do` already blocks concurrent `Close` callers until the first finishes — the only semantics it could provide.
- **Poller drain.** The status listener cancelled the previous auto-selected poller and started a new one without waiting for the old goroutine to exit, so two could overlap and the stale one still emit an `AutoSelectedEvent`. It now waits on the poller's done channel before starting the next.

### config: unsubscribe user-change handler on `Stop`

The `UserChangeEvent` subscription used the non-context `Subscribe` and was never torn down, so after `Stop()` it kept firing config refetches against a stopped handler. Binding it to `ch.ctx` lets it die with `Stop()`.

### vpn: buffer the tunnel closer's done channel; return done from the poller

- **Closer goroutine leak.** The close path used an unbuffered `done` channel; on the timeout branch it returned without receiving, leaving the closer goroutine blocked forever on the send. Buffering (cap 1) lets it exit even after the caller times out.
- **`AutoSelectedChangeListener` returns `<-chan struct{}`** (closed when the poller exits) so callers can await termination — consumed by the backend poller-drain above.

### ipc (mobile): document non-obvious event-delivery contracts

Comment-only. The app client's bus subscription coexisting with the SSE loop reads like duplicate delivery but is deliberate fallback: when the tunnel process is down, the client's fallback `LocalBackend` emits these events on the in-process bus. The loopback client's `localOnly` branches are defensive — no event stream is consumed there. Documented because the apparent redundancy has invited "fixes" that silently break fallback delivery.

### telemetry: remove unused `OnNewConfig`

Dead code — zero callers; the backend calls `Initialize` directly from its config subscriber. Drops the now-unused `reflect` and `settings` imports.
