### PR TITLE
deps: bump sing-tun to v0.7.13 to fix macOS TUN teardown busy-loop

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -281,7 +281,7 @@ require (
 	github.com/sagernet/sing-shadowsocks v0.2.8 // indirect
 	github.com/sagernet/sing-shadowsocks2 v0.2.1 // indirect
 	github.com/sagernet/sing-shadowtls v0.2.1-0.20250503051639-fcd445d33c11 // indirect
-	github.com/sagernet/sing-tun v0.7.11 // indirect
+	github.com/sagernet/sing-tun v0.7.13 // indirect
 	github.com/sagernet/sing-vmess v0.2.7 // indirect
 	github.com/sagernet/smux v1.5.50-sing-box-mod.1 // indirect
 	github.com/sagernet/wireguard-go v0.0.1-beta.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -674,8 +674,8 @@ github.com/sagernet/sing-shadowsocks2 v0.2.1 h1:dWV9OXCeFPuYGHb6IRqlSptVnSzOelnq
 github.com/sagernet/sing-shadowsocks2 v0.2.1/go.mod h1:RnXS0lExcDAovvDeniJ4IKa2IuChrdipolPYWBv9hWQ=
 github.com/sagernet/sing-shadowtls v0.2.1-0.20250503051639-fcd445d33c11 h1:tK+75l64tm9WvEFrYRE1t0YxoFdWQqw/h7Uhzj0vJ+w=
 github.com/sagernet/sing-shadowtls v0.2.1-0.20250503051639-fcd445d33c11/go.mod h1:sWqKnGlMipCHaGsw1sTTlimyUpgzP4WP3pjhCsYt9oA=
-github.com/sagernet/sing-tun v0.7.11 h1:qB7jy8JKqXg73fYBsDkBSy4ulRSbLrFut0e+y+QPhqU=
-github.com/sagernet/sing-tun v0.7.11/go.mod h1:pUEjh9YHQ2gJT6Lk0TYDklh3WJy7lz+848vleGM3JPM=
+github.com/sagernet/sing-tun v0.7.13 h1:GuUBCymnGV/2jyxPae3eM9HlX1d7FaNxM97EqktDfy0=
+github.com/sagernet/sing-tun v0.7.13/go.mod h1:pUEjh9YHQ2gJT6Lk0TYDklh3WJy7lz+848vleGM3JPM=
 github.com/sagernet/sing-vmess v0.2.7 h1:2ee+9kO0xW5P4mfe6TYVWf9VtY8k1JhNysBqsiYj0sk=
 github.com/sagernet/sing-vmess v0.2.7/go.mod h1:5aYoOtYksAyS0NXDm0qKeTYW1yoE1bJVcv+XLcVoyJs=
 github.com/sagernet/smux v1.5.50-sing-box-mod.1 h1:XkJcivBC9V4wBjiGXIXZ229aZCU1hzcbp6kSkkyQ478=


### PR DESCRIPTION
## Summary

Bumps `github.com/sagernet/sing-tun` from v0.7.11 to v0.7.13.

v0.7.13 widens the `batchLoopDarwin` exit check to treat `syscall.EBADF` as a closed condition:

```go
if E.IsClosed(err) || errors.Is(err, syscall.EBADF) {
    return
}
```

## Why

On macOS the TUN file descriptor is owned by the NetworkExtension's `NEPacketTunnelFlow`, not by sing-tun. During tunnel teardown the system can close that fd out-of-band, after which `BatchRead` returns a bare `syscall.EBADF`. The previous exit check (`E.IsClosed`) did not classify `EBADF` as closed, so `batchLoopDarwin` logged and `continue`d instead of returning — spinning the darwin read loop at full CPU and flooding logs with `batch read packet: bad file descriptor`. This surfaced as intermittent connectivity during reconnect/teardown windows.

The fix lives in the read loop's error classification; `BatchRead` still returns the raw errno.