### PR TITLE
fix(dnstt): demote tunnels returning a gateway 5xx instead of marking them healthy

### DIFF
--- a/kindling/dnstt/connected_roundtripper_test.go
+++ b/kindling/dnstt/connected_roundtripper_test.go
@@ -1,0 +1,57 @@
+package dnstt
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A tunnel that keeps returning a gateway 5xx must be demoted rather than
+// re-marked healthy on every response, so a persistently-broken tunnel leaves
+// the pool. Origin-generated statuses (4xx, 500) leave the tunnel healthy.
+func TestConnectedRoundtripperHealthTracking(t *testing.T) {
+	newCRT := func(status int) (*connectedRoundtripper, *dnsTunnel) {
+		tun := &dnsTunnel{domain: "t.iantem.io", resolver: "https://cloudflare-dns.com/dns-query"}
+		tun.markSucceeded() // a probed tunnel starts healthy
+		rt := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: status, Body: http.NoBody, Request: req}, nil
+		})
+		return &connectedRoundtripper{t: tun, rt: rt}, tun
+	}
+	req := httptest.NewRequest(http.MethodGet, "https://api.getiantem.org/v1/x", nil)
+
+	t.Run("gateway 5xx demotes the tunnel", func(t *testing.T) {
+		for _, status := range []int{http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout} {
+			crt, tun := newCRT(status)
+			for range maxTunnelFailures {
+				resp, err := crt.RoundTrip(req)
+				require.NoError(t, err) // the 5xx is still surfaced, not converted to an error
+				assert.Equal(t, status, resp.StatusCode)
+			}
+			assert.False(t, tun.isSucceeding(), "tunnel returning %d should be demoted", status)
+		}
+	})
+
+	t.Run("2xx keeps the tunnel healthy", func(t *testing.T) {
+		crt, tun := newCRT(http.StatusOK)
+		for range maxTunnelFailures + 2 {
+			_, err := crt.RoundTrip(req)
+			require.NoError(t, err)
+		}
+		assert.True(t, tun.isSucceeding())
+	})
+
+	t.Run("origin 4xx/500 does not demote the tunnel", func(t *testing.T) {
+		for _, status := range []int{http.StatusNotFound, http.StatusInternalServerError} {
+			crt, tun := newCRT(status)
+			for range maxTunnelFailures + 2 {
+				_, err := crt.RoundTrip(req)
+				require.NoError(t, err)
+			}
+			assert.True(t, tun.isSucceeding(), "status %d is an origin verdict, tunnel stays healthy", status)
+		}
+	})
+}

--- a/kindling/dnstt/connected_roundtripper_test.go
+++ b/kindling/dnstt/connected_roundtripper_test.go
@@ -23,13 +23,22 @@ func TestConnectedRoundtripperHealthTracking(t *testing.T) {
 	}
 	req := httptest.NewRequest(http.MethodGet, "https://api.getiantem.org/v1/x", nil)
 
