### PR TITLE
deps: bump amp + kindling to include the closed-channel crash fix (amp#18)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,12 +30,12 @@ require (
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/alexflint/go-arg v1.6.1
 	github.com/alitto/pond v1.9.2
-	github.com/getlantern/amp v0.0.0-20260305201851-782bc8045e58
+	github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c
 	github.com/getlantern/common v1.2.1-0.20260326210434-cb69537aaf46
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac
 	github.com/getlantern/domainfront v0.0.0-20260419161617-0bff0b2169f4
 	github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694
-	github.com/getlantern/kindling v0.0.0-20260603191740-3bab85a3e48f
+	github.com/getlantern/kindling v0.0.0-20260607234336-5372ea728050
 	github.com/getlantern/lantern-box v0.0.88
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,8 @@ github.com/gaukas/wazerofs v0.1.0 h1:wIkW1bAxSnpaaVkQ5LOb1tm1BXdVap3eKjJpVWIqt2E
 github.com/gaukas/wazerofs v0.1.0/go.mod h1:+JECB9Fwt0taPqSgHckG9lmT3tcoVK+9VJozTsq9UlI=
 github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52 h1:w2/RqYPw7PbTYfUMS2aToD5DMKLBnQed+fkTEYTKAqQ=
 github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52/go.mod h1:PrNR8tMXO26YNs8K9653XCUH7u2Kv4OdfFC3Ke1GsX0=
-github.com/getlantern/amp v0.0.0-20260305201851-782bc8045e58 h1:3wxMKw90adxiEzsJmAmMHqBJQr/P/9Goqy/U2a1l/sg=
-github.com/getlantern/amp v0.0.0-20260305201851-782bc8045e58/go.mod h1:p6WdG48YAz5SCUpiMSGLy616A6YghKToc63y3NP7avI=
+github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c h1:ZzxuhIWO295y4eE6wPYUq8Smntlgg+y39L5OOyMJY+k=
+github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c/go.mod h1:b5teAOFT+vpBqc2CHoz74QTEM15iOv1PLdQogwXcfrM=
 github.com/getlantern/broflake v0.0.0-20260504215251-ed3cf75062d1 h1:3WYvObOo8gpKwjcLrV6O/vRp+ubKdjpvJwZrRkbbDWw=
 github.com/getlantern/broflake v0.0.0-20260504215251-ed3cf75062d1/go.mod h1:bZGGfTwne9NIsy3Kc1avcXNWn/yA8ghUwlXdS2z+AlA=
 github.com/getlantern/common v1.2.1-0.20260326210434-cb69537aaf46 h1:Ab2esudqgFz2K1WYQKtX+58kaiVMX0UohjW2XmdEgf4=
@@ -246,8 +246,8 @@ github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 h1:cSrD9ryDfTV2y
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770/go.mod h1:GOQsoDnEHl6ZmNIL+5uVo+JWRFWozMEp18Izcb++H+A=
 github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694 h1:iLWm6S/47Hfk7FjW6yaD+1h6kO7C/iauV0DkVia/bXU=
 github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
-github.com/getlantern/kindling v0.0.0-20260603191740-3bab85a3e48f h1:3u5gy2KP54vWc2XfnE+6SpLd2jdEDuNxPCqmJ9iRVmM=
-github.com/getlantern/kindling v0.0.0-20260603191740-3bab85a3e48f/go.mod h1:+3NCIlClNof6Ovw67hH2cwiMrIzC9CTOsRgyfTSLffM=
+github.com/getlantern/kindling v0.0.0-20260607234336-5372ea728050 h1:fIZoAaS6SCpH+QqlkAsYsIKI1jNJ1k12vGqY8lmAbso=
+github.com/getlantern/kindling v0.0.0-20260607234336-5372ea728050/go.mod h1:9EDX+ZFoMVcd8M14LeE7ULn/TRuV9g5GijNUDgJyw2A=
 github.com/getlantern/lantern-box v0.0.88 h1:A+K417P/+1IMaI0NyEsyJLDY7xlk/faKpAgRI+WXyB0=
 github.com/getlantern/lantern-box v0.0.88/go.mod h1:7/V3MIU6+5zt4Ybg06rRJI0Yi/WSfqUfp8wWnk5ofDs=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=


### PR DESCRIPTION
## What

Hop 2 of propagating the keepcurrent closed-channel crash fix to clients. Bumps:

- `github.com/getlantern/amp` `20260305 (782bc804)` → `20260606 (a8629924577c)` — direct dep, imported in `kindling/fronted/amp.go`
- `github.com/getlantern/kindling` `20260603 (3bab85a)` → `20260607 (5372ea728050)` — [kindling#38](https://github.com/getlantern/kindling/pull/38), which carries the same amp bump

These pull in **[amp#18](https://github.com/getlantern/amp/pull/18)**: it removes the `close(chDB)` in amp's `keepCurrent` that races the keepcurrent `Runner`'s send and crashes the whole client with `panic: send on closed channel` (Freshdesk #176970 / lantern-forum-cn #1543, macOS v9 beta).

`go mod tidy` run; `go.mod` + `go.sum` committed together. Only the amp/kindling lines + their go.sum hashes change.

## ⚠️ Pre-existing, unrelated CI failure

`cmd/lantern` fails to build on `main` (`ipc.NewClient` signature drift — wants `(context.Context, backend.Options)`, the CLI calls it with `()`). This is **not introduced by this PR** — it reproduces on clean `main` (base `7c83b37`) with these go.mod/go.sum changes stashed, and `main`'s own CI is already red on it. `cmd/lantern` is a dev CLI, not the client library, so the lantern client build (hop 3) is unaffected. Happy to fix it in a separate PR.

## Chain

1. ~~kindling~~ ✅ [#38](https://github.com/getlantern/kindling/pull/38) (merged)
2. **radiance** ← this PR
3. lantern → bump radiance (next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
