### PR TITLE
feat(vpn): replace sing-box traffic manager with push-based tracker

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -522,7 +522,7 @@ func (r *LocalBackend) updateConnMetrics(status vpn.VPNStatus) {
 			return // already running
 		}
 		ctx, cancel := context.WithCancel(r.ctx)
-		observer, err := telemetry.StartConnectionMetrics(ctx)
+		observer, err := telemetry.StartConnectionMetrics(ctx, r.vpnClient.ActiveConnectionCount)
 		if err != nil {
 			cancel()
 			slog.Warn("Failed to start connection metrics collection", "error", err)

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -522,10 +522,17 @@ func (r *LocalBackend) updateConnMetrics(status vpn.VPNStatus) {
 			return // already running
 		}
 		ctx, cancel := context.WithCancel(r.ctx)
-		telemetry.StartConnectionMetrics(ctx, r.vpnClient, 1*time.Minute)
+		observer, err := telemetry.StartConnectionMetrics(ctx)
+		if err != nil {
+			cancel()
+			slog.Warn("Failed to start connection metrics collection", "error", err)
+			return
+		}
+		r.vpnClient.SetConnObserver(observer)
 		r.stopConnMetrics = cancel
 		slog.Debug("Started connection metrics collection")
 	} else if r.stopConnMetrics != nil {
+		r.vpnClient.SetConnObserver(nil)
 		r.stopConnMetrics()
 		r.stopConnMetrics = nil
 		slog.Debug("Stopped connection metrics collection")
@@ -833,29 +840,14 @@ func (r *LocalBackend) persistSelection(tag string) {
 	slog.Info("Selected server", "tag", tag, "type", server.Type)
 }
 
-// VPNConnections returns a list of all connections, both active and recently closed. If there are no
-// connections and the tunnel is open, an empty slice is returned without an error.
+// VPNConnections returns a list of the active connections. If there are no connections and the
+// tunnel is open, an empty slice is returned without an error.
 func (r *LocalBackend) VPNConnections() ([]vpn.Connection, error) {
 	return r.vpnClient.Connections()
 }
 
 func (r *LocalBackend) VPNThroughput() (vpn.ThroughputSnapshot, error) {
 	return r.vpnClient.Throughput()
-}
-
-// ActiveVPNConnections returns a list of currently active connections, ordered from newest to oldest.
-func (r *LocalBackend) ActiveVPNConnections() ([]vpn.Connection, error) {
-	connections, err := r.vpnClient.Connections()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get VPN connections: %w", err)
-	}
-	connections = slices.DeleteFunc(connections, func(conn vpn.Connection) bool {
-		return conn.ClosedAt != 0
-	})
-	slices.SortFunc(connections, func(a, b vpn.Connection) int {
-		return int(b.CreatedAt - a.CreatedAt)
-	})
-	return connections, nil
 }
 
 // SelectedServer returns the currently selected server and whether the server is still available.

--- a/ipc/client.go
+++ b/ipc/client.go
@@ -115,17 +115,10 @@ func (c *Client) RestartVPN(ctx context.Context) error {
 	return err
 }
 
