### PR TITLE
re-enable gvisor on ios for dns fakeip

### DIFF
--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -436,6 +436,9 @@ func buildOptions(bOptions BoxOptions) (O.Options, error) {
 				slog.Info("kernel below 5.10, using gvisor TUN stack", "kernel", kv)
 			}
 			slog.Debug("Android platform detected, OverrideAndroidVPN set to true")
+		case "ios":
+			opts.Inbounds[0].Options.(*O.TunInboundOptions).Stack = "gvisor"
+			slog.Debug("iOS platform detected, using gvisor TUN stack")
 		case "linux":
 			opts.Inbounds[0].Options.(*O.TunInboundOptions).AutoRedirect = true
 			slog.Debug("Linux platform detected, AutoRedirect set to true")

--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -437,8 +437,8 @@ func buildOptions(bOptions BoxOptions) (O.Options, error) {
 			}
 			slog.Debug("Android platform detected, OverrideAndroidVPN set to true")
 		case "ios":
-			opts.Inbounds[0].Options.(*O.TunInboundOptions).Stack = "gvisor"
-			slog.Debug("iOS platform detected, using gvisor TUN stack")
+			opts.Inbounds[0].Options.(*O.TunInboundOptions).Stack = ""
+			slog.Debug("iOS platform detected, using default TUN stack with no override")
 		case "linux":
 			opts.Inbounds[0].Options.(*O.TunInboundOptions).AutoRedirect = true
 			slog.Debug("Linux platform detected, AutoRedirect set to true")


### PR DESCRIPTION
This re-enables gvisor in iOS, which is required to use DNS fakeip.