### PR TITLE
feat(vpn): add clear tunnel cache operation

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -935,6 +935,14 @@ func (r *LocalBackend) startAutoSelectedListener() {
 	})
 }
 
+// ClearTunnelCache removes the tunnel cache from the configured data directory.
+// When force is true, an active tunnel is disconnected first; otherwise clearing
+// a connected tunnel's cache returns an error. ClearTunnelCache will not reopen
+// the tunnel if it had to close it.
+func (r *LocalBackend) ClearTunnelCache(force bool) error {
+	return r.vpnClient.ClearTunnelCache(settings.GetString(settings.DataPathKey), force)
+}
+
 func (r *LocalBackend) RunOfflineURLTests() error {
 	cfg, err := r.confHandler.GetConfig()
 	if err != nil {

--- a/ipc/client.go
+++ b/ipc/client.go
@@ -141,6 +141,13 @@ func (c *Client) VPNSessions(ctx context.Context, limit int) ([]vpn.Session, err
 	return sessions, err
 }
 
+// ClearTunnelCache removes the tunnel cache, disconnecting an active tunnel first
+// if one is connected. ClearTunnelCache will not reopen the tunnel.
+func (c *Client) ClearTunnelCache(ctx context.Context) error {
+	_, err := c.do(ctx, http.MethodPost, vpnClearTunnelCacheEndpoint, nil)
+	return err
+}
+
 // VPNThroughput returns the most recent global and per-outbound throughput sample.
 func (c *Client) VPNThroughput(ctx context.Context) (vpn.ThroughputSnapshot, error) {
 	var s vpn.ThroughputSnapshot

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -31,15 +31,16 @@ const (
 	tracerName = "github.com/getlantern/radiance/ipc"
 
 	// VPN endpoints
-	vpnStatusEndpoint       = "/vpn/status"
-	vpnConnectEndpoint      = "/vpn/connect"
-	vpnDisconnectEndpoint   = "/vpn/disconnect"
-	vpnRestartEndpoint      = "/vpn/restart"
-	vpnConnectionsEndpoint  = "/vpn/connections"
-	vpnThroughputEndpoint   = "/vpn/throughput"
-	vpnOfflineTestsEndpoint = "/vpn/offline-tests"
-	vpnStatusEventsEndpoint = "/vpn/status/events"
-	vpnSessionsEndpoint     = "/vpn/sessions"
+	vpnStatusEndpoint           = "/vpn/status"
+	vpnConnectEndpoint          = "/vpn/connect"
+	vpnDisconnectEndpoint       = "/vpn/disconnect"
+	vpnRestartEndpoint          = "/vpn/restart"
+	vpnConnectionsEndpoint      = "/vpn/connections"
+	vpnThroughputEndpoint       = "/vpn/throughput"
+	vpnOfflineTestsEndpoint     = "/vpn/offline-tests"
+	vpnStatusEventsEndpoint     = "/vpn/status/events"
+	vpnSessionsEndpoint         = "/vpn/sessions"
+	vpnClearTunnelCacheEndpoint = "/vpn/cache/clear"
 
 	// Server selection endpoints
 	serverSelectedEndpoint           = "/server/selected"
@@ -201,6 +202,7 @@ func newLocalAPI(b *backend.LocalBackend, withAuth bool) *localapi {
 	mux.HandleFunc("GET "+vpnThroughputEndpoint, traced(s.vpnThroughputHandler))
 	mux.HandleFunc("POST "+vpnOfflineTestsEndpoint, traced(s.vpnOfflineTestsHandler))
 	mux.HandleFunc("GET "+vpnSessionsEndpoint, traced(s.vpnSessionsHandler))
+	mux.HandleFunc("POST "+vpnClearTunnelCacheEndpoint, traced(s.vpnClearTunnelCacheHandler))
 
 	// SSE routes skip the tracer middleware since it buffers the entire response body.
 	mux.HandleFunc("GET "+vpnStatusEventsEndpoint, s.vpnStatusEventsHandler)
@@ -404,6 +406,14 @@ func (s *localapi) vpnSessionsHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	writeJSON(w, http.StatusOK, s.backend(r.Context()).Sessions(limit))
+}
+
+func (s *localapi) vpnClearTunnelCacheHandler(w http.ResponseWriter, r *http.Request) {
+	if err := s.backend(r.Context()).ClearTunnelCache(true); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
 }
 
 func (s *localapi) vpnOfflineTestsHandler(w http.ResponseWriter, r *http.Request) {

--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -167,7 +167,7 @@ func hasGlobalIPv6Using(getSnapshots func() ([]ifaceSnapshot, error)) bool {
 // function. Do not modify without understanding the downstream effects.
 func baseOpts(basePath string) O.Options {
 	splitTunnelPath := filepath.Join(basePath, splitTunnelFile)
-	cacheFile := filepath.Join(basePath, cacheFileName)
+	cacheFile := cacheFilePath(basePath)
 	loopbackAddr := badoption.Addr(netip.MustParseAddr("127.0.0.1"))
 
 	// v6 ULA conditional on system v6 — see hasGlobalIPv6.
@@ -360,6 +360,10 @@ func baseRoutingRules() []O.Rule {
 		},
 	}
 	return rules
+}
+
+func cacheFilePath(basePath string) string {
+	return filepath.Join(basePath, cacheFileName)
 }
 
 // rejectQUICRule rejects UDP/443 to force HTTP/2-over-TCP fallback. Standard

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
+	"os"
 	"runtime"
 	"strings"
 	"sync"
@@ -363,6 +365,26 @@ func (c *VPNClient) Connections() ([]Connection, error) {
 		connections = append(connections, newConnection(conn))
 	}
 	return connections, nil
+}
+
+// ClearTunnelCache removes the tunnel cache file at dataPath. The tunnel must be closed before
+// the cache file can be deleted. Setting force to true will close the tunnel if it's open.
+// ClearTunnelCache will not reopen the tunnel if it closed it.
+func (c *VPNClient) ClearTunnelCache(dataPath string, force bool) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.tunnel != nil {
+		if !force {
+			return errors.New("cannot clear cache while tunnel is currently connected")
+		}
+		if err := c.close(); err != nil {
+			c.logger.Error("closing tunnel while clearing cache. Attempting anyway", "error", err)
+		}
+	}
+	if err := os.Remove(cacheFilePath(dataPath)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("failed to remove cache file: %w", err)
+	}
+	return nil
 }
 
 // Bytes returns the cumulative up/down byte counters for the active tunnel. ok is false if the

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -373,18 +373,21 @@ func (c *VPNClient) Connections() ([]Connection, error) {
 func (c *VPNClient) ClearTunnelCache(dataPath string, force bool) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	var errs error
 	if c.tunnel != nil {
 		if !force {
 			return errors.New("cannot clear cache while tunnel is currently connected")
 		}
+		// Don't return early and don't swallow the close error: the cache must
+		// still be removed, but a failed disconnect must not be reported as success.
 		if err := c.close(); err != nil {
-			c.logger.Error("closing tunnel while clearing cache. Attempting anyway", "error", err)
+			errs = errors.Join(errs, fmt.Errorf("closing tunnel while clearing cache: %w", err))
 		}
 	}
 	if err := os.Remove(cacheFilePath(dataPath)); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("failed to remove cache file: %w", err)
+		errs = errors.Join(errs, fmt.Errorf("removing cache file: %w", err))
 	}
-	return nil
+	return errs
 }
 
 // Bytes returns the cumulative up/down byte counters for the active tunnel. ok is false if the

--- a/vpn/vpn_test.go
+++ b/vpn/vpn_test.go
@@ -2,7 +2,9 @@ package vpn
 
 import (
 	"errors"
+	"io"
 	"log/slog"
+	"os"
 	"sync"
 	"testing"
 
@@ -241,4 +243,52 @@ func TestRunOfflineURLTests_AlreadyConnected(t *testing.T) {
 
 	_, err := c.RunOfflineURLTests("", nil, nil)
 	assert.ErrorIs(t, err, ErrTunnelAlreadyConnected)
+}
+
+func TestClearTunnelCache(t *testing.T) {
+	newClient := func(t *testing.T, s VPNStatus, tun *tunnel, dir string) (*VPNClient, string) {
+		t.Helper()
+		path := cacheFilePath(dir)
+		require.NoError(t, os.WriteFile(path, []byte("cache"), 0o600))
+		c := NewVPNClient(dir, rlog.NoOpLogger(), nil)
+		c.status.Store(s)
+		c.tunnel = tun
+		return c, path
+	}
+
+	t.Run("disconnected", func(t *testing.T) {
+		dir := t.TempDir()
+		c, path := newClient(t, Disconnected, nil, dir)
+
+		assert.NoError(t, c.ClearTunnelCache(dir, false))
+		assert.NoFileExists(t, path)
+	})
+
+	t.Run("connected without force", func(t *testing.T) {
+		dir := t.TempDir()
+		c, path := newClient(t, Connected, &tunnel{}, dir)
+
+		assert.Error(t, c.ClearTunnelCache(dir, false))
+		assert.FileExists(t, path)
+		assert.NotNil(t, c.tunnel)
+	})
+
+	t.Run("connected with force", func(t *testing.T) {
+		dir := t.TempDir()
+		c, path := newClient(t, Connected, &tunnel{}, dir)
+
+		assert.NoError(t, c.ClearTunnelCache(dir, true))
+		assert.NoFileExists(t, path)
+		assert.Nil(t, c.tunnel)
+		assert.Equal(t, Disconnected, c.Status())
+	})
+
+	t.Run("connected with force error", func(t *testing.T) {
+		dir := t.TempDir()
+		tun := &tunnel{closers: []io.Closer{closerFunc(func() error { return assert.AnError })}}
+		c, path := newClient(t, Connected, tun, dir)
+
+		assert.Error(t, c.ClearTunnelCache(dir, true))
+		assert.NoFileExists(t, path)
+	})
 }


### PR DESCRIPTION
This pull request introduces a new feature that allows clearing the VPN tunnel cache through both the backend and IPC layers, including force-disconnect logic for active tunnels. It also adds supporting API endpoints and refactors cache file path handling for better maintainability.

**New tunnel cache clearing functionality:**

* Added a `ClearTunnelCache` method to `VPNClient` in `vpn/vpn.go` that removes the tunnel cache file, with an option to force-disconnect an active tunnel before clearing.
* Exposed `ClearTunnelCache` in the backend (`LocalBackend`) and IPC client (`Client`) to allow higher-level components to trigger cache clearing. [[1]](diffhunk://#diff-d7a5115ab346da59601a056266b297ad60b2db8ce5434ba7cd67023d47d5097bR938-R945) [[2]](diffhunk://#diff-723ed8d6367bbe37956df2f99440a2d76f0944e58e1fc8a4e01a699000f8ca55R144-R150)
* Added a `/vpn/cache/clear` POST endpoint to the IPC server, with a corresponding handler that invokes the backend's cache clearing logic. [[1]](diffhunk://#diff-dc406fc743858a2874d0cebfbc7c0be932056c3a247189aca780ca5ac3342c64R43) [[2]](diffhunk://#diff-dc406fc743858a2874d0cebfbc7c0be932056c3a247189aca780ca5ac3342c64R205) [[3]](diffhunk://#diff-dc406fc743858a2874d0cebfbc7c0be932056c3a247189aca780ca5ac3342c64R411-R418)

related to https://github.com/getlantern/engineering/issues/3608