+	// roundTrip issues one request and closes the body, per the
+	// http.RoundTripper contract.
+	roundTrip := func(t *testing.T, crt *connectedRoundtripper) *http.Response {
+		t.Helper()
+		resp, err := crt.RoundTrip(req)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		return resp
+	}
+
 	t.Run("gateway 5xx demotes the tunnel", func(t *testing.T) {
 		for _, status := range []int{http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout} {
 			crt, tun := newCRT(status)
 			for range maxTunnelFailures {
-				resp, err := crt.RoundTrip(req)
-				require.NoError(t, err) // the 5xx is still surfaced, not converted to an error
-				assert.Equal(t, status, resp.StatusCode)
+				// the 5xx is still surfaced, not converted to an error
+				assert.Equal(t, status, roundTrip(t, crt).StatusCode)
 			}
 			assert.False(t, tun.isSucceeding(), "tunnel returning %d should be demoted", status)
 		}
@@ -38,8 +47,7 @@ func TestConnectedRoundtripperHealthTracking(t *testing.T) {
 	t.Run("2xx keeps the tunnel healthy", func(t *testing.T) {
 		crt, tun := newCRT(http.StatusOK)
 		for range maxTunnelFailures + 2 {
-			_, err := crt.RoundTrip(req)
-			require.NoError(t, err)
+			roundTrip(t, crt)
 		}
 		assert.True(t, tun.isSucceeding())
 	})
@@ -48,8 +56,7 @@ func TestConnectedRoundtripperHealthTracking(t *testing.T) {
 		for _, status := range []int{http.StatusNotFound, http.StatusInternalServerError} {
 			crt, tun := newCRT(status)
 			for range maxTunnelFailures + 2 {
-				_, err := crt.RoundTrip(req)
-				require.NoError(t, err)
+				roundTrip(t, crt)
 			}
 			assert.True(t, tun.isSucceeding(), "status %d is an origin verdict, tunnel stays healthy", status)
 		}

--- a/kindling/dnstt/parser.go
+++ b/kindling/dnstt/parser.go
@@ -521,14 +521,32 @@ func (c *connectedRoundtripper) RoundTrip(req *http.Request) (*http.Response, er
 	if err != nil {
 		c.t.recordFailure()
 		slog.WarnContext(req.Context(), "dnstt roundtripper failed",
-			"domain", c.t.domain, "resolver", c.t.resolver, "error", err)
+			"domain", c.t.domain, "resolver", c.t.resolver, "host", req.URL.Host, "error", err)
 		return nil, err
 	}
 
+	// A gateway 5xx (502/503/504) comes from the tunnel's DoH/intermediary path,
+	// not the origin, so count it as a tunnel-health failure: otherwise a tunnel
+	// that keeps returning 502 is re-marked healthy and never leaves the pool.
+	if isGatewayError(resp.StatusCode) {
+		c.t.recordFailure()
+		slog.WarnContext(req.Context(), "dnstt roundtripper got gateway error",
+			"domain", c.t.domain, "resolver", c.t.resolver, "host", req.URL.Host, "status", resp.StatusCode)
+		return resp, nil
+	}
+
 	slog.DebugContext(req.Context(), "dnstt roundtripper succeeded",
-		"domain", c.t.domain, "resolver", c.t.resolver)
+		"domain", c.t.domain, "resolver", c.t.resolver, "host", req.URL.Host, "status", resp.StatusCode)
 	c.t.markSucceeded()
 	return resp, nil
+}
+
+// isGatewayError reports whether status is a gateway-level 5xx — the failure a
+// DNS tunnel's DoH/intermediary path produces, not an origin-generated error.
+func isGatewayError(status int) bool {
+	return status == http.StatusBadGateway ||
+		status == http.StatusServiceUnavailable ||
+		status == http.StatusGatewayTimeout
 }
 
 // Close releases resources and closes active sessions.


### PR DESCRIPTION
## Problem

`connectedRoundtripper.RoundTrip` treated **any** non-error response — including a `502`/`503`/`504` — as a tunnel success (`markSucceeded()`). Only a Go-level transport error took the failure path.

So a DNSTT tunnel whose DoH/intermediary path returns `502` was **re-confirmed healthy on every 502**: `lastSucceeded` refreshed, `consecutiveFailures` reset, the tunnel stayed in `tunChan` flagged `isSucceeding()`, and kindling's race kept selecting it. For **non-idempotent POSTs** (signup / login / `/subscription/pay`), kindling is single-shot, so that `502` was handed straight back to the client, which retried with **no timeout** — the **endless spinner** Derek hit on the macOS/Windows purchase + login flows (FD [#177919](https://lantern.freshdesk.com/a/tickets/177919), [#177920](https://lantern.freshdesk.com/a/tickets/177920), [#177921](https://lantern.freshdesk.com/a/tickets/177921)).

This is the transport-layer side of the kindling contract that `NewRoundTripper` should return a *working* RoundTripper (domain fronting enforces this with a live per-attempt handshake; DNSTT did not).

```mermaid
sequenceDiagram
    autonumber
    participant A as App<br/>Flutter client
    participant K as kindling race<br/>race_transport.go
    participant D as DNSTT pool<br/>radiance parser.go
    participant O as DoH tunnel + origin

    A->>K: POST /subscription/pay<br/>non-idempotent
    K->>D: parser.go:482<br/>NewRoundTripper — pull tunnel from tunChan
    Note over D: tunnel flagged isSucceeding<br/>probed vs gstatic up to 5 min ago ⚠️
    D-->>K: "connected" RoundTripper
    K->>D: RoundTrip req
    D->>O: tunneled request
    O-->>D: 502 Bad Gateway
    rect rgba(255, 200, 200, 0.3)
        Note over D: parser.go:530 markSucceeded on the 502<br/>tunnel re-marked healthy, never leaves pool 🐛
    end
    D-->>K: 502 response
    Note over K: race_transport.go:220<br/>non-idempotent = single-shot, returns the 502
    K-->>A: 502
    Note over A: retries with no timeout → endless spinner
```

## Fix

In `connectedRoundtripper.RoundTrip`, treat a **gateway 5xx (502/503/504)** as a tunnel-health failure (`recordFailure()`) so a persistently-bad tunnel is evicted from the pool instead of being re-marked healthy. The 502 response is **still returned**, so kindling applies its own retry/fallback policy unchanged. Origin-generated statuses (`4xx`, `500`) leave the tunnel healthy — they're the origin's verdict, not a tunnel fault.

Also added `host` + `status` to the round-tripper logs so a future 502 can be attributed to the DoH layer vs the origin (the question raised in the kindling#39 thread and never settled).

## Scope / relation to kindling#39

kindling#39 (DNSTT → last-resort tier) keeps DNSTT *out of the race* for users who have a working fronted path — which is why this stopped reproducing for uncensored testers. But for **censored users who depend on DNSTT**, the bad-tunnel-stays-healthy behavior was fully live; this fixes it at the source. The two are complementary.

Not addressed here (separate, app-side): the email-confirmation/login/purchase spinner should also **time out + show an error** rather than retry forever — the universal backstop for any 502 source.

## Test

`TestConnectedRoundtripperHealthTracking`: a tunnel returning 502/503/504 is demoted after `maxTunnelFailures`; 2xx keeps it healthy; origin `404`/`500` do **not** demote it. The 502 is still surfaced (not converted to an error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
