### PR TITLE
perf(log): memoize source formatting and reuse ring buffers

### DIFF
--- a/cmd/lanternd/lanternd.go
+++ b/cmd/lanternd/lanternd.go
@@ -199,7 +199,7 @@ func spawnChild(args []string, dataPath, logPath, logLevel string) (*childProces
 	go func() {
 		defer stdoutPipe.Close()
 		var w io.Writer = os.Stdout
-		if h, ok := logger.Handler().(rlog.Handler); ok {
+		if h, ok := logger.Handler().(*rlog.Handler); ok {
 			w = h.Writer()
 		}
 		scanner := bufio.NewScanner(stdoutPipe)

--- a/log/log.go
+++ b/log/log.go
@@ -216,9 +216,14 @@ func formatSource(function, file string, line int) slog.Attr {
 	)
 }
 
-// parseSourceFunction handles symbols like:
-//   - github.com/org/repo/pkg.Func
-//   - github.com/org/repo/pkg.(*Type).Method
+// parseSourceFunction splits a runtime function symbol into a package label and
+// a function name. The label is the symbol's third slash-separated segment, so
+// for a github.com/org/repo/leaf path it is the repo name, not the leaf package:
+//
+//   - "github.com/org/repo/leaf.Func"           → "repo", "Func"
+//   - "github.com/org/repo/leaf.(*Type).Method" → "repo", "(*Type).Method"
+//
+// ok is false when the symbol has fewer than three segments.
 func parseSourceFunction(symbol string) (pkg string, fn string, ok bool) {
 	pathParts := strings.SplitN(symbol, "/", 4)
 

--- a/log/log.go
+++ b/log/log.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -15,6 +16,8 @@ import (
 	"github.com/getlantern/radiance/common/env"
 	"github.com/getlantern/radiance/common/fileperm"
 	"github.com/getlantern/radiance/common/settings"
+
+	lsync "github.com/getlantern/common/sync"
 )
 
 const (
@@ -104,8 +107,7 @@ func NewLogger(cfg Config) *slog.Logger {
 		logWriter = io.MultiWriter(logWriter, Publisher())
 	}
 	var handler slog.Handler = slog.NewTextHandler(logWriter, &slog.HandlerOptions{
-		AddSource: true,
-		Level:     leveler,
+		Level: leveler,
 		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 			switch a.Key {
 			case slog.TimeKey:
@@ -113,40 +115,6 @@ func NewLogger(cfg Config) *slog.Logger {
 					a.Value = slog.StringValue(t.UTC().Format("2006-01-02 15:04:05.000 UTC"))
 				}
 				return a
-			case slog.SourceKey:
-				source, ok := a.Value.Any().(*slog.Source)
-				if !ok {
-					return a
-				}
-				// remove github.com/<username> to get pkg name
-				var pkg, fn string
-				fields := strings.SplitN(source.Function, "/", 4)
-				switch len(fields) {
-				case 0, 1, 2:
-					file := filepath.Base(source.File)
-					a.Value = slog.StringValue(fmt.Sprintf("%s:%d", file, source.Line))
-					return a
-				case 3:
-					pf := strings.SplitN(fields[2], ".", 2)
-					pkg, fn = pf[0], pf[1]
-				default:
-					pkg = fields[2]
-					fn = strings.SplitN(fields[3], ".", 2)[1]
-				}
-
-				_, file, fnd := strings.Cut(source.File, pkg+"/")
-				if !fnd {
-					file = filepath.Base(source.File)
-				}
-				src := slog.GroupValue(
-					slog.String("func", fn),
-					slog.String("file", fmt.Sprintf("%s:%d", file, source.Line)),
-				)
-				a.Value = slog.GroupValue(
-					slog.String("pkg", pkg),
-					slog.Any("source", src),
-				)
-				a.Key = ""
 			case slog.LevelKey:
 				// format the log level to account for the custom levels defined in internal/util.go, i.e. trace
 				// otherwise, slog will print as "DEBUG-4" (trace) or similar
@@ -156,6 +124,7 @@ func NewLogger(cfg Config) *slog.Logger {
 			return a
 		},
 	})
+	handler = newSourceHandler(handler)
 	handler = &Handler{Handler: handler, w: logWriter}
 	logger := slog.New(handler)
 	if !loggingToStdOut {
@@ -177,6 +146,104 @@ type Handler struct {
 
 func (h *Handler) Writer() io.Writer {
 	return h.w
+}
+
+// sourceHandler adds a cached, human-readable source attribute derived from the
+// record PC. This keeps source formatting out of ReplaceAttr and avoids
+// recomputing it for repeated call sites.
+type sourceHandler struct {
+	slog.Handler
+	cache *lsync.TypedMap[uintptr, slog.Attr]
+}
+
+func newSourceHandler(next slog.Handler) slog.Handler {
+	return &sourceHandler{
+		Handler: next,
+		cache:   new(lsync.TypedMap[uintptr, slog.Attr]),
+	}
+}
+
+func (h *sourceHandler) Handle(ctx context.Context, r slog.Record) error {
+	if r.PC == 0 {
+		return h.Handler.Handle(ctx, r)
+	}
+
+	r = r.Clone()
+	r.AddAttrs(h.sourceAttr(r.PC))
+	return h.Handler.Handle(ctx, r)
+}
+
+func (h *sourceHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return h.withHandler(h.Handler.WithAttrs(attrs))
+}
+
+func (h *sourceHandler) WithGroup(name string) slog.Handler {
+	return h.withHandler(h.Handler.WithGroup(name))
+}
+
+func (h *sourceHandler) withHandler(next slog.Handler) slog.Handler {
+	return &sourceHandler{
+		Handler: next,
+		cache:   h.cache,
+	}
+}
+
+func (h *sourceHandler) sourceAttr(pc uintptr) slog.Attr {
+	if attr, ok := h.cache.Load(pc); ok {
+		return attr
+	}
+
+	pcs := [1]uintptr{pc}
+	frame, _ := runtime.CallersFrames(pcs[:]).Next()
+
+	attr := formatSource(frame.Function, frame.File, frame.Line)
+	h.cache.Store(pc, attr)
+	return attr
+}
+
+func formatSource(function, file string, line int) slog.Attr {
+	pkg, fn, ok := parseSourceFunction(function)
+	if !ok {
+		return slog.String(slog.SourceKey, fmt.Sprintf("%s:%d", filepath.Base(file), line))
+	}
+
+	return slog.Group("",
+		slog.String("pkg", pkg),
+		slog.Group("source",
+			slog.String("func", fn),
+			slog.String("file", fmt.Sprintf("%s:%d", trimSourceFile(file, pkg), line)),
+		),
+	)
+}
+
+// parseSourceFunction handles symbols like:
+//   - github.com/org/repo/pkg.Func
+//   - github.com/org/repo/pkg.(*Type).Method
+func parseSourceFunction(symbol string) (pkg string, fn string, ok bool) {
+	pathParts := strings.SplitN(symbol, "/", 4)
+
+	switch len(pathParts) {
+	case 3:
+		pkg, fn, ok = strings.Cut(pathParts[2], ".")
+		return pkg, fn, ok && pkg != "" && fn != ""
+	case 4:
+		pkg = pathParts[2]
+		if pkg == "" {
+			return "", "", false
+		}
+
+		_, fn, ok = strings.Cut(pathParts[3], ".")
+		return pkg, fn, ok && fn != ""
+	default:
+		return "", "", false
+	}
+}
+
+func trimSourceFile(file, pkg string) string {
+	if _, after, found := strings.Cut(file, pkg+"/"); found && after != "" {
+		return after
+	}
+	return filepath.Base(file)
 }
 
 // settingsLeveler reads the current log level from settings on each call,

--- a/log/publish_handler.go
+++ b/log/publish_handler.go
@@ -51,7 +51,10 @@ func (p *publisher) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
-// publish always records b in the ring so a later subscriber still gets backlog.
+// publish records b in the ring and fans it out to live subscribers under one
+// exclusive lock. Ring insertion and broadcast must stay atomic with respect to
+// subscribe so a client subscribing concurrently observes b either in its
+// backlog replay or on its live channel, never both and never neither.
 func (p *publisher) publish(b []byte) {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/log/publish_handler.go
+++ b/log/publish_handler.go
@@ -4,6 +4,10 @@ import (
 	"sync"
 )
 
+const defaultPublisherRingSize = 30
+
+var defaultPublisher = newPublisher(defaultPublisherRingSize)
+
 // LogEntry is a formatted log line streamed to clients.
 type LogEntry = string
 
@@ -13,8 +17,6 @@ type LogEntry = string
 func Subscribe() (chan LogEntry, func()) {
 	return defaultPublisher.subscribe()
 }
-
-var defaultPublisher = newPublisher(200)
 
 // Publisher returns the default log publisher. Include it in the handler's
 // writer chain so published entries share the same format.
@@ -26,8 +28,10 @@ func Publisher() *publisher {
 // so it can be included in the handler's writer chain. It maintains a ring buffer
 // of recent entries so new subscribers get immediate context.
 type publisher struct {
-	clients  map[chan LogEntry]struct{}
-	ring     []LogEntry
+	clients map[chan LogEntry]struct{}
+	// ring retains the last ringSize entries as reused byte buffers, so the
+	// backlog avoids a per-line allocation once warm.
+	ring     [][]byte
 	ringSize int
 	ringIdx  int
 	mu       sync.RWMutex
@@ -36,27 +40,31 @@ type publisher struct {
 func newPublisher(ringSize int) *publisher {
 	return &publisher{
 		clients:  make(map[chan LogEntry]struct{}),
-		ring:     make([]LogEntry, ringSize),
+		ring:     make([][]byte, ringSize),
 		ringSize: ringSize,
 	}
 }
 
 // Write implements io.Writer. Each call is treated as a single log line.
-func (lb *publisher) Write(b []byte) (int, error) {
-	entry := string(b)
-	lb.publish(entry)
+func (p *publisher) Write(b []byte) (int, error) {
+	p.publish(b)
 	return len(b), nil
 }
 
-func (lb *publisher) publish(entry LogEntry) {
-	lb.mu.Lock()
-	lb.ring[lb.ringIdx%lb.ringSize] = entry
-	lb.ringIdx++
-	lb.mu.Unlock()
+// publish always records b in the ring so a later subscriber still gets backlog.
+func (p *publisher) publish(b []byte) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 
-	lb.mu.RLock()
-	defer lb.mu.RUnlock()
-	for ch := range lb.clients {
+	slot := p.ringIdx % p.ringSize
+	p.ring[slot] = append(p.ring[slot][:0], b...)
+	p.ringIdx++
+
+	if len(p.clients) == 0 {
+		return
+	}
+	entry := string(b)
+	for ch := range p.clients {
 		select {
 		case ch <- entry:
 		default: // drop if client is slow
@@ -64,23 +72,22 @@ func (lb *publisher) publish(entry LogEntry) {
 	}
 }
 
-func (lb *publisher) subscribe() (chan LogEntry, func()) {
-	ch := make(chan LogEntry, lb.ringSize)
-	lb.mu.Lock()
-	start := max(0, lb.ringIdx-lb.ringSize)
-	for i := start; i < lb.ringIdx; i++ {
-		entry := lb.ring[i%lb.ringSize]
-		if entry != "" {
-			ch <- entry
+func (p *publisher) subscribe() (chan LogEntry, func()) {
+	ch := make(chan LogEntry, p.ringSize)
+	p.mu.Lock()
+	start := max(0, p.ringIdx-p.ringSize)
+	for i := start; i < p.ringIdx; i++ {
+		if slot := p.ring[i%p.ringSize]; len(slot) > 0 {
+			ch <- string(slot)
 		}
 	}
-	lb.clients[ch] = struct{}{}
-	lb.mu.Unlock()
+	p.clients[ch] = struct{}{}
+	p.mu.Unlock()
 
 	unsub := func() {
-		lb.mu.Lock()
-		delete(lb.clients, ch)
-		lb.mu.Unlock()
+		p.mu.Lock()
+		delete(p.clients, ch)
+		p.mu.Unlock()
 	}
 	return ch, unsub
 }

--- a/log/publish_test.go
+++ b/log/publish_test.go
@@ -16,7 +16,7 @@ func TestPublisher(t *testing.T) {
 	defer unsub()
 
 	entry := "time=2025-01-01T00:00:00.000Z level=INFO msg=hello\n"
-	p.publish(entry)
+	p.publish([]byte(entry))
 
 	select {
 	case got := <-ch:
@@ -54,7 +54,7 @@ func TestMultipleSubscribers(t *testing.T) {
 	defer unsub2()
 
 	entry := "time=2025-01-01T00:00:00.000Z level=DEBUG msg=multi\n"
-	p.publish(entry)
+	p.publish([]byte(entry))
 
 	for _, ch := range []chan LogEntry{ch1, ch2} {
 		select {
@@ -72,7 +72,7 @@ func TestUnsubscribe(t *testing.T) {
 	ch, unsub := p.subscribe()
 	unsub()
 
-	p.publish("time=2025-01-01T00:00:00.000Z level=INFO msg=\"after unsub\"\n")
+	p.publish([]byte("time=2025-01-01T00:00:00.000Z level=INFO msg=\"after unsub\"\n"))
 
 	select {
 	case <-ch:
@@ -87,7 +87,7 @@ func TestRingBuffer(t *testing.T) {
 
 	// Fill the ring buffer with 5 entries, so only the last 3 should be available.
 	for i := range 5 {
-		p.publish(string(rune('a'+i)) + "\n")
+		p.publish([]byte(string(rune('a'+i)) + "\n"))
 	}
 
 	ch, unsub := p.subscribe()
@@ -117,7 +117,7 @@ func TestConcurrentBroadcast(t *testing.T) {
 	for i := range n {
 		go func(i int) {
 			defer wg.Done()
-			p.publish("msg\n")
+			p.publish([]byte("msg\n"))
 		}(i)
 	}
 	wg.Wait()


### PR DESCRIPTION
## Summary

Reworks log source formatting for performance and reduces per-line allocations in the log publisher. Source formatting is moved out of the `slog` `ReplaceAttr` callback into a dedicated `sourceHandler` that caches the formatted attribute per record program counter (PC), so repeated call sites no longer re-parse and re-format their source location on every log line. The publisher's ring buffer is reworked to reuse byte buffers instead of allocating a new string per entry.

## Changes

**`perf(log): memoize source formatting and reuse ring buffers` (46b9fbb)**

- `log/log.go`: Extract source formatting from the `ReplaceAttr` callback into a new `sourceHandler` that wraps the next handler. It derives the human-readable source attribute from the record PC and caches it in a `lsync.TypedMap[uintptr, slog.Attr]` keyed by PC, so each unique call site is formatted once. `WithAttrs`/`WithGroup` propagate the shared cache. `parseSourceFunction` and `trimSourceFile` carry the package/function/file derivation that previously lived inline in `ReplaceAttr`. `AddSource` is dropped from the base text handler options since the new handler reads the PC directly.
- `log/publish_handler.go`: Back the publisher ring buffer with reused `[]byte` slots (`append(slot[:0], b...)`) instead of allocating a string per entry, so a warm backlog avoids per-line allocation. The string conversion now happens only when broadcasting to subscribers, and is skipped entirely when there are no clients. The default ring size is reduced from 200 to 30. Receiver renamed `lb` → `p`.
- `log/publish_test.go`: Update `publish` call sites for the new `[]byte` signature.

Related to https://github.com/getlantern/engineering/issues/3542