### PR TITLE
deps: bump domainfront (h2-capable) and kindling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,9 +33,9 @@ require (
 	github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c
 	github.com/getlantern/common v1.2.1-0.20260326210434-cb69537aaf46
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac
-	github.com/getlantern/domainfront v0.0.0-20260419161617-0bff0b2169f4
+	github.com/getlantern/domainfront v0.0.0-20260624004218-93591749d736
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3
-	github.com/getlantern/kindling v0.0.0-20260611181428-9a360f63ad5a
+	github.com/getlantern/kindling v0.0.0-20260624005117-737fcffe2860
 	github.com/getlantern/lantern-box v0.0.95
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wd
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac/go.mod h1:0+wlia2hljruM7rhjzBMFhve011lGRO0OxjVSOcXBoQ=
-github.com/getlantern/domainfront v0.0.0-20260419161617-0bff0b2169f4 h1:/Q9FJvKPyuXfH6tfA+C+t9/AbvGWs3Yp9iqI74FYvb4=
-github.com/getlantern/domainfront v0.0.0-20260419161617-0bff0b2169f4/go.mod h1:nsdIvgenGUqPKnRFjkssbfxnV/WYWyC0c/t15qGym/A=
+github.com/getlantern/domainfront v0.0.0-20260624004218-93591749d736 h1:Y5d0XP7ammE/ryHj8fPR3JKBYKmOQaYQFN31oF3my7E=
+github.com/getlantern/domainfront v0.0.0-20260624004218-93591749d736/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
 github.com/getlantern/errors v1.0.4 h1:i2iR1M9GKj4WuingpNqJ+XQEw6i6dnAgKAmLj6ZB3X0=
 github.com/getlantern/errors v1.0.4/go.mod h1:/Foq8jtSDGP8GOXzAjeslsC4Ar/3kB+UiQH+WyV4pzY=
 github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65 h1:NlQedYmPI3pRAXJb+hLVVDGqfvvXGRPV8vp7XOjKAZ0=
@@ -244,8 +244,8 @@ github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 h1:cSrD9ryDfTV2y
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770/go.mod h1:GOQsoDnEHl6ZmNIL+5uVo+JWRFWozMEp18Izcb++H+A=
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvdWv+YvXDqADVwjxM0DyABg2x4UgLVKU9McKI=
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
-github.com/getlantern/kindling v0.0.0-20260611181428-9a360f63ad5a h1:w62TGPHwGqPDKq43pbwOkbvCofMY4Ldd5d17QBF9jnY=
-github.com/getlantern/kindling v0.0.0-20260611181428-9a360f63ad5a/go.mod h1:9EDX+ZFoMVcd8M14LeE7ULn/TRuV9g5GijNUDgJyw2A=
+github.com/getlantern/kindling v0.0.0-20260624005117-737fcffe2860 h1:QPS7mJMor1Zfd/+/Au4DKlVBobz3k0hn8fcIV+LP92Q=
+github.com/getlantern/kindling v0.0.0-20260624005117-737fcffe2860/go.mod h1:hVrWMg592ICfNj9gbfV7Xsa6Bpb4TV2UCVAo0ssMFMk=
 github.com/getlantern/lantern-box v0.0.95 h1:tsgjKQjWjPy3ZyCIYijT91W3XJY+8XENxb6mUogthI0=
 github.com/getlantern/lantern-box v0.0.95/go.mod h1:yQhnLpnDY17+c/s+4WiiUhun3HtoHNj5NFb355ThKQk=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=


### PR DESCRIPTION
Propagates the HTTP/2 fronting fix down the dependency chain (domainfront#9 →
kindling#40 → here).

## What

- `github.com/getlantern/domainfront` → `v0.0.0-20260624004218-93591749d736`
  ([domainfront#9](https://github.com/getlantern/domainfront/pull/9))
- `github.com/getlantern/kindling` → `v0.0.0-20260624005117-737fcffe2860`
  ([kindling#40](https://github.com/getlantern/kindling/pull/40))

## Why

domainfront#9 makes the fronted round trip **ALPN-aware**: when a CDN edge
negotiates HTTP/2 (CloudFront, Aliyun, …) the request is now framed as HTTP/2
instead of sending HTTP/1.1 over the h2 connection and failing with
`malformed HTTP response "\x00\x00\x12\x04..."`. radiance fronts through both
domainfront (directly) and kindling, so this fixes h2 edges across the board.
It also carries domainfront's `utls` v1.7.1 → v1.8.2 bump, already the version
radiance resolves (go 1.26 satisfies its Go-1.24-native ML-KEM requirement).

## Compatibility

domainfront's public API (`New`, `Config`, `Provider`, `Masquerade`,
`ParseConfig`, `WithConfigURL`) is unchanged — the h2 work was internal to the
round-trip path — so this is a transparent dependency update. The go.mod/go.sum
change is limited to these two modules.

Verified: all packages build (`cmd/lantern` via `-tags standalone`, everything
else via `-tags with_clash_api`), `go vet` clean, and the `kindling` package
tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->