### PR TITLE
Add a timeout for the HTTP client to avoid looping.

### DIFF
--- a/account/client.go
+++ b/account/client.go
@@ -94,8 +94,7 @@ func (a *Client) sendRequest(
 		url = a.baseURL() + url
 	}
 
-	// Bound the request with a timeout to prevent hanging indefinitely due to network issues or 512 bad gateway loops.
-	// This allows the error to flow through the existing error handling path and surface to the UI, instead of leaving the client stuck (e.g. an endless email-verification spinner).
+	// Bound the request with a timeout to prevent hanging indefinitely due to network issues or 502 Bad Gateway loops.
 	timeoutCtx, cancel := context.WithTimeout(ctx, common.DefaultHTTPTimeout)
 	defer cancel()
 

--- a/account/client.go
+++ b/account/client.go
@@ -94,6 +94,11 @@ func (a *Client) sendRequest(
 		url = a.baseURL() + url
 	}
 
+	// Bound the request with a timeout to prevent hanging indefinitely due to network issues or 512 bad gateway loops.
+	// This allows the error to flow through the existing error handling path and surface to the UI, instead of leaving the client stuck (e.g. an endless email-verification spinner).
+	timeoutCtx, cancel := context.WithTimeout(ctx, common.DefaultHTTPTimeout)
+	defer cancel()
+
 	var bodyReader io.Reader
 	contentType := ""
 	if body != nil {
@@ -113,7 +118,7 @@ func (a *Client) sendRequest(
 			contentType = "application/json"
 		}
 	}
-	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+	req, err := http.NewRequestWithContext(timeoutCtx, method, url, bodyReader)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}


### PR DESCRIPTION
This pull request adds a timeout to all HTTP requests made by the `Client` in `account/client.go`, improving reliability and preventing the client from hanging indefinitely due to network issues or server errors.

**HTTP request reliability improvements:**

* All HTTP requests in the `sendRequest` method are now automatically bounded by a default timeout (`common.DefaultHTTPTimeout`), ensuring requests do not hang indefinitely and errors are surfaced to the UI instead of causing endless loading states.
* The HTTP request is now created using the new timeout-bound context to enforce the timeout for the request lifecycle.