### PR TITLE
set default TUN stack to system

### DIFF
--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -205,7 +205,8 @@ func baseOpts(basePath string) O.Options {
 					Inet6Address:           tunInet6, // gated by hasGlobalIPv6
 					AutoRoute:              true,
 					StrictRoute:            true,
-					EndpointIndependentNat: true, // needed for QUIC migration and hole-punching
+					EndpointIndependentNat: true,     // needed for QUIC migration and hole-punching
+					Stack:                  "system", // fallback to gvisor on older Android kernels in buildOptions
 				},
 			},
 			{


### PR DESCRIPTION
Use the system stack for the TUN for all platforms except Android devices with kernels <=v5.10. This will avoid using gvisor for UDP connections, which will reduce memory usage. And as a side-bonus, improve performance.