### PR TITLE
backend: add opt-in pprof server (RADIANCE_PPROF_ADDR)

### DIFF
--- a/backend/pprof.go
+++ b/backend/pprof.go
@@ -6,37 +6,42 @@ import (
 	"net"
 	"net/http"
 	"net/http/pprof"
-	"os"
 	"time"
+
+	"github.com/getlantern/radiance/common/env"
 )
 
-// pprofAddrEnv names the environment variable that opts a build into the
-// on-device pprof server. Off by default: with the variable unset nothing
-// is registered and no port is opened, so this is safe to ship in release
-// builds. Set it to a loopback address (e.g. "localhost:6060") to profile.
-const pprofAddrEnv = "RADIANCE_PPROF_ADDR"
-
-// startDebugServer starts a loopback pprof/HTTP server when pprofAddrEnv is
-// set. Radiance is compiled into the host app via gomobile, so there is no
+// startDebugServer starts a loopback pprof/HTTP server when env.Pprof
+// (RADIANCE_PPROF_ADDR) resolves to a non-empty address. Off by default:
+// with nothing set, no handler is registered and no port is opened, so it
+// ships safely in release builds.
+//
+// The address is read through the radiance env package, so it honours an
+// OS env var, a .env file in the working dir, or a runtime env.Set (e.g.
+// via the IPC SetEnv path). The latter two matter on sandboxed macOS/iOS
+// system extensions, which don't inherit the launching shell's
+// environment. Example:
+//
+//	echo 'RADIANCE_PPROF_ADDR=localhost:6060' >> .env   # or OS env / env.Set
+//	go tool pprof http://localhost:6060/debug/pprof/profile?seconds=30
+//
+// Radiance is compiled into the host app via gomobile, so there is no
 // process to attach a profiler to and no other on-device profiling hook —
 // this is the way to capture a CPU/heap profile of the running client,
 // notably the broflake / Unbounded WebRTC relay, whose cost is otherwise
-// invisible. Example:
-//
-//	RADIANCE_PPROF_ADDR=localhost:6060 <app>
-//	go tool pprof http://localhost:6060/debug/pprof/profile?seconds=30
+// invisible.
 //
 // Non-loopback addresses are refused outright rather than trusted to the
 // caller: the pprof endpoints expose goroutine stacks and can be driven to
 // consume CPU, so they must never be reachable off-device.
 func (r *LocalBackend) startDebugServer() {
-	addr := os.Getenv(pprofAddrEnv)
+	addr := env.GetString(env.Pprof)
 	if addr == "" {
 		return
 	}
 	if !isLoopbackAddr(addr) {
 		slog.Error("Refusing to start pprof server on a non-loopback address",
-			"addr", addr, "env", pprofAddrEnv)
+			"addr", addr, "env", env.Pprof.String())
 		return
 	}
 

--- a/backend/pprof.go
+++ b/backend/pprof.go
@@ -1,0 +1,57 @@
+package backend
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/pprof"
+	"os"
+	"time"
+)
+
+// pprofAddrEnv names the environment variable that opts a build into the
+// on-device pprof server. Off by default: with the variable unset nothing
+// is registered and no port is opened, so this is safe to ship in release
+// builds. Set it to a loopback address (e.g. "localhost:6060") to profile.
+const pprofAddrEnv = "RADIANCE_PPROF_ADDR"
+
+// startDebugServer starts a loopback pprof/HTTP server when pprofAddrEnv is
+// set. Radiance is compiled into the host app via gomobile, so there is no
+// process to attach a profiler to and no other on-device profiling hook —
+// this is the way to capture a CPU/heap profile of the running client,
+// notably the broflake / Unbounded WebRTC relay, whose cost is otherwise
+// invisible. Example:
+//
+//	RADIANCE_PPROF_ADDR=localhost:6060 <app>
+//	go tool pprof http://localhost:6060/debug/pprof/profile?seconds=30
+//
+// Bind only to loopback: the pprof endpoints expose goroutine stacks and
+// can force expensive profiles, so they must never be reachable off-device.
+func startDebugServer() {
+	addr := os.Getenv(pprofAddrEnv)
+	if addr == "" {
+		return
+	}
+
+	// Dedicated mux rather than http.DefaultServeMux, so importing
+	// net/http/pprof here can't accidentally surface these handlers on any
+	// other server in the process that happens to serve DefaultServeMux.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	slog.Warn("Starting radiance pprof server (debug only)", "addr", addr)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("radiance pprof server stopped", "error", err)
+		}
+	}()
+}

--- a/backend/pprof.go
+++ b/backend/pprof.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"errors"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/pprof"
 	"os"
@@ -25,11 +26,17 @@ const pprofAddrEnv = "RADIANCE_PPROF_ADDR"
 //	RADIANCE_PPROF_ADDR=localhost:6060 <app>
 //	go tool pprof http://localhost:6060/debug/pprof/profile?seconds=30
 //
