### PR TITLE
deps: bump lantern-box v0.0.90 → v0.0.93 (samizdat half-close fix)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/getlantern/domainfront v0.0.0-20260419161617-0bff0b2169f4
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3
 	github.com/getlantern/kindling v0.0.0-20260611181428-9a360f63ad5a
-	github.com/getlantern/lantern-box v0.0.90
+	github.com/getlantern/lantern-box v0.0.93
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvd
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260611181428-9a360f63ad5a h1:w62TGPHwGqPDKq43pbwOkbvCofMY4Ldd5d17QBF9jnY=
 github.com/getlantern/kindling v0.0.0-20260611181428-9a360f63ad5a/go.mod h1:9EDX+ZFoMVcd8M14LeE7ULn/TRuV9g5GijNUDgJyw2A=
-github.com/getlantern/lantern-box v0.0.90 h1:/CKyzAl9ly9ShAuVBnqKmhJPs0xP4uk5AFAFDUrXof0=
-github.com/getlantern/lantern-box v0.0.90/go.mod h1:b3zidNoOsT2tk3D5scHVuoVk2ZalMbP7CTiyw7KGQ2I=
+github.com/getlantern/lantern-box v0.0.93 h1:R0c7NlT5M7fSp316KqKVw5KnDAk38xqbmQEue8Q+3pc=
+github.com/getlantern/lantern-box v0.0.93/go.mod h1:yQhnLpnDY17+c/s+4WiiUhun3HtoHNj5NFb355ThKQk=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395/go.mod h1:3JpJgwi4KEI6rS9loOAvcBp+F2jP65d0tTg2GQcTPBU=
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 h1:3BwvWj0JZzFEvNNiMhCu4bf60nqcIuQpTYb00Ezm1ag=


### PR DESCRIPTION
## What

Bumps `github.com/getlantern/lantern-box` **v0.0.90 → v0.0.93**.

Headline: pulls in the **samizdat half-close fix** ([lantern-box#278](https://github.com/getlantern/lantern-box/pull/278)) — `wrapConn` now forwards `CloseWrite`, so sing-box's relay can do a real TCP half-close (HTTP/2 `END_STREAM`) instead of silently downgrading to a full close. Also picks up two keepcurrent fixes tagged in between:

| Tag | Change |
|-----|--------|
| v0.0.93 | samizdat: forward `CloseWrite` (half-close no longer silently dropped) — #278 |
| v0.0.92 | keepcurrent fileSource pre-size fix — #276 |
| v0.0.91 | keepcurrent sync memory fix — #275 |

## Scope
`go.mod` + `go.sum` only (`go mod tidy` clean). `./vpn/...` and `./backend/...` (the lantern-box consumers) build against it.

`go build ./...` still fails on `cmd/lantern` (`ipc.NewClient` arity) — that's **pre-existing on main and unrelated** to this bump.

## Next hop
To reach the v9 client, `getlantern/lantern` needs a follow-up bump of radiance once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