-// VPNConnections returns all VPN connections (active and recently closed).
+// VPNConnections returns the active VPN connections.
 func (c *Client) VPNConnections(ctx context.Context) ([]vpn.Connection, error) {
 	var conns []vpn.Connection
 	err := c.doJSON(ctx, http.MethodGet, vpnConnectionsEndpoint, nil, &conns)
-	return conns, err
-}
-
-// ActiveVPNConnections returns currently active VPN connections.
-func (c *Client) ActiveVPNConnections(ctx context.Context) ([]vpn.Connection, error) {
-	var conns []vpn.Connection
-	err := c.doJSON(ctx, http.MethodGet, vpnConnectionsEndpoint+"?active=true", nil, &conns)
 	return conns, err
 }
 

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -366,17 +366,8 @@ func (s *localapi) vpnRestartHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// vpnConnectionsHandler handles GET /vpn/connections/ (all) and GET /vpn/connections/active.
 func (s *localapi) vpnConnectionsHandler(w http.ResponseWriter, r *http.Request) {
-	var (
-		conns []vpn.Connection
-		err   error
-	)
-	if r.URL.Query().Get("active") == "true" {
-		conns, err = s.backend(r.Context()).ActiveVPNConnections()
-	} else {
-		conns, err = s.backend(r.Context()).VPNConnections()
-	}
+	conns, err := s.backend(r.Context()).VPNConnections()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/telemetry/connections.go
+++ b/telemetry/connections.go
@@ -3,7 +3,6 @@ package telemetry
 import (
 	"context"
 	"log/slog"
-	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -12,98 +11,158 @@ import (
 	"github.com/getlantern/radiance/vpn"
 )
 
-// ConnectionSource provides access to the current VPN connections for metrics collection.
-type ConnectionSource interface {
-	Connections() ([]vpn.Connection, error)
+// connEventBuffer sizes the channel between the data-path push and the single recording goroutine.
+// Sends are non-blocking; on overflow the event is dropped and counted rather than stalling a
+// connection's open or close.
+const connEventBuffer = 4096
+
+type connEventKind uint8
+
+const (
+	connOpened connEventKind = iota
+	connClosed
+)
+
+type connEvent struct {
+	kind  connEventKind
+	attrs vpn.ConnAttrs
+	close vpn.ConnClose
 }
 
-// StartConnectionMetrics periodically polls the number of active connections and their total
-// upload and download bytes, setting the corresponding OpenTelemetry metrics. It runs until the
-// provided context is canceled.
-func StartConnectionMetrics(ctx context.Context, src ConnectionSource, pollInterval time.Duration) {
-	ticker := time.NewTicker(pollInterval)
+// connObserver records connection metrics from open/close pushes. OnOpen/OnClose run on the
+// connection's own goroutine and only enqueue; a single run goroutine does the OpenTelemetry work.
+type connObserver struct {
+	events chan connEvent
+
+	activeConnections  metric.Int64UpDownCounter
+	connectionDuration metric.Float64Histogram
+	downlinkBytes      metric.Int64Counter
+	uplinkBytes        metric.Int64Counter
+	droppedEvents      metric.Int64Counter
+}
+
+// StartConnectionMetrics builds the connection metric instruments and starts the goroutine that
+// records them, returning an observer to attach to the VPN client. Recording stops when ctx is
+// canceled.
+func StartConnectionMetrics(ctx context.Context) (vpn.ConnObserver, error) {
 	meter := otel.Meter("github.com/getlantern/radiance/metrics")
-	currentActiveConnections, err := meter.Int64Counter("current_active_connections", metric.WithDescription("Current number of active connections"))
+	active, err := meter.Int64UpDownCounter(
+		"current_active_connections",
+		metric.WithDescription("Current number of active connections"),
+	)
 	if err != nil {
-		slog.Warn("failed to create current_active_connections metric", slog.Any("error", err))
-		return
+		return nil, err
 	}
-	connectionDuration, err := meter.Float64Histogram("connection_duration_seconds", metric.WithDescription("Duration of connections in seconds"), metric.WithUnit("s"))
+	dur, err := meter.Float64Histogram(
+		"connection_duration_seconds",
+		metric.WithDescription("Duration of connections in seconds"),
+		metric.WithUnit("s"),
+	)
 	if err != nil {
-		slog.Warn("failed to create connection_duration_seconds metric", slog.Any("error", err))
-		return
+		return nil, err
 	}
-	downlinkBytes, err := meter.Int64Counter("downlink_bytes", metric.WithDescription("Total downlink bytes across all connections"), metric.WithUnit("By"))
+	down, err := meter.Int64Counter(
+		"downlink_bytes",
+		metric.WithDescription("Total downlink bytes across all connections"),
+		metric.WithUnit("By"),
+	)
 	if err != nil {
-		slog.Warn("failed to create downlink_bytes metric", slog.Any("error", err))
-		return
+		return nil, err
 	}
-	uplinkBytes, err := meter.Int64Counter("uplink_bytes", metric.WithDescription("Total uplink bytes across all connections"), metric.WithUnit("By"))
+	up, err := meter.Int64Counter(
+		"uplink_bytes",
+		metric.WithDescription("Total uplink bytes across all connections"),
+		metric.WithUnit("By"),
+	)
 	if err != nil {
-		slog.Warn("failed to create uplink_bytes metric", slog.Any("error", err))
-		return
+		return nil, err
 	}
-	go func() {
-		seenConnections := make(map[string]bool)
-		for {
-			select {
-			case <-ctx.Done():
-				ticker.Stop()
-				return
-			case <-ticker.C:
-				slog.Debug("polling connections for metrics", slog.Int("seen_connections", len(seenConnections)), slog.Duration("poll_interval", pollInterval))
-				conns, err := src.Connections()
-				if err != nil {
-					slog.Debug("failed to retrieve connections for metrics", slog.Any("error", err))
-					continue
-				}
+	dropped, err := meter.Int64Counter(
+		"connection_metric_events_dropped",
+		metric.WithDescription("Connection metric events dropped because the recording buffer was full"),
+	)
+	if err != nil {
+		return nil, err
+	}
+	observer := &connObserver{
+		events:             make(chan connEvent, connEventBuffer),
+		activeConnections:  active,
+		connectionDuration: dur,
+		downlinkBytes:      down,
+		uplinkBytes:        up,
+		droppedEvents:      dropped,
+	}
+	go observer.run(ctx)
+	return observer, nil
+}
 
-				// Track which connections are still reported so we can prune stale entries.
-				currentIDs := make(map[string]struct{}, len(conns))
-				for _, c := range conns {
-					currentIDs[c.ID] = struct{}{}
-					attributes := attribute.NewSet(
-						attribute.String("from_outbound", c.FromOutbound),
-						attribute.String("outbound_name", c.Outbound),
-						attribute.String("inbound", c.Inbound),
-						attribute.String("network", c.Network),
-						attribute.String("protocol", c.Protocol),
-						attribute.Int("ip_version", c.IPVersion),
-						attribute.String("rule", c.Rule),
-						attribute.StringSlice("chain_list", c.ChainList),
-					)
+func (o *connObserver) OnOpen(attrs vpn.ConnAttrs) {
+	o.enqueue(connEvent{kind: connOpened, attrs: attrs})
+}
 
-					active, seen := seenConnections[c.ID]
+func (o *connObserver) OnClose(closeEvent vpn.ConnClose) {
+	o.enqueue(connEvent{kind: connClosed, close: closeEvent})
+}
 
-					// not collecting duration of active connections
-					if c.ClosedAt == 0 && !seen {
-						seenConnections[c.ID] = true
-						currentActiveConnections.Add(ctx, 1, metric.WithAttributeSet(attributes))
-						continue
-					}
+func (o *connObserver) enqueue(event connEvent) {
+	select {
+	case o.events <- event:
+	default:
+		o.droppedEvents.Add(context.Background(), 1)
+	}
+}
 
-					// already registered this closed connection
-					if seen && !active {
-						continue
-					}
-
-					seenConnections[c.ID] = false
-					duration := float64(c.ClosedAt - c.CreatedAt)
-					if duration > 0 {
-						connectionDuration.Record(ctx, duration/1000, metric.WithAttributeSet(attributes))
-					}
-
-					downlinkBytes.Add(ctx, c.Downlink, metric.WithAttributeSet(attributes))
-					uplinkBytes.Add(ctx, c.Uplink, metric.WithAttributeSet(attributes))
-				}
-
-				// Remove entries for connections no longer reported by the source.
-				for id := range seenConnections {
-					if _, ok := currentIDs[id]; !ok {
-						delete(seenConnections, id)
-					}
-				}
-			}
+func (o *connObserver) run(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			o.drain(context.Background())
+			slog.Debug("Stopped connection metrics recording")
+			return
+		case event := <-o.events:
+			o.record(ctx, event)
 		}
-	}()
+	}
+}
+
+func (o *connObserver) drain(ctx context.Context) {
+	for {
+		select {
+		case event := <-o.events:
+			o.record(ctx, event)
+		default:
+			return
+		}
+	}
+}
+
+func (o *connObserver) record(ctx context.Context, event connEvent) {
+	switch event.kind {
+	case connOpened:
+		attrs := metric.WithAttributeSet(newConnAttributeSet(event.attrs))
+		o.activeConnections.Add(ctx, 1, attrs)
+
+	case connClosed:
+		attrs := metric.WithAttributeSet(newConnAttributeSet(event.close.ConnAttrs))
+		o.activeConnections.Add(ctx, -1, attrs)
+
+		if event.close.DurationSeconds > 0 {
+			o.connectionDuration.Record(ctx, event.close.DurationSeconds, attrs)
+		}
+		o.downlinkBytes.Add(ctx, event.close.Downlink, attrs)
+		o.uplinkBytes.Add(ctx, event.close.Uplink, attrs)
+	}
+}
+
+func newConnAttributeSet(attrs vpn.ConnAttrs) attribute.Set {
+	return attribute.NewSet(
+		attribute.String("from_outbound", attrs.FromOutbound),
+		attribute.String("outbound_name", attrs.Outbound),
+		attribute.String("inbound", attrs.Inbound),
+		attribute.String("network", attrs.Network),
+		attribute.String("protocol", attrs.Protocol),
+		attribute.Int("ip_version", attrs.IPVersion),
+		attribute.String("rule", attrs.Rule),
+		attribute.StringSlice("chain_list", attrs.ChainList),
+	)
 }

--- a/telemetry/connections.go
+++ b/telemetry/connections.go
@@ -11,42 +11,29 @@ import (
 	"github.com/getlantern/radiance/vpn"
 )
 
-// connEventBuffer sizes the channel between the data-path push and the single recording goroutine.
-// Sends are non-blocking; on overflow the event is dropped and counted rather than stalling a
-// connection's open or close.
+// connEventBuffer sizes the channel used for buffered ConnClose events.
+// Sends are non-blocking; on overflow the event is dropped and counted rather than stalling
+// a connection close.
 const connEventBuffer = 4096
 
-type connEventKind uint8
-
-const (
-	connOpened connEventKind = iota
-	connClosed
-)
-
-type connEvent struct {
-	kind  connEventKind
-	attrs vpn.ConnAttrs
-	close vpn.ConnClose
-}
-
-// connObserver records connection metrics from open/close pushes. OnOpen/OnClose run on the
-// connection's own goroutine and only enqueue; a single run goroutine does the OpenTelemetry work.
 type connObserver struct {
-	events chan connEvent
+	events chan vpn.ConnClose
 
-	activeConnections  metric.Int64UpDownCounter
 	connectionDuration metric.Float64Histogram
 	downlinkBytes      metric.Int64Counter
 	uplinkBytes        metric.Int64Counter
 	droppedEvents      metric.Int64Counter
+
+	activeConnectionsReg metric.Registration
 }
 
 // StartConnectionMetrics builds the connection metric instruments and starts the goroutine that
-// records them, returning an observer to attach to the VPN client. Recording stops when ctx is
-// canceled.
-func StartConnectionMetrics(ctx context.Context) (vpn.ConnObserver, error) {
+// records them, returning an observer to attach to the VPN client. Recording stops when ctx
+// is canceled.
+func StartConnectionMetrics(ctx context.Context, activeConnections func() int64) (vpn.ConnObserver, error) {
 	meter := otel.Meter("github.com/getlantern/radiance/metrics")
-	active, err := meter.Int64UpDownCounter(
+
+	active, err := meter.Int64ObservableGauge(
 		"current_active_connections",
 		metric.WithDescription("Current number of active connections"),
 	)
@@ -84,29 +71,30 @@ func StartConnectionMetrics(ctx context.Context) (vpn.ConnObserver, error) {
 	if err != nil {
 		return nil, err
 	}
+	activeReg, err := meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
+		o.ObserveInt64(active, activeConnections())
+		return nil
+	}, active)
+	if err != nil {
+		return nil, err
+	}
+
 	observer := &connObserver{
-		events:             make(chan connEvent, connEventBuffer),
-		activeConnections:  active,
-		connectionDuration: dur,
-		downlinkBytes:      down,
-		uplinkBytes:        up,
-		droppedEvents:      dropped,
+		events:               make(chan vpn.ConnClose, connEventBuffer),
+		connectionDuration:   dur,
+		downlinkBytes:        down,
+		uplinkBytes:          up,
+		droppedEvents:        dropped,
+		activeConnectionsReg: activeReg,
 	}
 	go observer.run(ctx)
+
 	return observer, nil
 }
 
-func (o *connObserver) OnOpen(attrs vpn.ConnAttrs) {
-	o.enqueue(connEvent{kind: connOpened, attrs: attrs})
-}
-
 func (o *connObserver) OnClose(closeEvent vpn.ConnClose) {
-	o.enqueue(connEvent{kind: connClosed, close: closeEvent})
-}
-
-func (o *connObserver) enqueue(event connEvent) {
 	select {
-	case o.events <- event:
+	case o.events <- closeEvent:
 	default:
 		o.droppedEvents.Add(context.Background(), 1)
 	}
@@ -116,11 +104,14 @@ func (o *connObserver) run(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			if err := o.activeConnectionsReg.Unregister(); err != nil {
+				slog.Debug("Failed to unregister active-connections gauge", "error", err)
+			}
 			o.drain(context.Background())
 			slog.Debug("Stopped connection metrics recording")
 			return
-		case event := <-o.events:
-			o.record(ctx, event)
+		case closeEvent := <-o.events:
+			o.record(ctx, closeEvent)
 		}
 	}
 }
@@ -136,22 +127,13 @@ func (o *connObserver) drain(ctx context.Context) {
 	}
 }
 
-func (o *connObserver) record(ctx context.Context, event connEvent) {
-	switch event.kind {
-	case connOpened:
-		attrs := metric.WithAttributeSet(newConnAttributeSet(event.attrs))
-		o.activeConnections.Add(ctx, 1, attrs)
-
-	case connClosed:
-		attrs := metric.WithAttributeSet(newConnAttributeSet(event.close.ConnAttrs))
-		o.activeConnections.Add(ctx, -1, attrs)
-
-		if event.close.DurationSeconds > 0 {
-			o.connectionDuration.Record(ctx, event.close.DurationSeconds, attrs)
-		}
-		o.downlinkBytes.Add(ctx, event.close.Downlink, attrs)
-		o.uplinkBytes.Add(ctx, event.close.Uplink, attrs)
+func (o *connObserver) record(ctx context.Context, closeEvent vpn.ConnClose) {
+	attrs := metric.WithAttributeSet(newConnAttributeSet(closeEvent.ConnAttrs))
+	if closeEvent.DurationSeconds > 0 {
+		o.connectionDuration.Record(ctx, closeEvent.DurationSeconds, attrs)
 	}
+	o.downlinkBytes.Add(ctx, closeEvent.Downlink, attrs)
+	o.uplinkBytes.Add(ctx, closeEvent.Uplink, attrs)
 }
 
 func newConnAttributeSet(attrs vpn.ConnAttrs) attribute.Set {

--- a/telemetry/connections.go
+++ b/telemetry/connections.go
@@ -3,6 +3,8 @@ package telemetry
 import (
 	"context"
 	"log/slog"
+	"sync/atomic"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -16,6 +18,10 @@ import (
 // a connection close.
 const connEventBuffer = 4096
 
+// droppedFlushInterval is how often run folds the dropped-event count into its metric. The overflow
+// path only touches an atomic, so the metric trails by at most one interval.
+const droppedFlushInterval = 10 * time.Second
+
 type connObserver struct {
 	events chan vpn.ConnClose
 
@@ -23,6 +29,10 @@ type connObserver struct {
 	downlinkBytes      metric.Int64Counter
 	uplinkBytes        metric.Int64Counter
 	droppedEvents      metric.Int64Counter
+
+	// dropped counts events shed on buffer overflow. OnClose runs on the connection close goroutine
+	// and must not touch the OTel SDK, so it bumps this atomic; run folds it into droppedEvents.
+	dropped atomic.Int64
 
 	activeConnectionsReg metric.Registration
 }
@@ -96,11 +106,13 @@ func (o *connObserver) OnClose(closeEvent vpn.ConnClose) {
 	select {
 	case o.events <- closeEvent:
 	default:
-		o.droppedEvents.Add(context.Background(), 1)
+		o.dropped.Add(1)
 	}
 }
 
 func (o *connObserver) run(ctx context.Context) {
+	ticker := time.NewTicker(droppedFlushInterval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
@@ -108,11 +120,20 @@ func (o *connObserver) run(ctx context.Context) {
 				slog.Debug("Failed to unregister active-connections gauge", "error", err)
 			}
 			o.drain(context.Background())
+			o.flushDropped(context.Background())
 			slog.Debug("Stopped connection metrics recording")
 			return
+		case <-ticker.C:
+			o.flushDropped(ctx)
 		case closeEvent := <-o.events:
 			o.record(ctx, closeEvent)
 		}
+	}
+}
+
+func (o *connObserver) flushDropped(ctx context.Context) {
+	if n := o.dropped.Swap(0); n > 0 {
+		o.droppedEvents.Add(ctx, n)
 	}
 }
 

--- a/vpn/clash.go
+++ b/vpn/clash.go
@@ -171,6 +171,9 @@ func (s *clashServer) resolveChain(matchOutbound adapter.Outbound) (outbound, ou
 	for next != "" {
 		detour, loaded := s.outbound.Outbound(next)
 		if !loaded {
+			if outbound == "" {
+				outbound = next
+			}
 			break
 		}
 

--- a/vpn/clash.go
+++ b/vpn/clash.go
@@ -9,14 +9,18 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/sagernet/sing/common"
+	"github.com/sagernet/sing/common/bufio"
 	N "github.com/sagernet/sing/common/network"
 	"github.com/sagernet/sing/service"
 
 	"github.com/sagernet/sing-box/adapter"
-	"github.com/sagernet/sing-box/experimental/clashapi/trafficontrol"
 	"github.com/sagernet/sing-box/log"
 	"github.com/sagernet/sing-box/option"
+
+	"github.com/gofrs/uuid/v5"
 )
 
 var _ adapter.ClashServer = (*clashServer)(nil)
@@ -34,7 +38,7 @@ type clashServer struct {
 	outbound  adapter.OutboundManager
 	endpoint  adapter.EndpointManager
 
-	trafficManager    *trafficontrol.Manager
+	connTracker       *connTracker
 	throughputTracker *throughputTracker
 	trackerDone       chan struct{}
 
@@ -57,15 +61,17 @@ func newClashServer(ctx context.Context, _ log.ObservableFactory, options option
 	}
 
 	runCtx, cancel := context.WithCancel(ctx)
-	trafficManager := trafficontrol.NewManager()
+	ct := newConnTracker()
+	tp := newThroughputTracker(ct, 0)
+	ct.tp = tp
 	return &clashServer{
 		ctx:               runCtx,
 		cancel:            cancel,
 		dnsRouter:         service.FromContext[adapter.DNSRouter](ctx),
 		outbound:          service.FromContext[adapter.OutboundManager](ctx),
 		endpoint:          service.FromContext[adapter.EndpointManager](ctx),
-		trafficManager:    trafficManager,
-		throughputTracker: newThroughputTracker(trafficManager, 0),
+		connTracker:       ct,
+		throughputTracker: tp,
 		modeList:          modeList,
 		mode:              initial,
 	}, nil
@@ -126,22 +132,111 @@ func (s *clashServer) HistoryStorage() adapter.URLTestHistoryStorage {
 	return nil
 }
 
-func (s *clashServer) TrafficManager() *trafficontrol.Manager {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.trafficManager
-}
-
 func (s *clashServer) ThroughputTracker() *throughputTracker {
 	return s.throughputTracker
 }
 
+// newRecord builds a lean record for a routed connection, copying the scalars radiance reads out of
+// metadata and resolving the outbound chain.
+func (s *clashServer) newRecord(metadata adapter.InboundContext, matchedRule adapter.Rule, matchOutbound adapter.Outbound) *record {
+	id, _ := uuid.NewV4()
+	outbound, outboundType, chain := s.resolveChain(matchOutbound)
+	return &record{
+		id:           id,
+		createdAt:    time.Now(),
+		outbound:     outbound,
+		outboundType: outboundType,
+		chain:        chain,
+		inboundType:  metadata.InboundType,
+		inboundName:  metadata.Inbound,
+		ipVersion:    metadata.IPVersion,
+		network:      metadata.Network,
+		source:       metadata.Source.String(),
+		destination:  metadata.Destination.String(),
+		domain:       metadata.Domain,
+		protocol:     metadata.Protocol,
+		fromOutbound: metadata.Outbound,
+		ruleStr:      formatRule(matchedRule),
+	}
+}
+
+func (s *clashServer) resolveChain(matchOutbound adapter.Outbound) (outbound, outboundType string, chain []string) {
+	var next string
+	if matchOutbound != nil {
+		next = matchOutbound.Tag()
+	} else {
+		next = s.outbound.Default().Tag()
+	}
+
+	for next != "" {
+		detour, loaded := s.outbound.Outbound(next)
+		if !loaded {
+			break
+		}
+
+		chain = append(chain, next)
+		outbound = detour.Tag()
+		outboundType = detour.Type()
+
+		group, isGroup := detour.(adapter.OutboundGroup)
+		if !isGroup {
+			break
+		}
+		next = group.Now()
+	}
+
+	return outbound, outboundType, common.Reverse(chain)
+}
+
+func formatRule(rule adapter.Rule) string {
+	if rule == nil {
+		return ""
+	}
+	return rule.String() + " => " + rule.Action().String()
+}
+
+func (s *clashServer) uploadCounter(r *record) N.CountFunc {
+	return func(n int64) {
+		r.upload.Add(n)
+		s.connTracker.pushUploaded(n)
+	}
+}
+
+func (s *clashServer) downloadCounter(r *record) N.CountFunc {
+	return func(n int64) {
+		r.download.Add(n)
+		s.connTracker.pushDownloaded(n)
+	}
+}
+
 func (s *clashServer) RoutedConnection(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, matchedRule adapter.Rule, matchOutbound adapter.Outbound) net.Conn {
-	return trafficontrol.NewTCPTracker(conn, s.trafficManager, metadata, s.outbound, matchedRule, matchOutbound)
+	r := s.newRecord(metadata, matchedRule, matchOutbound)
+	c := &tcpConn{
+		ExtendedConn: bufio.NewCounterConn(
+			conn,
+			[]N.CountFunc{s.uploadCounter(r)},
+			[]N.CountFunc{s.downloadCounter(r)},
+		),
+		rec: r,
+		ct:  s.connTracker,
+	}
+	s.connTracker.join(r)
+	return c
 }
 
 func (s *clashServer) RoutedPacketConnection(ctx context.Context, conn N.PacketConn, metadata adapter.InboundContext, matchedRule adapter.Rule, matchOutbound adapter.Outbound) N.PacketConn {
-	return trafficontrol.NewUDPTracker(conn, s.trafficManager, metadata, s.outbound, matchedRule, matchOutbound)
+	r := s.newRecord(metadata, matchedRule, matchOutbound)
+	c := &udpConn{
+		PacketConn: bufio.NewCounterPacketConn(
+			conn,
+			[]N.CountFunc{s.uploadCounter(r)},
+			[]N.CountFunc{s.downloadCounter(r)},
+		),
+		rec: r,
+		ct:  s.connTracker,
+	}
+	s.connTracker.join(r)
+	return c
 }
 
 func (s *clashServer) Name() string {

--- a/vpn/conntrack.go
+++ b/vpn/conntrack.go
@@ -1,0 +1,236 @@
+package vpn
+
+import (
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/sagernet/sing-box/experimental/clashapi/trafficontrol"
+	N "github.com/sagernet/sing/common/network"
+
+	lsync "github.com/getlantern/common/sync"
+)
+
+// record holds the lean per-connection state radiance actually reads. It is built once when a
+// connection is routed and never retains the full adapter.InboundContext; the scalars below are
+// copied out at creation. upload/download are mutated on the data path via atomics; every other
+// field is immutable after creation.
+type record struct {
+	id        uuid.UUID
+	createdAt time.Time
+	upload    atomic.Int64
+	download  atomic.Int64
+
+	outbound     string // raw leaf outbound tag: per-outbound bucket key and group-manager shim
+	outboundType string
+	chain        []string
+
+	inboundType  string
+	inboundName  string
+	ipVersion    uint8
+	network      string
+	source       string
+	destination  string
+	domain       string
+	protocol     string
+	fromOutbound string
+	ruleStr      string
+}
+
+// attrs returns the telemetry attribute set for the connection.
+func (r *record) attrs() ConnAttrs {
+	return ConnAttrs{
+		ID:           r.id.String(),
+		FromOutbound: r.fromOutbound,
+		Outbound:     r.outboundType + "/" + r.outbound,
+		Inbound:      r.inboundType + "/" + r.inboundName,
+		Network:      r.network,
+		Protocol:     r.protocol,
+		IPVersion:    int(r.ipVersion),
+		Rule:         r.ruleStr,
+		ChainList:    r.chain,
+	}
+}
+
+// trackerMetadata synthesizes the upstream metadata view required by the lantern-box group manager
+// (groups.ConnectionManager). That consumer reads only Outbound and ClosedAt.IsZero(); ClosedAt is
+// left zero because only active records are ever exposed. Upload/Download point at the live atomics
+// so any future consumer that converts or marshals the value does not dereference nil.
+func (r *record) trackerMetadata() trafficontrol.TrackerMetadata {
+	return trafficontrol.TrackerMetadata{
+		ID:           r.id,
+		CreatedAt:    r.createdAt,
+		Upload:       &r.upload,
+		Download:     &r.download,
+		Chain:        r.chain,
+		Outbound:     r.outbound,
+		OutboundType: r.outboundType,
+	}
+}
+
+// ConnAttrs is the attribute set describing a connection, pushed to a ConnObserver at open and close.
+type ConnAttrs struct {
+	ID           string
+	FromOutbound string
+	Outbound     string
+	Inbound      string
+	Network      string
+	Protocol     string
+	IPVersion    int
+	Rule         string
+	ChainList    []string
+}
+
+// ConnClose is pushed when a connection closes, carrying its final accounting.
+type ConnClose struct {
+	ConnAttrs
+	DurationSeconds float64
+	Uplink          int64
+	Downlink        int64
+}
+
+// ConnObserver receives push notifications as connections open and close. Implementations must not
+// block: OnClose runs on the connection's close goroutine.
+type ConnObserver interface {
+	OnOpen(ConnAttrs)
+	OnClose(ConnClose)
+}
+
+// connTracker is radiance's connection tracker. It holds only the active set and global byte totals;
+// closed connections are pushed to the throughput sampler and the telemetry observer at close rather
+// than retained.
+type connTracker struct {
+	upTotal   atomic.Int64
+	downTotal atomic.Int64
+
+	conns lsync.TypedMap[uuid.UUID, *record]
+
+	tp *throughputTracker // wired after construction
+
+	obsMu    sync.RWMutex
+	observer ConnObserver
+}
+
+func newConnTracker() *connTracker { return &connTracker{} }
+
+func (m *connTracker) pushUploaded(n int64)   { m.upTotal.Add(n) }
+func (m *connTracker) pushDownloaded(n int64) { m.downTotal.Add(n) }
+
+// Total returns the cumulative up/down byte counters across all connections, including those already
+// closed (counting happens on the data path, independent of the active set).
+func (m *connTracker) Total() (up, down int64) {
+	return m.upTotal.Load(), m.downTotal.Load()
+}
+
+// SetObserver sets the telemetry observer, or nil to detach. It is re-set on each tunnel connect
+// because the tracker is recreated per tunnel while the observer outlives it.
+func (m *connTracker) SetObserver(o ConnObserver) {
+	m.obsMu.Lock()
+	m.observer = o
+	m.obsMu.Unlock()
+}
+
+func (m *connTracker) currentObserver() ConnObserver {
+	m.obsMu.RLock()
+	defer m.obsMu.RUnlock()
+	return m.observer
+}
+
+func (m *connTracker) join(r *record) {
+	m.conns.Store(r.id, r)
+	if o := m.currentObserver(); o != nil {
+		o.OnOpen(r.attrs())
+	}
+}
+
+// leave folds the connection's final accounting exactly once. Close may fire more than once (half
+// close, error/abort, ctx cancel then explicit close); LoadAndDelete gates everything after it so a
+// repeat close is a no-op.
+func (m *connTracker) leave(r *record) {
+	if _, loaded := m.conns.LoadAndDelete(r.id); !loaded {
+		return
+	}
+	closedMs := time.Now().UnixMilli()
+	up, down := r.upload.Load(), r.download.Load()
+	if m.tp != nil {
+		m.tp.recordClosed(r.id, r.outbound, up, down)
+	}
+	if o := m.currentObserver(); o != nil {
+		o.OnClose(ConnClose{
+			ConnAttrs:       r.attrs(),
+			DurationSeconds: float64(closedMs-r.createdAt.UnixMilli()) / 1000,
+			Uplink:          up,
+			Downlink:        down,
+		})
+	}
+}
+
+// Connections satisfies groups.ConnectionManager (github.com/getlantern/lantern-box/adapter/groups),
+// returning the active connections as synthesized trafficontrol.TrackerMetadata.
+func (m *connTracker) Connections() []trafficontrol.TrackerMetadata {
+	var out []trafficontrol.TrackerMetadata
+	for _, r := range m.conns.Iter() {
+		out = append(out, r.trackerMetadata())
+	}
+	return out
+}
+
+// activeConnections returns the current active connections as IPC Connection values.
+func (m *connTracker) activeConnections() []Connection {
+	var out []Connection
+	for _, r := range m.conns.Iter() {
+		out = append(out, newConnection(r))
+	}
+	return out
+}
+
+// activeStats returns the active connection count and the per-(raw)-outbound-tag active counts.
+func (m *connTracker) activeStats() (count int, perOutbound map[string]int) {
+	perOutbound = make(map[string]int)
+	for _, r := range m.conns.Iter() {
+		count++
+		perOutbound[r.outbound]++
+	}
+	return count, perOutbound
+}
+
+// tcpConn and udpConn wrap a counted connection. Upstream/ReaderReplaceable/WriterReplaceable let
+// bufio unwrap to the underlying conn for its vectorised and read-waiter fast paths, and Close folds
+// the connection out of the tracker before closing the wrapped conn.
+type tcpConn struct {
+	N.ExtendedConn
+	rec *record
+	ct  *connTracker
+}
+
+func (c *tcpConn) Close() error {
+	c.ct.leave(c.rec)
+	return c.ExtendedConn.Close()
+}
+
+func (c *tcpConn) Upstream() any           { return c.ExtendedConn }
+func (c *tcpConn) ReaderReplaceable() bool { return true }
+func (c *tcpConn) WriterReplaceable() bool { return true }
+
+type udpConn struct {
+	N.PacketConn
+	rec *record
+	ct  *connTracker
+}
+
+func (c *udpConn) Close() error {
+	c.ct.leave(c.rec)
+	return c.PacketConn.Close()
+}
+
+func (c *udpConn) Upstream() any           { return c.PacketConn }
+func (c *udpConn) ReaderReplaceable() bool { return true }
+func (c *udpConn) WriterReplaceable() bool { return true }
+
+// Compile-time guard that the wrappers implement the interfaces sing-box's router expects.
+var (
+	_ net.Conn     = (*tcpConn)(nil)
+	_ N.PacketConn = (*udpConn)(nil)
+)

--- a/vpn/conntrack.go
+++ b/vpn/conntrack.go
@@ -23,6 +23,10 @@ type record struct {
 	upload    atomic.Int64
 	download  atomic.Int64
 
+	// closed is the exactly-once gate for leave: Close may fire more than once (half-close,
+	// error/abort, ctx-cancel then explicit close), but the accounting must fold only once.
+	closed atomic.Bool
+
 	outbound     string // raw leaf outbound tag: per-outbound bucket key and group-manager shim
 	outboundType string
 	chain        []string
@@ -143,19 +147,23 @@ func (m *connTracker) join(r *record) {
 	m.activeCount.Add(1)
 }
 
-// leave folds the connection's final accounting exactly once. Close may fire more than once (half
-// close, error/abort, ctx cancel then explicit close); LoadAndDelete gates everything after it so a
-// repeat close is a no-op.
+// leave folds the connection's final accounting exactly once, gated by record.closed.
 func (m *connTracker) leave(r *record) {
-	if _, loaded := m.conns.LoadAndDelete(r.id); !loaded {
+	if !r.closed.CompareAndSwap(false, true) {
 		return
 	}
-	m.activeCount.Add(-1)
 
 	up, down := r.upload.Load(), r.download.Load()
+	// Hand the close to the sampler before removing the connection from the active set: a sample
+	// tick that misses the connection in its active walk must then find it in the pending drain,
+	// never in neither. Were it absent from both, the tick would evict the connection's byte
+	// baseline and the next tick would recount its lifetime bytes against a zero baseline.
 	if m.tp != nil {
 		m.tp.recordClosed(r.id, r.outbound, up, down)
 	}
+	m.conns.Delete(r.id)
+	m.activeCount.Add(-1)
+
 	if o := m.currentObserver(); o != nil {
 		o.OnClose(ConnClose{
 			ConnAttrs:       r.attrs(),
@@ -176,9 +184,10 @@ func (m *connTracker) Connections() []trafficontrol.TrackerMetadata {
 	return out
 }
 
-// activeConnections returns the current active connections as IPC Connection values.
+// activeConnections returns the current active connections as IPC Connection values. An empty
+// slice is returned if there are no active connections.
 func (m *connTracker) activeConnections() []Connection {
-	var out []Connection
+	out := make([]Connection, 0)
 	for _, r := range m.conns.Iter() {
 		out = append(out, newConnection(r))
 	}
@@ -200,8 +209,9 @@ func (m *connTracker) activeConnectionCount() int64 {
 }
 
 // tcpConn and udpConn wrap a counted connection. Upstream/ReaderReplaceable/WriterReplaceable let
-// bufio unwrap to the underlying conn for its vectorised and read-waiter fast paths, and Close folds
-// the connection out of the tracker before closing the wrapped conn.
+// bufio unwrap to the underlying conn for its vectorised and read-waiter fast paths. Close first
+// closes the wrapped conn, then folds the connection out of the tracker so the final accounting
+// snapshot includes any bytes counted by in-flight I/O that completes as close races it.
 type tcpConn struct {
 	N.ExtendedConn
 	rec *record
@@ -209,8 +219,9 @@ type tcpConn struct {
 }
 
 func (c *tcpConn) Close() error {
+	err := c.ExtendedConn.Close()
 	c.ct.leave(c.rec)
-	return c.ExtendedConn.Close()
+	return err
 }
 
 func (c *tcpConn) Upstream() any           { return c.ExtendedConn }
@@ -224,8 +235,9 @@ type udpConn struct {
 }
 
 func (c *udpConn) Close() error {
+	err := c.PacketConn.Close()
 	c.ct.leave(c.rec)
-	return c.PacketConn.Close()
+	return err
 }
 
 func (c *udpConn) Upstream() any           { return c.PacketConn }

--- a/vpn/conntrack.go
+++ b/vpn/conntrack.go
@@ -70,7 +70,7 @@ func (r *record) trackerMetadata() trafficontrol.TrackerMetadata {
 	}
 }
 
-// ConnAttrs is the attribute set describing a connection, pushed to a ConnObserver at open and close.
+// ConnAttrs is the attribute set describing a connection, carried on each ConnClose push.
 type ConnAttrs struct {
 	ID           string
 	FromOutbound string
@@ -91,10 +91,9 @@ type ConnClose struct {
 	Downlink        int64
 }
 
-// ConnObserver receives push notifications as connections open and close. Implementations must not
+// ConnObserver receives a push notification when a connection closes. Implementations must not
 // block: OnClose runs on the connection's close goroutine.
 type ConnObserver interface {
-	OnOpen(ConnAttrs)
 	OnClose(ConnClose)
 }
 
@@ -105,7 +104,8 @@ type connTracker struct {
 	upTotal   atomic.Int64
 	downTotal atomic.Int64
 
-	conns lsync.TypedMap[uuid.UUID, *record]
+	conns       lsync.TypedMap[uuid.UUID, *record]
+	activeCount atomic.Int64
 
 	tp *throughputTracker // wired after construction
 
@@ -114,15 +114,6 @@ type connTracker struct {
 }
 
 func newConnTracker() *connTracker { return &connTracker{} }
-
-func (m *connTracker) pushUploaded(n int64)   { m.upTotal.Add(n) }
-func (m *connTracker) pushDownloaded(n int64) { m.downTotal.Add(n) }
-
-// Total returns the cumulative up/down byte counters across all connections, including those already
-// closed (counting happens on the data path, independent of the active set).
-func (m *connTracker) Total() (up, down int64) {
-	return m.upTotal.Load(), m.downTotal.Load()
-}
 
 // SetObserver sets the telemetry observer, or nil to detach. It is re-set on each tunnel connect
 // because the tracker is recreated per tunnel while the observer outlives it.
@@ -138,11 +129,18 @@ func (m *connTracker) currentObserver() ConnObserver {
 	return m.observer
 }
 
+func (m *connTracker) pushUploaded(n int64)   { m.upTotal.Add(n) }
+func (m *connTracker) pushDownloaded(n int64) { m.downTotal.Add(n) }
+
+// Total returns the cumulative up/down byte counters across all connections, including those already
+// closed (counting happens on the data path, independent of the active set).
+func (m *connTracker) Total() (up, down int64) {
+	return m.upTotal.Load(), m.downTotal.Load()
+}
+
 func (m *connTracker) join(r *record) {
 	m.conns.Store(r.id, r)
-	if o := m.currentObserver(); o != nil {
-		o.OnOpen(r.attrs())
-	}
+	m.activeCount.Add(1)
 }
 
 // leave folds the connection's final accounting exactly once. Close may fire more than once (half
@@ -152,7 +150,8 @@ func (m *connTracker) leave(r *record) {
 	if _, loaded := m.conns.LoadAndDelete(r.id); !loaded {
 		return
 	}
-	closedMs := time.Now().UnixMilli()
+	m.activeCount.Add(-1)
+
 	up, down := r.upload.Load(), r.download.Load()
 	if m.tp != nil {
 		m.tp.recordClosed(r.id, r.outbound, up, down)
@@ -160,7 +159,7 @@ func (m *connTracker) leave(r *record) {
 	if o := m.currentObserver(); o != nil {
 		o.OnClose(ConnClose{
 			ConnAttrs:       r.attrs(),
-			DurationSeconds: float64(closedMs-r.createdAt.UnixMilli()) / 1000,
+			DurationSeconds: time.Since(r.createdAt).Seconds(),
 			Uplink:          up,
 			Downlink:        down,
 		})
@@ -194,6 +193,10 @@ func (m *connTracker) activeStats() (count int, perOutbound map[string]int) {
 		perOutbound[r.outbound]++
 	}
 	return count, perOutbound
+}
+
+func (m *connTracker) activeConnectionCount() int64 {
+	return m.activeCount.Load()
 }
 
 // tcpConn and udpConn wrap a counted connection. Upstream/ReaderReplaceable/WriterReplaceable let

--- a/vpn/conntrack_test.go
+++ b/vpn/conntrack_test.go
@@ -1,0 +1,192 @@
+package vpn
+
+import (
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sagernet/sing/common/bufio"
+	N "github.com/sagernet/sing/common/network"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingObserver struct {
+	mu     sync.Mutex
+	opens  []ConnAttrs
+	closes []ConnClose
+}
+
+func (o *recordingObserver) OnOpen(a ConnAttrs) {
+	o.mu.Lock()
+	o.opens = append(o.opens, a)
+	o.mu.Unlock()
+}
+
+func (o *recordingObserver) OnClose(c ConnClose) {
+	o.mu.Lock()
+	o.closes = append(o.closes, c)
+	o.mu.Unlock()
+}
+
+// wrapTCP mirrors clashServer.RoutedConnection's counter wiring so byte counting can be exercised
+// without a full tunnel.
+func wrapTCP(ct *connTracker, r *record, conn net.Conn) *tcpConn {
+	c := &tcpConn{
+		ExtendedConn: bufio.NewCounterConn(conn, []N.CountFunc{func(n int64) {
+			r.upload.Add(n)
+			ct.pushUploaded(n)
+		}}, []N.CountFunc{func(n int64) {
+			r.download.Add(n)
+			ct.pushDownloaded(n)
+		}}),
+		rec: r,
+		ct:  ct,
+	}
+	ct.join(r)
+	return c
+}
+
+func TestConnTracker_LeaveFoldsOnce(t *testing.T) {
+	ct := newConnTracker()
+	tr := newThroughputTracker(ct, time.Second)
+	ct.tp = tr
+
+	r := newRec("out")
+	ct.join(r)
+	addBytes(ct, r, 100, 50)
+
+	ct.leave(r)
+	ct.leave(r) // repeat close must be a no-op
+
+	_, ok := ct.conns.Load(r.id)
+	assert.False(t, ok, "record should be removed from the active set")
+	require.Len(t, tr.pending, 1, "final bytes folded exactly once")
+	assert.Equal(t, closedDelta{id: r.id, outbound: "out", up: 100, down: 50}, tr.pending[0])
+}
+
+func TestConnTracker_ObserverOpenClose(t *testing.T) {
+	ct := newConnTracker()
+	obs := &recordingObserver{}
+	ct.SetObserver(obs)
+
+	r := newRec("vpn-a")
+	r.createdAt = time.Now().Add(-2 * time.Second)
+	r.outboundType = "vmess"
+	r.inboundType, r.inboundName = "tun", "tun-in"
+
+	ct.join(r)
+	addBytes(ct, r, 300, 120)
+	ct.leave(r)
+
+	require.Len(t, obs.opens, 1)
+	require.Len(t, obs.closes, 1)
+	assert.Equal(t, "vmess/vpn-a", obs.opens[0].Outbound)
+	assert.Equal(t, "tun/tun-in", obs.opens[0].Inbound)
+	c := obs.closes[0]
+	assert.Equal(t, int64(300), c.Uplink)
+	assert.Equal(t, int64(120), c.Downlink)
+	assert.InDelta(t, 2.0, c.DurationSeconds, 0.5)
+}
+
+func TestConnTracker_TotalAndShim(t *testing.T) {
+	ct := newConnTracker()
+	a, b := newRec("vpn-a"), newRec("vpn-b")
+	a.outboundType = "vmess"
+	ct.join(a)
+	ct.join(b)
+	addBytes(ct, a, 10, 20)
+	addBytes(ct, b, 5, 7)
+
+	up, down := ct.Total()
+	assert.Equal(t, int64(15), up)
+	assert.Equal(t, int64(27), down)
+
+	conns := ct.Connections()
+	require.Len(t, conns, 2)
+	for _, m := range conns {
+		assert.True(t, m.ClosedAt.IsZero(), "active records report a zero ClosedAt")
+		assert.NotNil(t, m.Upload)
+		assert.NotNil(t, m.Download)
+		assert.Contains(t, []string{"vpn-a", "vpn-b"}, m.Outbound)
+	}
+
+	count, perOut := ct.activeStats()
+	assert.Equal(t, 2, count)
+	assert.Equal(t, map[string]int{"vpn-a": 1, "vpn-b": 1}, perOut)
+
+	active := ct.activeConnections()
+	require.Len(t, active, 2)
+}
+
+func TestConnTracker_CountsBytesAndFoldsOnClose(t *testing.T) {
+	ct := newConnTracker()
+	tr := newThroughputTracker(ct, time.Second)
+	ct.tp = tr
+
+	srv, cli := net.Pipe()
+	defer srv.Close()
+	r := newRec("out")
+	tc := wrapTCP(ct, r, cli)
+
+	msg := []byte("hello, world!")
+	done := make(chan struct{})
+	go func() {
+		buf := make([]byte, len(msg))
+		io.ReadFull(srv, buf)
+		close(done)
+	}()
+	n, err := tc.Write(msg)
+	require.NoError(t, err)
+	require.Equal(t, len(msg), n)
+	<-done
+
+	_, down := ct.Total()
+	assert.Equal(t, int64(len(msg)), down)
+	assert.Equal(t, int64(len(msg)), r.download.Load())
+
+	require.NoError(t, tc.Close())
+	_ = tc.Close() // second close: leave is a no-op, inner close may error
+
+	_, ok := ct.conns.Load(r.id)
+	assert.False(t, ok)
+	require.Len(t, tr.pending, 1)
+	assert.Equal(t, int64(len(msg)), tr.pending[0].down)
+}
+
+func TestConnTracker_ConcurrentJoinLeave(t *testing.T) {
+	ct := newConnTracker()
+	tr := newThroughputTracker(ct, time.Second)
+	ct.tp = tr
+
+	const n = 200
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r := newRec("out")
+			ct.join(r)
+			addBytes(ct, r, 1, 1)
+			ct.leave(r)
+		}()
+	}
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = ct.Connections()
+			_, _ = ct.activeStats()
+			ct.Total()
+		}()
+	}
+	wg.Wait()
+
+	count, _ := ct.activeStats()
+	assert.Equal(t, 0, count, "all connections left")
+	up, down := ct.Total()
+	assert.Equal(t, int64(n), up)
+	assert.Equal(t, int64(n), down)
+}

--- a/vpn/conntrack_test.go
+++ b/vpn/conntrack_test.go
@@ -15,14 +15,7 @@ import (
 
 type recordingObserver struct {
 	mu     sync.Mutex
-	opens  []ConnAttrs
 	closes []ConnClose
-}
-
-func (o *recordingObserver) OnOpen(a ConnAttrs) {
-	o.mu.Lock()
-	o.opens = append(o.opens, a)
-	o.mu.Unlock()
 }
 
 func (o *recordingObserver) OnClose(c ConnClose) {
@@ -67,7 +60,7 @@ func TestConnTracker_LeaveFoldsOnce(t *testing.T) {
 	assert.Equal(t, closedDelta{id: r.id, outbound: "out", up: 100, down: 50}, tr.pending[0])
 }
 
-func TestConnTracker_ObserverOpenClose(t *testing.T) {
+func TestConnTracker_ObserverOnClose(t *testing.T) {
 	ct := newConnTracker()
 	obs := &recordingObserver{}
 	ct.SetObserver(obs)
@@ -81,11 +74,10 @@ func TestConnTracker_ObserverOpenClose(t *testing.T) {
 	addBytes(ct, r, 300, 120)
 	ct.leave(r)
 
-	require.Len(t, obs.opens, 1)
 	require.Len(t, obs.closes, 1)
-	assert.Equal(t, "vmess/vpn-a", obs.opens[0].Outbound)
-	assert.Equal(t, "tun/tun-in", obs.opens[0].Inbound)
 	c := obs.closes[0]
+	assert.Equal(t, "vmess/vpn-a", c.Outbound)
+	assert.Equal(t, "tun/tun-in", c.Inbound)
 	assert.Equal(t, int64(300), c.Uplink)
 	assert.Equal(t, int64(120), c.Downlink)
 	assert.InDelta(t, 2.0, c.DurationSeconds, 0.5)

--- a/vpn/conntrack_test.go
+++ b/vpn/conntrack_test.go
@@ -24,6 +24,50 @@ func (o *recordingObserver) OnClose(c ConnClose) {
 	o.mu.Unlock()
 }
 
+// closeWaitsForWriteConn forces tcpConn.Close's fold to observe an in-flight Write's byte count:
+// Close blocks on writeAccounted, which the test signals only after tcpConn.Write returns (after
+// CounterConn counts). Without that gate the close-before-fold contract could only be checked on a
+// timing race.
+type closeWaitsForWriteConn struct {
+	writeStarted   chan struct{}
+	releaseWrite   chan struct{}
+	writeAccounted chan struct{}
+	closeOnce      sync.Once
+}
+
+func newCloseWaitsForWriteConn() *closeWaitsForWriteConn {
+	return &closeWaitsForWriteConn{
+		writeStarted:   make(chan struct{}),
+		releaseWrite:   make(chan struct{}),
+		writeAccounted: make(chan struct{}),
+	}
+}
+
+func (c *closeWaitsForWriteConn) Read(_ []byte) (int, error) { return 0, io.EOF }
+
+func (c *closeWaitsForWriteConn) Write(p []byte) (int, error) {
+	close(c.writeStarted)
+	<-c.releaseWrite
+	return len(p), nil
+}
+
+func (c *closeWaitsForWriteConn) Close() error {
+	c.closeOnce.Do(func() { close(c.releaseWrite) })
+	<-c.writeAccounted
+	return nil
+}
+
+func (c *closeWaitsForWriteConn) LocalAddr() net.Addr                { return dummyAddr("local") }
+func (c *closeWaitsForWriteConn) RemoteAddr() net.Addr               { return dummyAddr("remote") }
+func (c *closeWaitsForWriteConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *closeWaitsForWriteConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *closeWaitsForWriteConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+type dummyAddr string
+
+func (a dummyAddr) Network() string { return string(a) }
+func (a dummyAddr) String() string  { return string(a) }
+
 // wrapTCP mirrors clashServer.RoutedConnection's counter wiring so byte counting can be exercised
 // without a full tunnel.
 func wrapTCP(ct *connTracker, r *record, conn net.Conn) *tcpConn {
@@ -181,4 +225,35 @@ func TestConnTracker_ConcurrentJoinLeave(t *testing.T) {
 	up, down := ct.Total()
 	assert.Equal(t, int64(n), up)
 	assert.Equal(t, int64(n), down)
+}
+
+func TestConnTracker_CloseWaitsForInFlightWriteAccounting(t *testing.T) {
+	ct := newConnTracker()
+	tr := newThroughputTracker(ct, time.Second)
+	ct.tp = tr
+	obs := &recordingObserver{}
+	ct.SetObserver(obs)
+
+	r := newRec("out")
+	inner := newCloseWaitsForWriteConn()
+	tc := wrapTCP(ct, r, inner)
+	msg := []byte("late bytes")
+
+	writeErr := make(chan error, 1)
+	go func() {
+		_, err := tc.Write(msg)
+		close(inner.writeAccounted) // unblocks inner.Close only after CounterConn has counted msg
+		writeErr <- err
+	}()
+	<-inner.writeStarted
+
+	require.NoError(t, tc.Close())
+	require.NoError(t, <-writeErr)
+
+	_, ok := ct.conns.Load(r.id)
+	assert.False(t, ok)
+	require.Len(t, tr.pending, 1)
+	assert.Equal(t, int64(len(msg)), tr.pending[0].down)
+	require.Len(t, obs.closes, 1)
+	assert.Equal(t, int64(len(msg)), obs.closes[0].Downlink)
 }

--- a/vpn/throughput_tracker.go
+++ b/vpn/throughput_tracker.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid/v5"
-	"github.com/sagernet/sing-box/experimental/clashapi/trafficontrol"
 
 	"github.com/getlantern/radiance/common"
 )
@@ -17,9 +16,8 @@ type Throughput struct {
 	Down int64 `json:"down"`
 }
 
-// defaultThroughputSampleInterval is longer on mobile because each tick allocates
-// a snapshot slice of every live and recently-closed connection via the upstream
-// trafficontrol API; at 1s on a phone this dominates GC churn under heavy traffic.
+// defaultThroughputSampleInterval is longer on mobile because each tick iterates every active
+// connection to compute its byte delta; at 1s on a phone this adds up under heavy traffic.
 var defaultThroughputSampleInterval = func() time.Duration {
 	if common.IsMobile() {
 		return 3 * time.Second
@@ -32,11 +30,20 @@ type byteTotals struct {
 	down int64
 }
 
+// closedDelta carries the final byte counts of a connection that closed since the last sample, so
+// its bytes still count toward its outbound's rate for the window in which it closed.
+type closedDelta struct {
+	id       uuid.UUID
+	outbound string
+	up       int64
+	down     int64
+}
+
 // throughputTracker reports network throughput, globally and per outbound tag.
 // Throughput is sampled at a fixed interval; readers see the most recent
 // completed sample.
 type throughputTracker struct {
-	manager  *trafficontrol.Manager
+	manager  *connTracker
 	interval time.Duration
 
 	mu               sync.RWMutex
@@ -47,6 +54,11 @@ type throughputTracker struct {
 	lastGlobal byteTotals
 	lastTickAt time.Time
 
+	// pending holds the final byte counts of connections closed since the last sample. The
+	// connTracker pushes here on close; sample drains it.
+	pendingMu sync.Mutex
+	pending   []closedDelta
+
 	// Scratch maps reused across ticks to avoid excessive allocations
 	nextSeen        map[uuid.UUID]byteTotals
 	nextPerOutbound map[string]Throughput
@@ -55,7 +67,7 @@ type throughputTracker struct {
 
 // newThroughputTracker returns a tracker sampling at interval; a non-positive
 // interval selects defaultThroughputSampleInterval.
-func newThroughputTracker(manager *trafficontrol.Manager, interval time.Duration) *throughputTracker {
+func newThroughputTracker(manager *connTracker, interval time.Duration) *throughputTracker {
 	if interval <= 0 {
 		interval = defaultThroughputSampleInterval
 	}
@@ -112,32 +124,54 @@ func (s *throughputTracker) PerOutbound() map[string]Throughput {
 	return out
 }
 
+// recordClosed is called by the connTracker when a connection closes, handing off its final byte
+// counts so the next sample can attribute them to the connection's outbound.
+func (s *throughputTracker) recordClosed(id uuid.UUID, outbound string, up, down int64) {
+	s.pendingMu.Lock()
+	s.pending = append(s.pending, closedDelta{id: id, outbound: outbound, up: up, down: down})
+	s.pendingMu.Unlock()
+}
+
+func (s *throughputTracker) applyDelta(id uuid.UUID, outbound string, up, down int64) {
+	previous := s.seen[id]
+
+	delta := s.deltas[outbound]
+	delta.up += up - previous.up
+	delta.down += down - previous.down
+	s.deltas[outbound] = delta
+}
+
 func (s *throughputTracker) sample(now time.Time) {
 	elapsed := now.Sub(s.lastTickAt).Seconds()
 	// Skip on clock jumps or coalesced ticks: leaving lastTickAt and the byte baselines
-	// untouched means the next sample's elapsed and deltas span the same window.
+	// untouched means the next sample's elapsed and deltas span the same window. Pending
+	// closed records are left for the next real tick to drain.
 	if elapsed <= 0 {
 		return
 	}
 	s.lastTickAt = now
 
+	s.pendingMu.Lock()
+	pending := s.pending
+	s.pending = s.pending[:0]
+	s.pendingMu.Unlock()
+
 	clear(s.deltas)
 	clear(s.nextSeen)
-	visit := func(m trafficontrol.TrackerMetadata) {
-		up := m.Upload.Load()
-		down := m.Download.Load()
-		prev := s.seen[m.ID]
-		d := s.deltas[m.Outbound]
-		d.up += up - prev.up
-		d.down += down - prev.down
-		s.deltas[m.Outbound] = d
-		s.nextSeen[m.ID] = byteTotals{up: up, down: down}
+	for id, rec := range s.manager.conns.Iter() {
+		up := rec.upload.Load()
+		down := rec.download.Load()
+
+		s.applyDelta(id, rec.outbound, up, down)
+		s.nextSeen[id] = byteTotals{up: up, down: down}
 	}
-	for _, m := range s.manager.Connections() {
-		visit(m)
-	}
-	for _, m := range s.manager.ClosedConnections() {
-		visit(m)
+	for _, closed := range pending {
+		// A connection still present in the active set this tick was already counted above; skip
+		// it so a close racing with the active walk cannot double-count.
+		if _, counted := s.nextSeen[closed.id]; counted {
+			continue
+		}
+		s.applyDelta(closed.id, closed.outbound, closed.up, closed.down)
 	}
 	s.seen, s.nextSeen = s.nextSeen, s.seen
 

--- a/vpn/throughput_tracker.go
+++ b/vpn/throughput_tracker.go
@@ -54,10 +54,13 @@ type throughputTracker struct {
 	lastGlobal byteTotals
 	lastTickAt time.Time
 
-	// pending holds the final byte counts of connections closed since the last sample. The
-	// connTracker pushes here on close; sample drains it.
+	// pending holds the final byte counts of connections closed since the last sample; connTracker
+	// appends here on close. pending and draining are swapped under pendingMu so producers only ever
+	// touch pending: a post-swap append lands in the fresh buffer and never races sample's unlocked
+	// read of draining. Both are reused across ticks, growing to the high-water mark.
 	pendingMu sync.Mutex
 	pending   []closedDelta
+	draining  []closedDelta
 
 	// Scratch maps reused across ticks to avoid excessive allocations
 	nextSeen        map[uuid.UUID]byteTotals
@@ -132,13 +135,26 @@ func (s *throughputTracker) recordClosed(id uuid.UUID, outbound string, up, down
 	s.pendingMu.Unlock()
 }
 
+func (s *throughputTracker) addDelta(outbound string, up, down int64) {
+	delta := s.deltas[outbound]
+	delta.up += up
+	delta.down += down
+	s.deltas[outbound] = delta
+}
+
 func (s *throughputTracker) applyDelta(id uuid.UUID, outbound string, up, down int64) {
 	previous := s.seen[id]
+	s.addDelta(outbound, up-previous.up, down-previous.down)
+}
 
-	delta := s.deltas[outbound]
-	delta.up += up - previous.up
-	delta.down += down - previous.down
-	s.deltas[outbound] = delta
+func (s *throughputTracker) applyClosedDelta(closed closedDelta) {
+	if sampled, counted := s.nextSeen[closed.id]; counted {
+		s.addDelta(closed.outbound, max(0, closed.up-sampled.up), max(0, closed.down-sampled.down))
+		delete(s.nextSeen, closed.id)
+		return
+	}
+
+	s.applyDelta(closed.id, closed.outbound, closed.up, closed.down)
 }
 
 func (s *throughputTracker) sample(now time.Time) {
@@ -161,19 +177,14 @@ func (s *throughputTracker) sample(now time.Time) {
 		s.nextSeen[id] = byteTotals{up: up, down: down}
 	}
 
-	// Drain pending after the active walk: a connection that closes during the walk is either still
-	// seen as active above or captured here, never dropped to the next window.
+	// Drain pending after the active walk. A connection that closes during the walk may already
+	// have contributed bytes via its active snapshot above; if so, attribute only the bytes accrued
+	// after that snapshot and remove its baseline so it does not survive into the next tick.
 	s.pendingMu.Lock()
-	pending := s.pending
-	s.pending = s.pending[:0]
+	s.pending, s.draining = s.draining[:0], s.pending
 	s.pendingMu.Unlock()
-	for _, closed := range pending {
-		// A connection still present in the active set this tick was already counted above; skip
-		// it so a close racing with the active walk cannot double-count.
-		if _, counted := s.nextSeen[closed.id]; counted {
-			continue
-		}
-		s.applyDelta(closed.id, closed.outbound, closed.up, closed.down)
+	for _, closed := range s.draining {
+		s.applyClosedDelta(closed)
 	}
 	s.seen, s.nextSeen = s.nextSeen, s.seen
 

--- a/vpn/throughput_tracker.go
+++ b/vpn/throughput_tracker.go
@@ -151,11 +151,6 @@ func (s *throughputTracker) sample(now time.Time) {
 	}
 	s.lastTickAt = now
 
-	s.pendingMu.Lock()
-	pending := s.pending
-	s.pending = s.pending[:0]
-	s.pendingMu.Unlock()
-
 	clear(s.deltas)
 	clear(s.nextSeen)
 	for id, rec := range s.manager.conns.Iter() {
@@ -165,6 +160,13 @@ func (s *throughputTracker) sample(now time.Time) {
 		s.applyDelta(id, rec.outbound, up, down)
 		s.nextSeen[id] = byteTotals{up: up, down: down}
 	}
+
+	// Drain pending after the active walk: a connection that closes during the walk is either still
+	// seen as active above or captured here, never dropped to the next window.
+	s.pendingMu.Lock()
+	pending := s.pending
+	s.pending = s.pending[:0]
+	s.pendingMu.Unlock()
 	for _, closed := range pending {
 		// A connection still present in the active set this tick was already counted above; skip
 		// it so a close racing with the active walk cannot double-count.

--- a/vpn/throughput_tracker_test.go
+++ b/vpn/throughput_tracker_test.go
@@ -1,6 +1,7 @@
 package vpn
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -126,6 +127,103 @@ func TestThroughputTracker_OutboundUnknownTag(t *testing.T) {
 	tr := newThroughputTracker(newConnTracker(), time.Second)
 	assert.Equal(t, Throughput{}, tr.Outbound("missing"))
 }
+
+func TestThroughputTracker_ClosedAfterActiveSnapshotAddsOnlyPostSnapshotBytes(t *testing.T) {
+	ct := newConnTracker()
+	tr := newThroughputTracker(ct, time.Second)
+	ct.tp = tr
+
+	r := newRec("vpn-a")
+	ct.join(r)
+	addBytes(ct, r, 50, 25)
+
+	t0 := time.Unix(5000, 0)
+	tr.lastTickAt = t0
+	tr.sample(t0.Add(time.Second))
+	require.Equal(t, Throughput{Up: 50 * 8, Down: 25 * 8}, tr.Outbound("vpn-a"))
+
+	clear(tr.deltas)
+	clear(tr.nextSeen)
+	for id, rec := range tr.manager.conns.Iter() {
+		up := rec.upload.Load()
+		down := rec.download.Load()
+
+		tr.applyDelta(id, rec.outbound, up, down)
+		tr.nextSeen[id] = byteTotals{up: up, down: down}
+	}
+
+	addBytes(ct, r, 20, 10)
+	ct.leave(r)
+
+	tr.pendingMu.Lock()
+	pending := append([]closedDelta(nil), tr.pending...)
+	tr.pending = tr.pending[:0]
+	tr.pendingMu.Unlock()
+	for _, closed := range pending {
+		tr.applyClosedDelta(closed)
+	}
+
+	require.Equal(t, byteTotals{up: 20, down: 10}, tr.deltas["vpn-a"])
+	_, stillTracked := tr.nextSeen[r.id]
+	assert.False(t, stillTracked, "closed connection baseline should not survive into the next tick")
+}
+
+// Run with -race: regression guard for the buffer-aliasing bug where sample's drained slice aliased
+// recordClosed's live append target.
+func TestThroughputTracker_ConcurrentSampleAndClose(t *testing.T) {
+	ct := newConnTracker()
+	tr := newThroughputTracker(ct, time.Second)
+	ct.tp = tr
+
+	t0 := time.Unix(6000, 0)
+	tr.lastTickAt = t0
+
+	const (
+		producers   = 8
+		perProducer = 500
+	)
+
+	var prod sync.WaitGroup
+	prod.Add(producers)
+	for p := 0; p < producers; p++ {
+		go func() {
+			defer prod.Done()
+			for i := 0; i < perProducer; i++ {
+				r := newRec("vpn-a")
+				ct.join(r)
+				addBytes(ct, r, 10, 5)
+				ct.leave(r)
+			}
+		}()
+	}
+
+	stop := make(chan struct{})
+	var sampler sync.WaitGroup
+	sampler.Add(1)
+	go func() {
+		defer sampler.Done()
+		tick := t0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			tick = tick.Add(time.Millisecond)
+			tr.sample(tick)
+		}
+	}()
+
+	prod.Wait()
+	close(stop)
+	sampler.Wait()
+
+	up, down := ct.Total()
+	assert.Equal(t, int64(producers*perProducer*10), up)
+	assert.Equal(t, int64(producers*perProducer*5), down)
+}
+
+
 
 func TestThroughputTracker_NonPositiveIntervalUsesDefault(t *testing.T) {
 	ct := newConnTracker()

--- a/vpn/throughput_tracker_test.go
+++ b/vpn/throughput_tracker_test.go
@@ -1,63 +1,46 @@
 package vpn
 
 import (
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/gofrs/uuid/v5"
-	"github.com/sagernet/sing-box/experimental/clashapi/trafficontrol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-type fakeTracker struct {
-	md trafficontrol.TrackerMetadata
-}
-
-func (f *fakeTracker) Metadata() trafficontrol.TrackerMetadata { return f.md }
-func (f *fakeTracker) Close() error                            { return nil }
-
-func newFakeTracker(outbound string) *fakeTracker {
+func newRec(outbound string) *record {
 	id, err := uuid.NewV4()
 	if err != nil {
 		panic(err)
 	}
-	return &fakeTracker{
-		md: trafficontrol.TrackerMetadata{
-			ID:        id,
-			CreatedAt: time.Now(),
-			Upload:    new(atomic.Int64),
-			Download:  new(atomic.Int64),
-			Outbound:  outbound,
-		},
-	}
+	return &record{id: id, createdAt: time.Now(), outbound: outbound}
 }
 
-// addBytes keeps the fake tracker and manager totals in sync; updating only one side
-// produces phantom throughput in the next sample.
-func addBytes(mgr *trafficontrol.Manager, t *fakeTracker, up, down int64) {
-	t.md.Upload.Add(up)
-	t.md.Download.Add(down)
-	mgr.PushUploaded(up)
-	mgr.PushDownloaded(down)
+// addBytes keeps the record's per-conn counters and the tracker's global totals in sync; updating
+// only one side produces phantom throughput in the next sample.
+func addBytes(ct *connTracker, r *record, up, down int64) {
+	r.upload.Add(up)
+	r.download.Add(down)
+	ct.pushUploaded(up)
+	ct.pushDownloaded(down)
 }
 
 func TestThroughputTracker_Sample(t *testing.T) {
 	tests := []struct {
 		name       string
-		run        func(mgr *trafficontrol.Manager, tr *throughputTracker, t0 time.Time)
+		run        func(ct *connTracker, tr *throughputTracker, t0 time.Time)
 		wantPer    map[string]Throughput
 		wantGlobal Throughput
 	}{
 		{
 			name: "computes per-outbound and global bps from byte deltas",
-			run: func(mgr *trafficontrol.Manager, tr *throughputTracker, t0 time.Time) {
-				a, b := newFakeTracker("vpn-a"), newFakeTracker("vpn-b")
-				mgr.Join(a)
-				mgr.Join(b)
-				addBytes(mgr, a, 125, 250)
-				addBytes(mgr, b, 500, 1000)
+			run: func(ct *connTracker, tr *throughputTracker, t0 time.Time) {
+				a, b := newRec("vpn-a"), newRec("vpn-b")
+				ct.join(a)
+				ct.join(b)
+				addBytes(ct, a, 125, 250)
+				addBytes(ct, b, 500, 1000)
 				tr.sample(t0.Add(time.Second))
 			},
 			wantPer: map[string]Throughput{
@@ -68,27 +51,39 @@ func TestThroughputTracker_Sample(t *testing.T) {
 		},
 		{
 			name: "includes bytes from connections closed during the window",
-			run: func(mgr *trafficontrol.Manager, tr *throughputTracker, t0 time.Time) {
-				live, closing := newFakeTracker("vpn-a"), newFakeTracker("vpn-a")
-				mgr.Join(live)
-				mgr.Join(closing)
-				addBytes(mgr, live, 100, 0)
-				addBytes(mgr, closing, 400, 0)
-				mgr.Leave(closing)
+			run: func(ct *connTracker, tr *throughputTracker, t0 time.Time) {
+				live, closing := newRec("vpn-a"), newRec("vpn-a")
+				ct.join(live)
+				ct.join(closing)
+				addBytes(ct, live, 100, 0)
+				addBytes(ct, closing, 400, 0)
+				ct.leave(closing)
 				tr.sample(t0.Add(time.Second))
 			},
 			wantPer:    map[string]Throughput{"vpn-a": {Up: 500 * 8}},
 			wantGlobal: Throughput{Up: 500 * 8},
 		},
 		{
+			name: "counts a connection that opens and closes within one window",
+			run: func(ct *connTracker, tr *throughputTracker, t0 time.Time) {
+				c := newRec("vpn-a")
+				ct.join(c)
+				addBytes(ct, c, 300, 100)
+				ct.leave(c)
+				tr.sample(t0.Add(time.Second))
+			},
+			wantPer:    map[string]Throughput{"vpn-a": {Up: 300 * 8, Down: 100 * 8}},
+			wantGlobal: Throughput{Up: 300 * 8, Down: 100 * 8},
+		},
+		{
 			name: "non-positive elapsed leaves baselines untouched for the next tick",
-			run: func(mgr *trafficontrol.Manager, tr *throughputTracker, t0 time.Time) {
-				a := newFakeTracker("vpn-a")
-				mgr.Join(a)
-				addBytes(mgr, a, 100, 200)
+			run: func(ct *connTracker, tr *throughputTracker, t0 time.Time) {
+				a := newRec("vpn-a")
+				ct.join(a)
+				addBytes(ct, a, 100, 200)
 				tr.sample(t0)
 
-				addBytes(mgr, a, 50, 50)
+				addBytes(ct, a, 50, 50)
 				tr.sample(t0.Add(time.Second))
 			},
 			wantPer:    map[string]Throughput{"vpn-a": {Up: 150 * 8, Down: 250 * 8}},
@@ -97,11 +92,12 @@ func TestThroughputTracker_Sample(t *testing.T) {
 	}
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mgr := trafficontrol.NewManager()
-			tr := newThroughputTracker(mgr, time.Second)
+			ct := newConnTracker()
+			tr := newThroughputTracker(ct, time.Second)
+			ct.tp = tr
 			t0 := time.Unix(int64(1000+i), 0)
 			tr.lastTickAt = t0
-			tt.run(mgr, tr, t0)
+			tt.run(ct, tr, t0)
 			assert.Equal(t, tt.wantPer, tr.PerOutbound())
 			assert.Equal(t, tt.wantGlobal, tr.Global())
 		})
@@ -109,11 +105,12 @@ func TestThroughputTracker_Sample(t *testing.T) {
 }
 
 func TestThroughputTracker_PerOutboundIsIsolatedCopy(t *testing.T) {
-	mgr := trafficontrol.NewManager()
-	tr := newThroughputTracker(mgr, time.Second)
-	a := newFakeTracker("vpn-a")
-	mgr.Join(a)
-	addBytes(mgr, a, 10, 10)
+	ct := newConnTracker()
+	tr := newThroughputTracker(ct, time.Second)
+	ct.tp = tr
+	a := newRec("vpn-a")
+	ct.join(a)
+	addBytes(ct, a, 10, 10)
 
 	t0 := time.Unix(4000, 0)
 	tr.lastTickAt = t0
@@ -126,14 +123,14 @@ func TestThroughputTracker_PerOutboundIsIsolatedCopy(t *testing.T) {
 }
 
 func TestThroughputTracker_OutboundUnknownTag(t *testing.T) {
-	tr := newThroughputTracker(trafficontrol.NewManager(), time.Second)
+	tr := newThroughputTracker(newConnTracker(), time.Second)
 	assert.Equal(t, Throughput{}, tr.Outbound("missing"))
 }
 
 func TestThroughputTracker_NonPositiveIntervalUsesDefault(t *testing.T) {
-	mgr := trafficontrol.NewManager()
+	ct := newConnTracker()
 	for _, interval := range []time.Duration{0, -time.Second} {
-		tr := newThroughputTracker(mgr, interval)
+		tr := newThroughputTracker(ct, interval)
 		assert.Equal(t, defaultThroughputSampleInterval, tr.interval)
 	}
 }

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -59,6 +59,10 @@ type tunnel struct {
 
 	clientContextTracker *clientcontext.ClientContextInjector
 
+	// connObserver, if non-nil, is attached to clashServer's tracker at connect to receive
+	// connection open/close pushes for telemetry.
+	connObserver ConnObserver
+
 	cancel  context.CancelFunc
 	closers []io.Closer
 }
@@ -275,12 +279,13 @@ func (t *tunnel) connect(ctx context.Context) (err error) {
 
 	t.clashServer = service.FromContext[adapter.ClashServer](t.ctx).(*clashServer)
 	t.outboundMgr = service.FromContext[adapter.OutboundManager](t.ctx)
+	t.clashServer.connTracker.SetObserver(t.connObserver)
 
 	var mutGrpMgr *groups.MutableGroupManager
 	if err := traceSpan(ctx, "newMutableGroupManager", func() error {
 		var err error
 		mutGrpMgr, err = newMutableGroupManager(
-			t.ctx, t.logFactory.NewLogger("groupsManager"), t.clashServer.TrafficManager(),
+			t.ctx, t.logFactory.NewLogger("groupsManager"), t.clashServer.connTracker,
 		)
 		return err
 	}); err != nil {

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -60,7 +60,7 @@ type tunnel struct {
 	clientContextTracker *clientcontext.ClientContextInjector
 
 	// connObserver, if non-nil, is attached to clashServer's tracker at connect to receive
-	// connection open/close pushes for telemetry.
+	// connection-close pushes for telemetry.
 	connObserver ConnObserver
 
 	cancel  context.CancelFunc

--- a/vpn/types.go
+++ b/vpn/types.go
@@ -2,7 +2,6 @@ package vpn
 
 import (
 	"github.com/sagernet/sing-box/adapter"
-	"github.com/sagernet/sing-box/experimental/clashapi/trafficontrol"
 
 	lbA "github.com/getlantern/lantern-box/adapter"
 
@@ -71,33 +70,24 @@ type Connection struct {
 	ChainList    []string `json:"chain,omitempty"`
 }
 
-// NewConnection creates a Connection from tracker metadata.
-func newConnection(metadata trafficontrol.TrackerMetadata) Connection {
-	var rule string
-	if metadata.Rule != nil {
-		rule = metadata.Rule.String() + " => " + metadata.Rule.Action().String()
-	}
-	var closedAt int64
-	if !metadata.ClosedAt.IsZero() {
-		closedAt = metadata.ClosedAt.UnixMilli()
-	}
-	md := metadata.Metadata
+// newConnection creates a Connection from a tracker record. Only active records are exposed, so
+// ClosedAt is always zero.
+func newConnection(r *record) Connection {
 	return Connection{
-		ID:           metadata.ID.String(),
-		Inbound:      md.InboundType + "/" + md.Inbound,
-		IPVersion:    int(md.IPVersion),
-		Network:      md.Network,
-		Source:       md.Source.String(),
-		Destination:  md.Destination.String(),
-		Domain:       md.Domain,
-		Protocol:     md.Protocol,
-		FromOutbound: md.Outbound,
-		CreatedAt:    metadata.CreatedAt.UnixMilli(),
-		ClosedAt:     closedAt,
-		Uplink:       metadata.Upload.Load(),
-		Downlink:     metadata.Download.Load(),
-		Rule:         rule,
-		Outbound:     metadata.OutboundType + "/" + metadata.Outbound,
-		ChainList:    metadata.Chain,
+		ID:           r.id.String(),
+		Inbound:      r.inboundType + "/" + r.inboundName,
+		IPVersion:    int(r.ipVersion),
+		Network:      r.network,
+		Source:       r.source,
+		Destination:  r.destination,
+		Domain:       r.domain,
+		Protocol:     r.protocol,
+		FromOutbound: r.fromOutbound,
+		CreatedAt:    r.createdAt.UnixMilli(),
+		Uplink:       r.upload.Load(),
+		Downlink:     r.download.Load(),
+		Rule:         r.ruleStr,
+		Outbound:     r.outboundType + "/" + r.outbound,
+		ChainList:    r.chain,
 	}
 }

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -75,7 +75,7 @@ type VPNClient struct {
 
 	status atomic.Value // VPNStatus
 
-	// connObserver, if set, receives connection open/close pushes. It outlives individual tunnels
+	// connObserver, if set, receives connection-close pushes. It outlives individual tunnels
 	// and is re-attached to each tunnel's tracker at connect.
 	connObserver ConnObserver
 

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -361,6 +361,17 @@ func (c *VPNClient) Connections() ([]Connection, error) {
 	return c.tunnel.clashServer.connTracker.activeConnections(), nil
 }
 
+// ActiveConnectionCount returns the number of active connections, or 0 if the tunnel is not
+// connected. It is cheap enough to back an observable metric gauge.
+func (c *VPNClient) ActiveConnectionCount() int64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.tunnel == nil {
+		return 0
+	}
+	return c.tunnel.clashServer.connTracker.activeConnectionCount()
+}
+
 // ClearTunnelCache removes the tunnel cache file at dataPath. The tunnel must be closed before
 // the cache file can be deleted. Setting force to true will close the tunnel if it's open.
 // ClearTunnelCache will not reopen the tunnel if it closed it.
@@ -414,7 +425,7 @@ func (c *VPNClient) Throughput() (ThroughputSnapshot, error) {
 	}, nil
 }
 
-// SetConnObserver sets the observer notified as connections open and close, or nil to detach. It is
+// SetConnObserver sets the observer notified when connections close, or nil to detach. It is
 // retained across tunnels and attached to the live tunnel's tracker if one is connected.
 func (c *VPNClient) SetConnObserver(observer ConnObserver) {
 	c.mu.Lock()

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -75,6 +75,10 @@ type VPNClient struct {
 
 	status atomic.Value // VPNStatus
 
+	// connObserver, if set, receives connection open/close pushes. It outlives individual tunnels
+	// and is re-attached to each tunnel's tracker at connect.
+	connObserver ConnObserver
+
 	mu sync.RWMutex
 }
 
@@ -170,6 +174,7 @@ func (c *VPNClient) start(ctx context.Context, boxOptions BoxOptions, options st
 	t := tunnel{
 		dataPath:             boxOptions.BasePath,
 		selectionHistorySeed: boxOptions.SelectionHistorySeed,
+		connObserver:         c.connObserver,
 	}
 	if err := t.start(ctx, options, c.platformIfce, isRestart); err != nil {
 		c.setStatus(ErrorStatus, err)
@@ -342,7 +347,7 @@ func (c *VPNClient) RemoveOutbounds(tags []string) error {
 	return c.tunnel.removeOutbounds(tags)
 }
 
-// Connections returns a list of all connections, both active and recently closed. A non-nil error
+// Connections returns a list of the active connections. A non-nil error
 // is only returned if there was an error retrieving the connections, or if the tunnel is closed.
 // If there are no connections and the tunnel is open, an empty slice is returned without an error.
 func (c *VPNClient) Connections() ([]Connection, error) {
@@ -353,17 +358,7 @@ func (c *VPNClient) Connections() ([]Connection, error) {
 	if c.tunnel == nil {
 		return nil, fmt.Errorf("failed to get connections: %w", ErrTunnelNotConnected)
 	}
-	tm := c.tunnel.clashServer.TrafficManager()
-	activeConns := tm.Connections()
-	closedConns := tm.ClosedConnections()
-	connections := make([]Connection, 0, len(activeConns)+len(closedConns))
-	for _, conn := range activeConns {
-		connections = append(connections, newConnection(conn))
-	}
-	for _, conn := range closedConns {
-		connections = append(connections, newConnection(conn))
-	}
-	return connections, nil
+	return c.tunnel.clashServer.connTracker.activeConnections(), nil
 }
 
 // ClearTunnelCache removes the tunnel cache file at dataPath. The tunnel must be closed before
@@ -397,7 +392,7 @@ func (c *VPNClient) Bytes() (up, down int64, ok bool) {
 	if c.tunnel == nil {
 		return 0, 0, false
 	}
-	up, down = c.tunnel.clashServer.TrafficManager().Total()
+	up, down = c.tunnel.clashServer.connTracker.Total()
 	return up, down, true
 }
 
@@ -410,18 +405,31 @@ func (c *VPNClient) Throughput() (ThroughputSnapshot, error) {
 		return ThroughputSnapshot{}, ErrTunnelNotConnected
 	}
 	tt := c.tunnel.clashServer.ThroughputTracker()
-	tm := c.tunnel.clashServer.TrafficManager()
-	active := tm.Connections()
-	perOut := make(map[string]int, len(active))
-	for _, m := range active {
-		perOut[m.Outbound]++
-	}
+	active, perOut := c.tunnel.clashServer.connTracker.activeStats()
 	return ThroughputSnapshot{
 		Global:            tt.Global(),
 		PerOutbound:       tt.PerOutbound(),
-		ActiveConnections: len(active),
+		ActiveConnections: active,
 		ActivePerOutbound: perOut,
 	}, nil
+}
+
+// SetConnObserver sets the observer notified as connections open and close, or nil to detach. It is
+// retained across tunnels and attached to the live tunnel's tracker if one is connected.
+func (c *VPNClient) SetConnObserver(observer ConnObserver) {
+	c.mu.Lock()
+	c.connObserver = observer
+
+	var tracker *connTracker
+	if c.tunnel != nil && c.tunnel.clashServer != nil {
+		tracker = c.tunnel.clashServer.connTracker
+	}
+
+	c.mu.Unlock()
+
+	if tracker != nil {
+		tracker.SetObserver(observer)
+	}
 }
 
 // AutoSelectedEvent is emitted when the auto-selected server changes.


### PR DESCRIPTION
## Why

radiance wrapped every proxied connection in sing-box's `trafficontrol.Manager`, which retained up to **1000 closed connections** — each holding a full `adapter.InboundContext` (~34 fields) when radiance reads only ~14 scalars. Both the throughput sampler (1–3s) and telemetry (60s) **polled the active + closed lists every tick**, copying them in full. That recurring transient allocation was the dominant source of GC churn under the constrained mobile memory budget.

## What changed

- **New `vpn/conntrack.go` — a radiance-native `connTracker`.** Holds only the active set (`sync.Map`) plus global atomic byte totals. Byte counting uses sing's `bufio.NewCounterConn`/`NewCounterPacketConn` (same wiring as upstream) into per-connection atomics and the global totals. `leave()` folds each connection exactly once on close (idempotent under repeated `Close`). **No retained closed-connection list.**

- **Telemetry and per-outbound throughput inverted from poll to push.** On close, the tracker hands the connection's final bytes to the throughput sampler (`recordClosed`) and to a `ConnObserver`. Telemetry implements the observer with a buffered channel drained by a **single goroutine**, so OpenTelemetry recording happens off the data path with no goroutine-per-event. The interval sampler still computes live rate over the active set; it no longer walks a closed list.

- **Metric semantics.** `current_active_connections` is an `Int64ObservableGauge` sampled from the live active-connection count at collection time (so there is no per-connection open event, and the value can't drift if events are dropped). `connection_duration_seconds`, `uplink_bytes`, `downlink_bytes` are recorded once at close as before; attribute names are unchanged. Added `connection_metric_events_dropped` to surface buffer overflow.

- **Active-only connection view.** `VPNClient.Connections()` and the `/vpn/connections` IPC endpoint now return **active connections only**. `ActiveVPNConnections` and the `?active=true` branch are removed (they became redundant once the closed tail was dropped).

## Behavior change to note

The `/vpn/connections` endpoint no longer returns recently-closed connections — only active ones. This is intentional; the recently-closed tail (and its 1000-entry retention) is gone.

Related to https://github.com/getlantern/engineering/issues/3542