### PR TITLE
deps: bump keepcurrent to the send-on-closed-channel backstop (keepcurrent#8)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/getlantern/common v1.2.1-0.20260326210434-cb69537aaf46
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac
 	github.com/getlantern/domainfront v0.0.0-20260419161617-0bff0b2169f4
-	github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694
+	github.com/getlantern/keepcurrent v0.0.0-20260608000050-6b50f5857840
 	github.com/getlantern/kindling v0.0.0-20260607234336-5372ea728050
 	github.com/getlantern/lantern-box v0.0.88
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,8 @@ github.com/getlantern/hex v0.0.0-20220104173244-ad7e4b9194dc h1:sue+aeVx7JF5v36H
 github.com/getlantern/hex v0.0.0-20220104173244-ad7e4b9194dc/go.mod h1:D9RWpXy/EFPYxiKUURo2TB8UBosbqkiLhttRrZYtvqM=
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 h1:cSrD9ryDfTV2yaur9Qk3rHYD414j3Q1rl7+L0AylxrE=
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770/go.mod h1:GOQsoDnEHl6ZmNIL+5uVo+JWRFWozMEp18Izcb++H+A=
-github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694 h1:iLWm6S/47Hfk7FjW6yaD+1h6kO7C/iauV0DkVia/bXU=
-github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
+github.com/getlantern/keepcurrent v0.0.0-20260608000050-6b50f5857840 h1:/YhIurj1ekh7UUNu5/67vYt7gl7S4eAvCXhx+treDE8=
+github.com/getlantern/keepcurrent v0.0.0-20260608000050-6b50f5857840/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260607234336-5372ea728050 h1:fIZoAaS6SCpH+QqlkAsYsIKI1jNJ1k12vGqY8lmAbso=
 github.com/getlantern/kindling v0.0.0-20260607234336-5372ea728050/go.mod h1:9EDX+ZFoMVcd8M14LeE7ULn/TRuV9g5GijNUDgJyw2A=
 github.com/getlantern/lantern-box v0.0.88 h1:A+K417P/+1IMaI0NyEsyJLDY7xlk/faKpAgRI+WXyB0=


### PR DESCRIPTION
## What

Bumps `github.com/getlantern/keepcurrent` `20260422 (54a4d9a)` → `20260608 (6b50f58)` to pull in **[keepcurrent#8](https://github.com/getlantern/keepcurrent/pull/8)**: `byteChannel.UpdateFrom` now `recover`s the `send on closed channel` panic and returns it as a sink error instead of crashing the whole process (Freshdesk #176970).

radiance imports keepcurrent directly in `kindling/dnstt/parser.go`, so it pins the version.

## Defense-in-depth

This is the **backstop**, not the primary fix — [amp#18](https://github.com/getlantern/amp/pull/18) (already merged + propagated to radiance) removed the only current `close(chDB)` trigger. keepcurrent#8 just prevents any *future* consumer from reintroducing the crash. Via Go MVS, bumping keepcurrent here is the highest version in the client graph, so it also covers amp's keepcurrent use in the client build without needing a separate amp bump.

## Notes
- `go mod tidy` run; only the keepcurrent line + go.sum hashes change. The `dnstt` package (the keepcurrent consumer) builds.
- `cmd/lantern` fails to build on `main` (`ipc.NewClient` signature drift) — **pre-existing and unrelated**, reproduces on clean main; not from this bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
