### PR TITLE
fix: server propagation, settings atomicity, and config defects

### DIFF
--- a/account/user.go
+++ b/account/user.go
@@ -700,11 +700,13 @@ func (a *Client) setData(data *UserData) {
 }
 
 func (a *Client) ClearUser() {
-	settings.Clear(settings.UserIDKey)
-	settings.Clear(settings.TokenKey)
-	settings.Clear(settings.UserLevelKey)
-	settings.Clear(settings.EmailKey)
-	settings.Clear(settings.DevicesKey)
-	settings.Clear(settings.JwtTokenKey)
-	settings.Clear(settings.UserDataKey)
+	settings.Clear(
+		settings.UserIDKey,
+		settings.TokenKey,
+		settings.UserLevelKey,
+		settings.EmailKey,
+		settings.DevicesKey,
+		settings.JwtTokenKey,
+		settings.UserDataKey,
+	)
 }

--- a/account/user.go
+++ b/account/user.go
@@ -700,7 +700,7 @@ func (a *Client) setData(data *UserData) {
 }
 
 func (a *Client) ClearUser() {
-	settings.Clear(
+	err := settings.Clear(
 		settings.UserIDKey,
 		settings.TokenKey,
 		settings.UserLevelKey,
@@ -709,4 +709,7 @@ func (a *Client) ClearUser() {
 		settings.JwtTokenKey,
 		settings.UserDataKey,
 	)
+	if err != nil {
+		slog.Warn("failed to clear user info", "error", err)
+	}
 }

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
-	"strings"
 	"sync"
 
 	"time"
@@ -233,38 +232,21 @@ func (r *LocalBackend) Start() {
 			return
 		}
 		cfg := evt.New
-		locs := make(map[string]C.ServerLocation, len(cfg.OutboundLocations))
-		// Track which cities are already covered by active outbounds.
-		coveredCities := make(map[string]bool, len(cfg.OutboundLocations))
-		for k, v := range cfg.OutboundLocations {
-			if v == nil {
-				slog.Warn("Server location is nil, skipping", "tag", k)
-				continue
-			}
-			locs[k] = *v
-			coveredCities[v.City+"|"+v.CountryCode] = true
-		}
-		// Include available server locations not already covered by active
-		// outbounds so the client's location picker shows every location.
-		for _, sl := range cfg.Servers {
-			if coveredCities[sl.City+"|"+sl.CountryCode] {
-				continue
-			}
-			key := strings.ToLower(strings.ReplaceAll(sl.City, " ", "-") + "-" + sl.CountryCode)
-			locs[key] = sl
-		}
 		var srvs []*servers.Server
+		addSvr := func(tag, typ string, opts any, loc *C.ServerLocation) {
+			s := &servers.Server{
+				Tag: tag, Type: typ, IsLantern: true, Options: opts,
+			}
+			if loc != nil {
+				s.Location = *loc
+			}
+			srvs = append(srvs, s)
+		}
 		for _, out := range cfg.Options.Outbounds {
-			srvs = append(srvs, &servers.Server{
-				Tag: out.Tag, Type: out.Type, IsLantern: true,
-				Options: out, Location: locs[out.Tag],
-			})
+			addSvr(out.Tag, out.Type, out, cfg.OutboundLocations[out.Tag])
 		}
 		for _, ep := range cfg.Options.Endpoints {
-			srvs = append(srvs, &servers.Server{
-				Tag: ep.Tag, Type: ep.Type, IsLantern: true,
-				Options: ep, Location: locs[ep.Tag],
-			})
+			addSvr(ep.Tag, ep.Type, ep, cfg.OutboundLocations[ep.Tag])
 		}
 		list := servers.ServerList{Servers: srvs, URLOverrides: cfg.BanditURLOverrides}
 		if len(cfg.BanditURLOverrides) > 0 {
@@ -562,16 +544,6 @@ func (r *LocalBackend) GetServerByTag(tag string) (*servers.Server, bool) {
 	return r.srvManager.GetServerByTag(tag)
 }
 
-func (r *LocalBackend) AddServers(list servers.ServerList) error {
-	if err := r.srvManager.AddServers(list, false); err != nil {
-		return fmt.Errorf("failed to add servers to ServerManager: %w", err)
-	}
-	if err := r.vpnClient.AddOutbounds(list); err != nil && !errors.Is(err, vpn.ErrTunnelNotConnected) {
-		return fmt.Errorf("failed to add outbounds to VPN client: %w", err)
-	}
-	return nil
-}
-
 func (r *LocalBackend) RemoveServers(tags []string) error {
 	removed, err := r.srvManager.RemoveServers(tags)
 	if err != nil {
@@ -590,6 +562,50 @@ func (r *LocalBackend) RemoveServers(tags []string) error {
 	return nil
 }
 
+func (r *LocalBackend) AddServers(list servers.ServerList) error {
+	if err := r.srvManager.AddServers(list, false); err != nil {
+		return fmt.Errorf("failed to add servers to ServerManager: %w", err)
+	}
+	if err := r.vpnClient.AddOutbounds(list); err != nil && !errors.Is(err, vpn.ErrTunnelNotConnected) {
+		return fmt.Errorf("failed to add outbounds to VPN client: %w", err)
+	}
+	return nil
+}
+
+func (r *LocalBackend) AddServersByJSON(config string) ([]string, error) {
+	list, err := r.srvManager.AddServersByJSON(r.ctx, []byte(config))
+	if err != nil {
+		return nil, fmt.Errorf("failed to add servers by JSON: %w", err)
+	}
+	if err := r.vpnClient.AddOutbounds(*list); err != nil && !errors.Is(err, vpn.ErrTunnelNotConnected) {
+		return nil, fmt.Errorf("failed to add outbounds to VPN client: %w", err)
+	}
+	return list.Tags(), nil
+}
+
+func (r *LocalBackend) AddServersByURL(urls []string, skipCertVerification bool) ([]string, error) {
+	list, err := r.srvManager.AddServersByURL(r.ctx, urls, skipCertVerification)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add servers by URL: %w", err)
+	}
+	if err := r.vpnClient.AddOutbounds(*list); err != nil && !errors.Is(err, vpn.ErrTunnelNotConnected) {
+		return nil, fmt.Errorf("failed to add outbounds to VPN client: %w", err)
+	}
+	return list.Tags(), nil
+}
+
+func (r *LocalBackend) AddPrivateServer(tag, ip string, port int, accessToken string, loc C.ServerLocation, joined bool) error {
+	return r.srvManager.AddPrivateServer(tag, ip, port, accessToken, loc, joined)
+}
+
+func (r *LocalBackend) InviteToPrivateServer(ip string, port int, accessToken string, inviteName string) (string, error) {
+	return r.srvManager.InviteToPrivateServer(ip, port, accessToken, inviteName)
+}
+
+func (r *LocalBackend) RevokePrivateServerInvite(ip string, port int, accessToken string, inviteName string) error {
+	return r.srvManager.RevokePrivateServerInvite(ip, port, accessToken, inviteName)
+}
+
 func (r *LocalBackend) setServers(list servers.ServerList, isLantern bool) error {
 	if err := r.srvManager.SetServers(list, isLantern); err != nil {
 		return fmt.Errorf("failed to set servers in ServerManager: %w", err)
@@ -599,6 +615,9 @@ func (r *LocalBackend) setServers(list servers.ServerList, isLantern bool) error
 	allList := servers.ServerList{Servers: r.srvManager.AllServers(), URLOverrides: list.URLOverrides}
 	if err := r.vpnClient.UpdateOutbounds(allList); err != nil && !errors.Is(err, vpn.ErrTunnelNotConnected) {
 		return fmt.Errorf("failed to update VPN outbounds: %w", err)
+	}
+	if r.vpnClient.Status() != vpn.Connected {
+		r.clearSelectedIfMissing()
 	}
 	return nil
 }
@@ -619,26 +638,6 @@ func (r *LocalBackend) clearSelectedIfMissing() {
 	if err := r.vpnClient.SelectServer(vpn.AutoSelectTag); err != nil && !errors.Is(err, vpn.ErrTunnelNotConnected) {
 		slog.Warn("Failed to switch to auto-select after selected server was removed", "error", err)
 	}
-}
-
-func (r *LocalBackend) AddServersByJSON(config string) ([]string, error) {
-	return r.srvManager.AddServersByJSON(context.Background(), []byte(config))
-}
-
-func (r *LocalBackend) AddServersByURL(urls []string, skipCertVerification bool) ([]string, error) {
-	return r.srvManager.AddServersByURL(context.Background(), urls, skipCertVerification)
-}
-
-func (r *LocalBackend) AddPrivateServer(tag, ip string, port int, accessToken string, loc C.ServerLocation, joined bool) error {
-	return r.srvManager.AddPrivateServer(tag, ip, port, accessToken, loc, joined)
-}
-
-func (r *LocalBackend) InviteToPrivateServer(ip string, port int, accessToken string, inviteName string) (string, error) {
-	return r.srvManager.InviteToPrivateServer(ip, port, accessToken, inviteName)
-}
-
-func (r *LocalBackend) RevokePrivateServerInvite(ip string, port int, accessToken string, inviteName string) error {
-	return r.srvManager.RevokePrivateServerInvite(ip, port, accessToken, inviteName)
 }
 
 const selectionHistoryFlushInterval = 5 * time.Second

--- a/common/settings/settings.go
+++ b/common/settings/settings.go
@@ -315,8 +315,8 @@ func Exists(key _key) bool {
 }
 
 func Set(key _key, value any) error {
-	// take lock for the entire duration of the Set + save sequence to prevent mutltiple Set
-	// calls from interleaving and leaving the file in an inconsistent state until next write.
+	// take lock for the entire duration of the Set + save sequence to prevent multiple Set
+	// calls from interleaving and leaving the file in an inconsistent state until the next write.
 	k.mu.Lock()
 	defer k.mu.Unlock()
 	err := k.k.Set(key.String(), value)
@@ -327,7 +327,7 @@ func Set(key _key, value any) error {
 }
 
 func Clear(keys ..._key) error {
-	// take lock for the entire duration. See [Set] for explaination.
+	// take lock for the entire duration. See [Set] for explanation.
 	k.mu.Lock()
 	defer k.mu.Unlock()
 	for _, key := range keys {
@@ -369,7 +369,7 @@ func GetAllFor(keys ..._key) Settings {
 
 // Patch takes a map of settings to update and applies them all at once.
 func Patch(updates Settings) error {
-	// take lock for the entire duration. See [Set] for explaination.
+	// take lock for the entire duration. See [Set] for explanation.
 	k.mu.Lock()
 	defer k.mu.Unlock()
 	for key, value := range updates {

--- a/common/settings/settings.go
+++ b/common/settings/settings.go
@@ -128,11 +128,11 @@ type candidateSource struct {
 //  1. <fileDir>/settings.json                 — canonical
 //  2. <fileDir>/local.json                    — v9.0.x (renamed in #370)
 //  3. Windows ${PUBLIC}\Lantern\data\*        — v9.0.x cross-dir (#3460);
-//                                               spliced in below, Windows only
+//     spliced in below, Windows only
 //  4. pre-9.x platform-specific YAML (legacy_yaml.go); spliced in below
 //  5. <fileDir>/data/settings.json            — v9.1.x (bugged: #370's
-//                                               setupDirectories appended an
-//                                               unconditional "/data" suffix)
+//     setupDirectories appended an
+//     unconditional "/data" suffix)
 //
 // Pick the highest-priority candidate with user_level=="pro"; if none
 // is pro, the highest-priority candidate that exists. Losing Pro is
@@ -315,6 +315,10 @@ func Exists(key _key) bool {
 }
 
 func Set(key _key, value any) error {
+	// take lock for the entire duration of the Set + save sequence to prevent mutltiple Set
+	// calls from interleaving and leaving the file in an inconsistent state until next write.
+	k.mu.Lock()
+	defer k.mu.Unlock()
 	err := k.k.Set(key.String(), value)
 	if err != nil {
 		return fmt.Errorf("could not set key %s: %w", key, err)
@@ -322,8 +326,14 @@ func Set(key _key, value any) error {
 	return save()
 }
 
-func Clear(key _key) {
-	k.k.Delete(key.String())
+func Clear(keys ..._key) error {
+	// take lock for the entire duration. See [Set] for explaination.
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	for _, key := range keys {
+		k.k.Delete(key.String())
+	}
+	return save()
 }
 
 type Settings map[_key]any
@@ -359,6 +369,9 @@ func GetAllFor(keys ..._key) Settings {
 
 // Patch takes a map of settings to update and applies them all at once.
 func Patch(updates Settings) error {
+	// take lock for the entire duration. See [Set] for explaination.
+	k.mu.Lock()
+	defer k.mu.Unlock()
 	for key, value := range updates {
 		if err := k.k.Set(_key(key).String(), value); err != nil {
 			return fmt.Errorf("could not set key %s: %w", key, err)

--- a/servers/manager.go
+++ b/servers/manager.go
@@ -362,7 +362,7 @@ func (m *Manager) AddServers(list ServerList, force bool) error {
 			}
 		}
 		for _, srv := range list.Servers {
-			m.servers[srv.Tag] = srv
+			m.servers[srv.Tag] = srv.Clone()
 		}
 		return nil
 	}(); err != nil {
@@ -638,7 +638,7 @@ func (m *Manager) RevokePrivateServerInvite(ip string, port int, accessToken str
 }
 
 // AddServersByJSON adds any outbounds and endpoints defined in the provided sing-box JSON config.
-func (m *Manager) AddServersByJSON(ctx context.Context, config []byte) ([]string, error) {
+func (m *Manager) AddServersByJSON(ctx context.Context, config []byte) (*ServerList, error) {
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "Manager.AddServerBySingboxJSON")
 	defer span.End()
 	type singboxConfig struct {
@@ -653,29 +653,27 @@ func (m *Manager) AddServersByJSON(ctx context.Context, config []byte) ([]string
 		return nil, traces.RecordError(ctx, fmt.Errorf("no endpoints or outbounds found in the provided configuration"))
 	}
 	servers := make([]*Server, 0, len(cfg.Outbounds)+len(cfg.Endpoints))
-	tags := make([]string, 0, len(cfg.Outbounds)+len(cfg.Endpoints))
 	for _, out := range cfg.Outbounds {
 		if out.Tag == "" {
 			return nil, traces.RecordError(ctx, fmt.Errorf("outbound missing tag"))
 		}
 		servers = append(servers, &Server{Tag: out.Tag, Type: out.Type, Options: out})
-		tags = append(tags, out.Tag)
 	}
 	for _, ep := range cfg.Endpoints {
 		if ep.Tag == "" {
 			return nil, traces.RecordError(ctx, fmt.Errorf("endpoint missing tag"))
 		}
 		servers = append(servers, &Server{Tag: ep.Tag, Type: ep.Type, Options: ep})
-		tags = append(tags, ep.Tag)
 	}
-	if err := m.AddServers(ServerList{Servers: servers}, false); err != nil {
+	list := ServerList{Servers: servers}
+	if err := m.AddServers(list, false); err != nil {
 		return nil, traces.RecordError(ctx, fmt.Errorf("failed to add servers: %w", err))
 	}
-	return tags, nil
+	return &list, nil
 }
 
 // AddServersByURL adds a server(s) by downloading and parsing the config from a list of URLs.
-func (m *Manager) AddServersByURL(ctx context.Context, urls []string, skipCertVerification bool) ([]string, error) {
+func (m *Manager) AddServersByURL(ctx context.Context, urls []string, skipCertVerification bool) (*ServerList, error) {
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "Manager.AddServerByURLs")
 	defer span.End()
 	urlProvider, loaded := pluriconfig.GetProvider(string(model.ProviderURL))

--- a/servers/manager_test.go
+++ b/servers/manager_test.go
@@ -157,9 +157,9 @@ func TestAddServersByJSON(t *testing.T) {
 			Options:   cfg.Outbounds[0],
 		}
 		m := testManager(t)
-		tags, err := m.AddServersByJSON(t.Context(), testConfig)
+		list, err := m.AddServersByJSON(t.Context(), testConfig)
 		require.NoError(t, err)
-		assert.Equal(t, []string{"out"}, tags)
+		assert.Equal(t, []string{"out"}, list.Tags())
 		got, exists := m.GetServerByTag("out")
 		assert.True(t, exists, "server was not added")
 		assert.Equal(t, want.Tag, got.Tag)
@@ -181,9 +181,9 @@ func TestAddServersByURL(t *testing.T) {
 	}
 	t.Run("valid urls", func(t *testing.T) {
 		m := testManager(t)
-		tags, err := m.AddServersByURL(t.Context(), urls, false)
+		list, err := m.AddServersByURL(t.Context(), urls, false)
 		require.NoError(t, err)
-		assert.Len(t, tags, 2)
+		assert.Len(t, list.Tags(), 2)
 		_, exists := m.GetServerByTag("VLESS+over+WS+with+TLS")
 		assert.True(t, exists, "VLESS server should be added")
 		_, exists = m.GetServerByTag("Trojan+with+TLS")

--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -166,7 +166,9 @@ func hasGlobalIPv6Using(getSnapshots func() ([]ifaceSnapshot, error)) bool {
 // baseOpts returns the minimum sing-box options required for the tunnel to
 // function. Do not modify without understanding the downstream effects.
 func baseOpts(basePath string) O.Options {
-	splitTunnelPath := filepath.Join(basePath, splitTunnelFile)
+	// ensure split tunnel file exists
+	splitTunnelPath := newSplitTunnel(basePath, slog.Default()).ruleFile
+
 	cacheFile := filepath.Join(basePath, cacheFileName)
 	loopbackAddr := badoption.Addr(netip.MustParseAddr("127.0.0.1"))
 

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -95,7 +95,6 @@ func NewVPNClient(dataPath string, logger *slog.Logger, platformIfce PlatformInt
 	if logger == nil {
 		logger = slog.Default()
 	}
-	_ = newSplitTunnel(dataPath, logger)
 	done := make(chan struct{})
 	close(done)
 	c := &VPNClient{


### PR DESCRIPTION
## Summary

Independent, self-contained defect fixes:

- **servers:** `AddServersByJSON`/`AddServersByURL` now propagate added servers to a running tunnel — they return the added `*ServerList` and call `AddOutbounds` (ignoring `ErrTunnelNotConnected`), matching `AddServers`. Previously the servers were persisted but never pushed to the live tunnel.
- **settings:** `Set`/`Clear`/`Patch` hold `k.mu` across the full mutate+save, closing a lost-update window between concurrent writers. `ClearUser` clears all user keys in a single atomic `Clear`, so logout is all-or-nothing rather than seven separate saves.
- **vpn:** removed the discarded `newSplitTunnel(...)` construction in `NewVPNClient`; the rule-set file is ensured where it's consumed.
- **backend:** `setServers` clears a stale server selection while disconnected; removed a dead location-picker loop (its entries were written to a map only ever read by tag) and nil-guarded the per-server location lookup.
