### PR TITLE
Bump keepcurrent to f204338b01a3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/getlantern/common v1.2.1-0.20260326210434-cb69537aaf46
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac
 	github.com/getlantern/domainfront v0.0.0-20260419161617-0bff0b2169f4
-	github.com/getlantern/keepcurrent v0.0.0-20260608000050-6b50f5857840
+	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3
 	github.com/getlantern/kindling v0.0.0-20260611181428-9a360f63ad5a
 	github.com/getlantern/lantern-box v0.0.90
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,8 @@ github.com/getlantern/hex v0.0.0-20220104173244-ad7e4b9194dc h1:sue+aeVx7JF5v36H
 github.com/getlantern/hex v0.0.0-20220104173244-ad7e4b9194dc/go.mod h1:D9RWpXy/EFPYxiKUURo2TB8UBosbqkiLhttRrZYtvqM=
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 h1:cSrD9ryDfTV2yaur9Qk3rHYD414j3Q1rl7+L0AylxrE=
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770/go.mod h1:GOQsoDnEHl6ZmNIL+5uVo+JWRFWozMEp18Izcb++H+A=
-github.com/getlantern/keepcurrent v0.0.0-20260608000050-6b50f5857840 h1:/YhIurj1ekh7UUNu5/67vYt7gl7S4eAvCXhx+treDE8=
-github.com/getlantern/keepcurrent v0.0.0-20260608000050-6b50f5857840/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
+github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvdWv+YvXDqADVwjxM0DyABg2x4UgLVKU9McKI=
+github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260611181428-9a360f63ad5a h1:w62TGPHwGqPDKq43pbwOkbvCofMY4Ldd5d17QBF9jnY=
 github.com/getlantern/kindling v0.0.0-20260611181428-9a360f63ad5a/go.mod h1:9EDX+ZFoMVcd8M14LeE7ULn/TRuV9g5GijNUDgJyw2A=
 github.com/getlantern/lantern-box v0.0.90 h1:/CKyzAl9ly9ShAuVBnqKmhJPs0xP4uk5AFAFDUrXof0=


### PR DESCRIPTION
Bumps `github.com/getlantern/keepcurrent` from `20260608000050-6b50f5857840` to `20260616120552-f204338b01a3`.

`go mod tidy` was run; only `go.mod` and `go.sum` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)