### PR TITLE
feat(vpn): set explicit mobile GC and memory limits

### DIFF
--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -174,16 +174,37 @@ func (t *tunnel) init(ctx context.Context, options string, platformIfce libbox.P
 	t.closers = append(t.closers, lb)
 	t.lbService = lb
 
-	// set memory limit for Android and iOS
-	switch common.Platform {
-	case "android", "ios":
-		slog.Debug("Setting memory limit for mobile platform", "platform", common.Platform)
-		libbox.SetMemoryLimit(true)
-	default:
+	if common.IsMobile() {
+		setMobileMemoryLimits()
 	}
 
 	slog.Info("Tunnel initializated")
 	return nil
+}
+
+// Memory tuning for mobile devices, which have more constrained resources. iOS will silently
+// kill the extension if it exceeds a hard cap (≈50 MB).
+const (
+	// mobileGCPercent trades heap headroom for fewer collections; GC churn under load,
+	// not heap size, was the cost.
+	mobileGCPercent = 50
+	// mobileMemoryLimit is the GOMEMLIMIT soft cap. This needs to be below the iOS hard cap
+	// to leave room for the non-Go side (swift, CGo, etc.).
+	mobileMemoryLimit = 40 * 1024 * 1024 // 40 MB
+	// mobileConntrackLimit is the footprint at which the conntrack killer closes all
+	// connections and frees OS memory — the last resort before the OS kills the
+	// extension. It sits above GOMEMLIMIT so Go GC reacts first.
+	mobileConntrackLimit = 45 * 1024 * 1024 // 45 MB
+)
+
+func setMobileMemoryLimits() {
+	slog.Debug("Setting memory limits for mobile platform", "platform", common.Platform,
+		"gc_percent", mobileGCPercent, "go_mem_limit", mobileMemoryLimit, "conntrack_limit", mobileConntrackLimit,
+	)
+	runtimeDebug.SetGCPercent(mobileGCPercent)
+	runtimeDebug.SetMemoryLimit(mobileMemoryLimit)
+	conntrack.KillerEnabled = true
+	conntrack.MemoryLimit = mobileConntrackLimit
 }
 
 func newClientContextInjector(outboundMgr adapter.OutboundManager, dataPath string) *clientcontext.ClientContextInjector {

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -185,11 +185,11 @@ func (t *tunnel) init(ctx context.Context, options string, platformIfce libbox.P
 // Memory tuning for mobile devices, which have more constrained resources. iOS will silently
 // kill the extension if it exceeds a hard cap (≈50 MB).
 const (
-	// mobileGCPercent trades heap headroom for fewer collections; GC churn under load,
-	// not heap size, was the cost.
+	// mobileGCPercent is the soft cap for triggering the GC. This is higher than sing-box's
+	// default of 30 to allow more memory headroom for the Go side before hitting the iOS hard cap.
 	mobileGCPercent = 50
 	// mobileMemoryLimit is the GOMEMLIMIT soft cap. This needs to be below the iOS hard cap
-	// to leave room for the non-Go side (swift, CGo, etc.).
+	// to leave room for the non-Go side (Swift, cgo, etc.).
 	mobileMemoryLimit = 40 * 1024 * 1024 // 40 MB
 	// mobileConntrackLimit is the footprint at which the conntrack killer closes all
 	// connections and frees OS memory — the last resort before the OS kills the

--- a/vpn/tunnel_test.go
+++ b/vpn/tunnel_test.go
@@ -109,3 +109,11 @@ func TestContextDone(t *testing.T) {
 	cancel()
 	assert.True(t, contextDone(ctx))
 }
+
+// The mobile memory limits must stay ordered: GOMEMLIMIT below the conntrack killer
+// (so Go GC reacts before connections are dropped), and the killer below the iOS cap.
+func TestMobileMemoryLimitsOrdering(t *testing.T) {
+	const iOSFootprintCap = 50 << 20
+	assert.Less(t, mobileMemoryLimit, mobileConntrackLimit, "GOMEMLIMIT must be below the conntrack killer")
+	assert.Less(t, mobileConntrackLimit, iOSFootprintCap, "conntrack killer must be below the iOS footprint cap")
+}


### PR DESCRIPTION
## What

Replace `libbox.SetMemoryLimit(true)` on mobile (`vpn/tunnel.go`) with explicit, named limits set in `setMobileMemoryLimits()`:

| | libbox default | this PR |
|---|---|---|
| `GCPercent` | 10 | **50** |
| `GOMEMLIMIT` | 30 MB | **40 MB** |
| conntrack killer | 45 MB | 45 MB (unchanged) |

## Why

iOS memory-pressure logs show `GOMEMLIMIT=30 MB` driving pathological GC (`num_gc` in the tens of thousands) while the footprint still climbed to ~44 MB — because the footprint is dominated by **non-Go/native memory** (gVisor netstack, tun, sing-box C), which `GOMEMLIMIT` doesn't govern. The aggressive `10`/`30 MB` settings paid heavy GC churn for no footprint benefit.

Raising to `50`/`40 MB` relieves the churn and lifts the Go-heap ceiling while staying safely below the conntrack killer and the OS cap.

## Invariant

The three limits stay ordered **GOMEMLIMIT (40) < conntrack killer (45) < iOS cap (50)** so Go GC reacts before connections are dropped, and the killer fires before the OS kills the extension. 