### PR TITLE
feat(vpn): defer tunnel cache clear via on-disk marker

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -935,11 +935,19 @@ func (r *LocalBackend) startAutoSelectedListener() {
 }
 
 // ClearTunnelCache removes the tunnel cache from the configured data directory.
-// When force is true, an active tunnel is disconnected first; otherwise clearing
-// a connected tunnel's cache returns an error. ClearTunnelCache will not reopen
-// the tunnel if it had to close it.
-func (r *LocalBackend) ClearTunnelCache(force bool) error {
-	return r.vpnClient.ClearTunnelCache(settings.GetString(settings.DataPathKey), force)
+// If removal was deferred because the tunnel was active, it restarts the tunnel
+// to apply the clear immediately.
+func (r *LocalBackend) ClearTunnelCache() error {
+	shouldRestart, err := r.vpnClient.ClearTunnelCache(settings.GetString(settings.DataPathKey))
+	if err != nil || !shouldRestart {
+		return err
+	}
+
+	err = r.RestartVPN()
+	if err == nil || errors.Is(err, vpn.ErrTunnelNotConnected) {
+		return nil
+	}
+	return err
 }
 
 func (r *LocalBackend) RunOfflineURLTests() error {

--- a/cmd/lantern/lantern.go
+++ b/cmd/lantern/lantern.go
@@ -23,23 +23,24 @@ import (
 )
 
 type args struct {
-	Connect      *ConnectCmd      `arg:"subcommand:connect" help:"connect to VPN"`
-	Disconnect   *DisconnectCmd   `arg:"subcommand:disconnect" help:"disconnect VPN"`
-	Status       *StatusCmd       `arg:"subcommand:status" help:"show VPN status"`
-	Servers      *ServersCmd      `arg:"subcommand:servers" help:"manage servers"`
-	Set          *SetCmd          `arg:"subcommand:set" help:"update one or more settings"`
-	Get          *GetCmd          `arg:"subcommand:get" help:"show one or all settings"`
-	SplitTunnel  *SplitTunnelCmd  `arg:"subcommand:split-tunnel" help:"split-tunnel filter management"`
-	Features     *FeaturesCmd     `arg:"subcommand:features" help:"list available features and their status"`
-	Account      *AccountCmd      `arg:"subcommand:account" help:"login, signup, user data, devices, recovery"`
-	Subscription *SubscriptionCmd `arg:"subcommand:subscription" help:"plans, payments, and billing"`
-	ReportIssue  *ReportIssueCmd  `arg:"subcommand:report-issue" help:"report an issue"`
-	Throughput   *ThroughputCmd   `arg:"subcommand:throughput" help:"show throughput, globally and per outbound"`
-	Monitor      *MonitorCmd      `arg:"subcommand:monitor" help:"watch status, throughput, settings, recent history and errors; press q or Ctrl-C to quit"`
-	Logs         *LogsCmd         `arg:"subcommand:logs" help:"tail daemon logs; press q or Ctrl-C to quit"`
-	UpdateConfig *UpdateConfigCmd `arg:"subcommand:update-config" help:"force an immediate config fetch"`
-	IP           *IPCmd           `arg:"subcommand:ip" help:"show public IP address"`
-	Version      *VersionCmd      `arg:"subcommand:version" help:"print version"`
+	Connect          *ConnectCmd          `arg:"subcommand:connect" help:"connect to VPN"`
+	Disconnect       *DisconnectCmd       `arg:"subcommand:disconnect" help:"disconnect VPN"`
+	ClearTunnelCache *ClearTunnelCacheCmd `arg:"subcommand:clear-cache" help:"clear the tunnel cache"`
+	Status           *StatusCmd           `arg:"subcommand:status" help:"show VPN status"`
+	Servers          *ServersCmd          `arg:"subcommand:servers" help:"manage servers"`
+	Set              *SetCmd              `arg:"subcommand:set" help:"update one or more settings"`
+	Get              *GetCmd              `arg:"subcommand:get" help:"show one or all settings"`
+	SplitTunnel      *SplitTunnelCmd      `arg:"subcommand:split-tunnel" help:"split-tunnel filter management"`
+	Features         *FeaturesCmd         `arg:"subcommand:features" help:"list available features and their status"`
+	Account          *AccountCmd          `arg:"subcommand:account" help:"login, signup, user data, devices, recovery"`
+	Subscription     *SubscriptionCmd     `arg:"subcommand:subscription" help:"plans, payments, and billing"`
+	ReportIssue      *ReportIssueCmd      `arg:"subcommand:report-issue" help:"report an issue"`
+	Throughput       *ThroughputCmd       `arg:"subcommand:throughput" help:"show throughput, globally and per outbound"`
+	Monitor          *MonitorCmd          `arg:"subcommand:monitor" help:"watch status, throughput, settings, recent history and errors; press q or Ctrl-C to quit"`
+	Logs             *LogsCmd             `arg:"subcommand:logs" help:"tail daemon logs; press q or Ctrl-C to quit"`
+	UpdateConfig     *UpdateConfigCmd     `arg:"subcommand:update-config" help:"force an immediate config fetch"`
+	IP               *IPCmd               `arg:"subcommand:ip" help:"show public IP address"`
+	Version          *VersionCmd          `arg:"subcommand:version" help:"print version"`
 }
 
 func (args) Description() string {
@@ -182,6 +183,8 @@ func run(ctx context.Context, c *ipc.Client, a *args) error {
 		return vpnConnect(ctx, c, a.Connect.Name, a.Connect.Wait)
 	case a.Disconnect != nil:
 		return c.DisconnectVPN(ctx)
+	case a.ClearTunnelCache != nil:
+		return runClearTunnelCache(ctx, c)
 	case a.Status != nil:
 		return vpnStatus(ctx, c, a.Status)
 	case a.Throughput != nil:

--- a/cmd/lantern/vpn.go
+++ b/cmd/lantern/vpn.go
@@ -18,6 +18,8 @@ type ConnectCmd struct {
 
 type DisconnectCmd struct{}
 
+type ClearTunnelCacheCmd struct{}
+
 type StatusCmd struct {
 	JSON bool `arg:"--json" help:"output JSON"`
 }
@@ -66,6 +68,14 @@ func vpnConnect(ctx context.Context, c *ipc.Client, tag string, wait bool) error
 	} else {
 		fmt.Printf("\rIP change not detected after %v\n", time.Since(start).Truncate(time.Second))
 	}
+	return nil
+}
+
+func runClearTunnelCache(ctx context.Context, c *ipc.Client) error {
+	if err := c.ClearTunnelCache(ctx); err != nil {
+		return err
+	}
+	fmt.Println("Tunnel cache cleared")
 	return nil
 }
 

--- a/ipc/client.go
+++ b/ipc/client.go
@@ -141,8 +141,9 @@ func (c *Client) VPNSessions(ctx context.Context, limit int) ([]vpn.Session, err
 	return sessions, err
 }
 
-// ClearTunnelCache removes the tunnel cache, disconnecting an active tunnel first
-// if one is connected. ClearTunnelCache will not reopen the tunnel.
+// ClearTunnelCache removes the tunnel cache. If the tunnel is connected, the
+// backend restarts it to apply the removal, since the cache cannot be deleted
+// while in use.
 func (c *Client) ClearTunnelCache(ctx context.Context) error {
 	_, err := c.do(ctx, http.MethodPost, vpnClearTunnelCacheEndpoint, nil)
 	return err

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -409,7 +409,7 @@ func (s *localapi) vpnSessionsHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *localapi) vpnClearTunnelCacheHandler(w http.ResponseWriter, r *http.Request) {
-	if err := s.backend(r.Context()).ClearTunnelCache(true); err != nil {
+	if err := s.backend(r.Context()).ClearTunnelCache(); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -410,9 +410,7 @@ func consumeCacheClearMarker(basePath string) error {
 	if err := removeCacheFile(basePath); err != nil {
 		return err
 	}
-	if err := os.Remove(marker); err != nil {
-		return fmt.Errorf("removing cache clear marker: %w", err)
-	}
+	os.Remove(marker) // we can safely ignore errors here
 	return nil
 }
 

--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -393,7 +393,10 @@ func removeCacheFile(basePath string) error {
 // tunnel start.
 func writeCacheClearMarker(basePath string) error {
 	slog.Debug("writing cache clear marker", "path", cacheClearMarkerPath(basePath))
-	return atomicfile.WriteFile(cacheClearMarkerPath(basePath), nil, fileperm.File)
+	if err := atomicfile.WriteFile(cacheClearMarkerPath(basePath), nil, fileperm.File); err != nil {
+		return fmt.Errorf("writing cache clear marker: %w", err)
+	}
+	return nil
 }
 
 // consumeCacheClearMarker applies a deferred cache clear during tunnel start

--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -6,9 +6,11 @@ import (
 	stdjson "encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"net"
 	"net/netip"
+	"os"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -45,8 +47,9 @@ const (
 	urlTestInterval    = 3 * time.Minute
 	urlTestIdleTimeout = 15 * time.Minute
 
-	cacheID       = "lantern"
-	cacheFileName = "lantern.cache"
+	cacheID              = "lantern"
+	cacheFileName        = "lantern.cache"
+	cacheClearMarkerName = "lantern.cache.clear"
 	// minAndroidSystemStackKernel is the minimum Linux kernel version (major.minor) required
 	// for the system TUN stack to work reliably on Android only. Devices running a
 	// kernel below this version fall back to gvisor. This constant has no effect on
@@ -368,6 +371,49 @@ func baseRoutingRules() []O.Rule {
 
 func cacheFilePath(basePath string) string {
 	return filepath.Join(basePath, cacheFileName)
+}
+
+func cacheClearMarkerPath(basePath string) string {
+	return filepath.Join(basePath, cacheClearMarkerName)
+}
+
+// removeCacheFile deletes the tunnel cache if it exists.
+func removeCacheFile(basePath string) error {
+	err := os.Remove(cacheFilePath(basePath))
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("removing cache file: %w", err)
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		slog.Info("removed cache file", "path", cacheFilePath(basePath))
+	}
+	return nil
+}
+
+// writeCacheClearMarker records that cache removal must be retried on the next
+// tunnel start.
+func writeCacheClearMarker(basePath string) error {
+	slog.Debug("writing cache clear marker", "path", cacheClearMarkerPath(basePath))
+	return atomicfile.WriteFile(cacheClearMarkerPath(basePath), nil, fileperm.File)
+}
+
+// consumeCacheClearMarker applies a deferred cache clear during tunnel start
+// and removes the marker after a successful cache deletion.
+func consumeCacheClearMarker(basePath string) error {
+	marker := cacheClearMarkerPath(basePath)
+	if _, err := os.Stat(marker); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+
+	if err := removeCacheFile(basePath); err != nil {
+		return err
+	}
+	if err := os.Remove(marker); err != nil {
+		return fmt.Errorf("removing cache clear marker: %w", err)
+	}
+	return nil
 }
 
 // rejectQUICRule rejects UDP/443 to force HTTP/2-over-TCP fallback. Standard

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -138,6 +138,11 @@ func (t *tunnel) init(ctx context.Context, options string, platformIfce libbox.P
 		return fmt.Errorf("setup libbox: %w", err)
 	}
 
+	// Must run before NewServiceWithContext, which acquires the cache flock.
+	if err := consumeCacheClearMarker(dataPath); err != nil {
+		slog.Warn("Failed to apply deferred tunnel cache clear", "path", dataPath, "error", err)
+	}
+
 	t.logFactory = lblog.NewFactory(slog.Default().Handler())
 	service.MustRegister[sblog.Factory](t.ctx, t.logFactory)
 

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
-	"os"
 	"runtime"
 	"strings"
 	"sync"
@@ -366,27 +365,26 @@ func (c *VPNClient) Connections() ([]Connection, error) {
 	return connections, nil
 }
 
-// ClearTunnelCache removes the tunnel cache file at dataPath. The tunnel must be closed before
-// the cache file can be deleted. Setting force to true will close the tunnel if it's open.
-// ClearTunnelCache will not reopen the tunnel if it closed it.
-func (c *VPNClient) ClearTunnelCache(dataPath string, force bool) error {
+// ClearTunnelCache removes the tunnel cache file at dataPath. If the tunnel is
+// active, or if another process owns the cache file, it records a marker so the
+// next tunnel start can retry the deletion. The returned flag reports whether
+// the caller should restart the tunnel now to apply a deferred clear.
+func (c *VPNClient) ClearTunnelCache(dataPath string) (shouldRestart bool, err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	var errs error
+
 	if c.tunnel != nil {
-		if !force {
-			return errors.New("cannot clear cache while tunnel is currently connected")
-		}
-		// Don't return early and don't swallow the close error: the cache must
-		// still be removed, but a failed disconnect must not be reported as success.
-		if err := c.close(); err != nil {
-			errs = errors.Join(errs, fmt.Errorf("closing tunnel while clearing cache: %w", err))
-		}
+		return true, writeCacheClearMarker(dataPath)
 	}
-	if err := os.Remove(cacheFilePath(dataPath)); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		errs = errors.Join(errs, fmt.Errorf("removing cache file: %w", err))
+
+	if err := removeCacheFile(dataPath); err != nil {
+		if errors.Is(err, fs.ErrPermission) {
+			return false, writeCacheClearMarker(dataPath)
+		}
+		return false, err
 	}
-	return errs
+
+	return false, nil
 }
 
 // Bytes returns the cumulative up/down byte counters for the active tunnel. ok is false if the

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -365,9 +365,8 @@ func (c *VPNClient) Connections() ([]Connection, error) {
 	return connections, nil
 }
 
-// ClearTunnelCache removes the tunnel cache file at dataPath. If the tunnel is
-// active, or if another process owns the cache file, it records a marker so the
-// next tunnel start can retry the deletion. The returned flag reports whether
+// ClearTunnelCache removes the tunnel cache file at dataPath. If the tunnel is active it records
+// a marker so the next tunnel start can retry the deletion. The returned flag reports whether
 // the caller should restart the tunnel now to apply a deferred clear.
 func (c *VPNClient) ClearTunnelCache(dataPath string) (shouldRestart bool, err error) {
 	c.mu.Lock()

--- a/vpn/vpn_test.go
+++ b/vpn/vpn_test.go
@@ -2,7 +2,6 @@ package vpn
 
 import (
 	"errors"
-	"io"
 	"log/slog"
 	"os"
 	"sync"
@@ -256,39 +255,46 @@ func TestClearTunnelCache(t *testing.T) {
 		return c, path
 	}
 
-	t.Run("disconnected", func(t *testing.T) {
+	t.Run("disconnected deletes in place", func(t *testing.T) {
 		dir := t.TempDir()
 		c, path := newClient(t, Disconnected, nil, dir)
 
-		assert.NoError(t, c.ClearTunnelCache(dir, false))
+		restart, err := c.ClearTunnelCache(dir)
+		assert.NoError(t, err)
+		assert.False(t, restart)
 		assert.NoFileExists(t, path)
+		assert.NoFileExists(t, cacheClearMarkerPath(dir))
 	})
 
-	t.Run("connected without force", func(t *testing.T) {
+	t.Run("connected defers via marker and requests restart", func(t *testing.T) {
 		dir := t.TempDir()
 		c, path := newClient(t, Connected, &tunnel{}, dir)
 
-		assert.Error(t, c.ClearTunnelCache(dir, false))
+		restart, err := c.ClearTunnelCache(dir)
+		assert.NoError(t, err)
+		assert.True(t, restart)
 		assert.FileExists(t, path)
+		assert.FileExists(t, cacheClearMarkerPath(dir))
 		assert.NotNil(t, c.tunnel)
 	})
+}
 
-	t.Run("connected with force", func(t *testing.T) {
+func TestConsumeCacheClearMarker(t *testing.T) {
+	t.Run("marker present deletes cache and marker", func(t *testing.T) {
 		dir := t.TempDir()
-		c, path := newClient(t, Connected, &tunnel{}, dir)
+		require.NoError(t, os.WriteFile(cacheFilePath(dir), []byte("cache"), 0o600))
+		require.NoError(t, writeCacheClearMarker(dir))
 
-		assert.NoError(t, c.ClearTunnelCache(dir, true))
-		assert.NoFileExists(t, path)
-		assert.Nil(t, c.tunnel)
-		assert.Equal(t, Disconnected, c.Status())
+		assert.NoError(t, consumeCacheClearMarker(dir))
+		assert.NoFileExists(t, cacheFilePath(dir))
+		assert.NoFileExists(t, cacheClearMarkerPath(dir))
 	})
 
-	t.Run("connected with force error", func(t *testing.T) {
+	t.Run("no marker leaves cache untouched", func(t *testing.T) {
 		dir := t.TempDir()
-		tun := &tunnel{closers: []io.Closer{closerFunc(func() error { return assert.AnError })}}
-		c, path := newClient(t, Connected, tun, dir)
+		require.NoError(t, os.WriteFile(cacheFilePath(dir), []byte("cache"), 0o600))
 
-		assert.Error(t, c.ClearTunnelCache(dir, true))
-		assert.NoFileExists(t, path)
+		assert.NoError(t, consumeCacheClearMarker(dir))
+		assert.FileExists(t, cacheFilePath(dir))
 	})
 }


### PR DESCRIPTION
## Summary

Clearing the tunnel cache while it is held by an active tunnel — or owned by another process for mobile — cannot delete the file in place. Previously `ClearTunnelCache` forced a disconnect to free the file and did not reopen the tunnel.

This change replaces that behavior with a deferred-clear marker:

- `ClearTunnelCache` now writes an on-disk marker (`lantern.cache.clear`) when the tunnel is active or the cache file is owned by another process, instead of forcing a disconnect.
- The next tunnel start consumes the marker and retries the deletion **before** the cache flock is acquired, then removes the marker on success.
- When the tunnel is active, `ClearTunnelCache` signals the caller to restart the tunnel so the deferred clear is applied immediately; `LocalBackend.ClearTunnelCache` performs that restart.
- A new `clear-cache` CLI subcommand exposes the operation over IPC.