-// Bind only to loopback: the pprof endpoints expose goroutine stacks and
-// can force expensive profiles, so they must never be reachable off-device.
-func startDebugServer() {
+// Non-loopback addresses are refused outright rather than trusted to the
+// caller: the pprof endpoints expose goroutine stacks and can be driven to
+// consume CPU, so they must never be reachable off-device.
+func (r *LocalBackend) startDebugServer() {
 	addr := os.Getenv(pprofAddrEnv)
 	if addr == "" {
+		return
+	}
+	if !isLoopbackAddr(addr) {
+		slog.Error("Refusing to start pprof server on a non-loopback address",
+			"addr", addr, "env", pprofAddrEnv)
 		return
 	}
 
@@ -48,10 +55,32 @@ func startDebugServer() {
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
+	// Tie the server to Close() so a Start/Close cycle (re-init, tests,
+	// in-process clients) doesn't leak the goroutine or leave the port
+	// bound — which would fail the next Start with "address already in
+	// use". srv.Close aborts in-flight profile requests immediately, which
+	// is what we want on shutdown.
+	r.shutdownFuncs = append(r.shutdownFuncs, srv.Close)
 	slog.Warn("Starting radiance pprof server (debug only)", "addr", addr)
 	go func() {
 		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			slog.Error("radiance pprof server stopped", "error", err)
 		}
 	}()
+}
+
+// isLoopbackAddr reports whether addr (a "host:port") binds only to the
+// loopback interface. The empty host (e.g. ":6060") binds every interface
+// and is rejected; "localhost" and explicit loopback IPs (127.0.0.0/8,
+// ::1) are accepted.
+func isLoopbackAddr(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -200,6 +200,11 @@ func NewLocalBackend(ctx context.Context, opts Options) (*LocalBackend, error) {
 }
 
 func (r *LocalBackend) Start() {
+	// Opt-in pprof server (RADIANCE_PPROF_ADDR); no-op unless set. See
+	// startDebugServer — the only on-device hook for profiling the client,
+	// e.g. the broflake/Unbounded WebRTC relay's CPU.
+	startDebugServer()
+
 	// eagerly start kindling so it's ready by the time we need to make network requests
 	kindling.Init()
 	go func() {

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -203,7 +203,7 @@ func (r *LocalBackend) Start() {
 	// Opt-in pprof server (RADIANCE_PPROF_ADDR); no-op unless set. See
 	// startDebugServer — the only on-device hook for profiling the client,
 	// e.g. the broflake/Unbounded WebRTC relay's CPU.
-	startDebugServer()
+	r.startDebugServer()
 
 	// eagerly start kindling so it's ready by the time we need to make network requests
 	kindling.Init()

--- a/common/env/env.go
+++ b/common/env/env.go
@@ -34,6 +34,13 @@ var (
 	// on the user's router (handy for eero / ISP CPE that don't expose UPnP).
 	PeerExternalPort _key = "RADIANCE_PEER_EXTERNAL_PORT"
 
+	// Pprof, set to a loopback address (e.g. localhost:6060), starts an
+	// on-device pprof/HTTP server for profiling the running client. Off
+	// unless set. See backend.startDebugServer. Read through this package
+	// so a .env file or runtime Set works on sandboxed system extensions
+	// that don't inherit the launching shell's environment.
+	Pprof _key = "RADIANCE_PPROF_ADDR"
+
 	Testing _key = "RADIANCE_TESTING"
 
 	mu     sync.RWMutex


### PR DESCRIPTION
## What

Adds a loopback pprof/HTTP server to `LocalBackend`, gated behind the `RADIANCE_PPROF_ADDR` env var. **Off by default** — with the var unset, nothing is registered and no port is opened, so it's safe in release builds.

```bash
RADIANCE_PPROF_ADDR=localhost:6060 <app>
go tool pprof http://localhost:6060/debug/pprof/profile?seconds=30
```

## Why

Radiance is compiled into the host app via gomobile, so there's no separate process to attach a profiler to, and no other on-device profiling hook. This came out of investigating high CPU while the **Unbounded / broflake WebRTC relay** is active — that relay's cost (pion DTLS/ICE/SCTP + QUIC-over-datachannel + byte copying) is otherwise invisible, and there was no way to capture a CPU/heap profile of the running client.

## Safety

- **Hard-refuses non-loopback addresses.** `isLoopbackAddr` rejects an empty host (`:6060` → all interfaces), `0.0.0.0`, and public IPs before the listener opens; only `localhost`, `127.0.0.0/8`, and `::1` are accepted. The pprof endpoints expose goroutine stacks and can be driven to burn CPU, so they must never be reachable off-device — this is enforced, not left to the caller.
- **Tied to `Close()`.** The server's `Close` is registered in `shutdownFuncs`, so a Start/Close cycle (re-init, tests, in-process clients) frees the port and stops the goroutine instead of leaking it and failing the next Start with "address already in use".
- Served from a **dedicated mux**, not `http.DefaultServeMux`, so importing `net/http/pprof` here can't surface these handlers on any other server in the process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)