### PR TITLE
Fix retained servers missing from cold-start VPN options

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -857,16 +857,11 @@ func (r *LocalBackend) getBoxOptions() vpn.BoxOptions {
 			bOptions.AdBlock = cfg.AdBlock
 		}
 	}
+	servers := r.srvManager.AllServers()
+	appendManagedServerOptions(&bOptions.Options, servers)
+
 	seed := make(map[string]lbA.TagHistory)
-	for _, srv := range r.srvManager.AllServers() {
-		if !srv.IsLantern {
-			switch opts := srv.Options.(type) {
-			case option.Outbound:
-				bOptions.Options.Outbounds = append(bOptions.Options.Outbounds, opts)
-			case option.Endpoint:
-				bOptions.Options.Endpoints = append(bOptions.Options.Endpoints, opts)
-			}
-		}
+	for _, srv := range servers {
 		if srv.SelectionHistory != nil {
 			seed[srv.Tag] = *srv.SelectionHistory
 		}
@@ -875,6 +870,34 @@ func (r *LocalBackend) getBoxOptions() vpn.BoxOptions {
 		bOptions.SelectionHistorySeed = seed
 	}
 	return bOptions
+}
+
+func appendManagedServerOptions(options *option.Options, managed []*servers.Server) {
+	existingTags := optionTagSet(*options)
+	for _, srv := range managed {
+		if _, exists := existingTags[srv.Tag]; exists {
+			continue
+		}
+		switch opts := srv.Options.(type) {
+		case option.Outbound:
+			options.Outbounds = append(options.Outbounds, opts)
+			existingTags[opts.Tag] = struct{}{}
+		case option.Endpoint:
+			options.Endpoints = append(options.Endpoints, opts)
+			existingTags[opts.Tag] = struct{}{}
+		}
+	}
+}
+
+func optionTagSet(options option.Options) map[string]struct{} {
+	tags := make(map[string]struct{}, len(options.Outbounds)+len(options.Endpoints))
+	for _, out := range options.Outbounds {
+		tags[out.Tag] = struct{}{}
+	}
+	for _, ep := range options.Endpoints {
+		tags[ep.Tag] = struct{}{}
+	}
+	return tags
 }
 
 func (r *LocalBackend) DisconnectVPN() error {

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -881,39 +881,27 @@ func appendManagedServerOptions(options *option.Options, managed []*servers.Serv
 	for _, srv := range managed {
 		switch opts := srv.Options.(type) {
 		case option.Outbound:
-			tag := managedOptionTag(srv.Tag, opts.Tag)
+			tag := opts.Tag
 			if tag == "" {
 				continue
 			}
 			if _, exists := existingTags[tag]; exists {
 				continue
 			}
-			opts.Tag = tag
 			options.Outbounds = append(options.Outbounds, opts)
 			existingTags[tag] = struct{}{}
 		case option.Endpoint:
-			tag := managedOptionTag(srv.Tag, opts.Tag)
+			tag := opts.Tag
 			if tag == "" {
 				continue
 			}
 			if _, exists := existingTags[tag]; exists {
 				continue
 			}
-			opts.Tag = tag
 			options.Endpoints = append(options.Endpoints, opts)
 			existingTags[tag] = struct{}{}
 		}
 	}
-}
-
-// managedOptionTag returns the tag that sing-box will see for a managed option.
-// Prefer the embedded option tag, falling back to Server.Tag for older or
-// partially populated records.
-func managedOptionTag(serverTag, optionTag string) string {
-	if optionTag != "" {
-		return optionTag
-	}
-	return serverTag
 }
 
 // optionTagSet returns the outbound and endpoint tags already present in the

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -872,6 +872,10 @@ func (r *LocalBackend) getBoxOptions() vpn.BoxOptions {
 	return bOptions
 }
 
+// appendManagedServerOptions adds server-manager options that are missing from
+// the current config options. Config options remain authoritative for duplicate
+// tags, but retained Lantern servers and user servers stay connectable on cold
+// tunnel start.
 func appendManagedServerOptions(options *option.Options, managed []*servers.Server) {
 	existingTags := optionTagSet(*options)
 	for _, srv := range managed {
@@ -902,6 +906,9 @@ func appendManagedServerOptions(options *option.Options, managed []*servers.Serv
 	}
 }
 
+// managedOptionTag returns the tag that sing-box will see for a managed option.
+// Prefer the embedded option tag, falling back to Server.Tag for older or
+// partially populated records.
 func managedOptionTag(serverTag, optionTag string) string {
 	if optionTag != "" {
 		return optionTag
@@ -909,6 +916,8 @@ func managedOptionTag(serverTag, optionTag string) string {
 	return serverTag
 }
 
+// optionTagSet returns the outbound and endpoint tags already present in the
+// box options.
 func optionTagSet(options option.Options) map[string]struct{} {
 	tags := make(map[string]struct{}, len(options.Outbounds)+len(options.Endpoints))
 	for _, out := range options.Outbounds {

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -857,11 +857,11 @@ func (r *LocalBackend) getBoxOptions() vpn.BoxOptions {
 			bOptions.AdBlock = cfg.AdBlock
 		}
 	}
-	servers := r.srvManager.AllServers()
-	appendManagedServerOptions(&bOptions.Options, servers)
+	managedServers := r.srvManager.AllServers()
+	appendManagedServerOptions(&bOptions.Options, managedServers)
 
 	seed := make(map[string]lbA.TagHistory)
-	for _, srv := range servers {
+	for _, srv := range managedServers {
 		if srv.SelectionHistory != nil {
 			seed[srv.Tag] = *srv.SelectionHistory
 		}
@@ -875,18 +875,38 @@ func (r *LocalBackend) getBoxOptions() vpn.BoxOptions {
 func appendManagedServerOptions(options *option.Options, managed []*servers.Server) {
 	existingTags := optionTagSet(*options)
 	for _, srv := range managed {
-		if _, exists := existingTags[srv.Tag]; exists {
-			continue
-		}
 		switch opts := srv.Options.(type) {
 		case option.Outbound:
+			tag := managedOptionTag(srv.Tag, opts.Tag)
+			if tag == "" {
+				continue
+			}
+			if _, exists := existingTags[tag]; exists {
+				continue
+			}
+			opts.Tag = tag
 			options.Outbounds = append(options.Outbounds, opts)
-			existingTags[opts.Tag] = struct{}{}
+			existingTags[tag] = struct{}{}
 		case option.Endpoint:
+			tag := managedOptionTag(srv.Tag, opts.Tag)
+			if tag == "" {
+				continue
+			}
+			if _, exists := existingTags[tag]; exists {
+				continue
+			}
+			opts.Tag = tag
 			options.Endpoints = append(options.Endpoints, opts)
-			existingTags[opts.Tag] = struct{}{}
+			existingTags[tag] = struct{}{}
 		}
 	}
+}
+
+func managedOptionTag(serverTag, optionTag string) string {
+	if optionTag != "" {
+		return optionTag
+	}
+	return serverTag
 }
 
 func optionTagSet(options option.Options) map[string]struct{} {

--- a/backend/radiance_test.go
+++ b/backend/radiance_test.go
@@ -156,7 +156,7 @@ func TestAppendManagedServerOptionsIncludesRetainedLanternServers(t *testing.T) 
 			Options:   option.Outbound{Tag: "user-missing", Type: "trojan"},
 		},
 		{
-			Tag:       "fallback-tag",
+			Tag:       "missing-option-tag",
 			Type:      "shadowsocks",
 			IsLantern: true,
 			Options:   option.Outbound{Type: "shadowsocks"},
@@ -186,7 +186,6 @@ func TestAppendManagedServerOptionsIncludesRetainedLanternServers(t *testing.T) 
 		"retained-current",
 		"retained-missing",
 		"user-missing",
-		"fallback-tag",
 	}, outboundTags(options.Outbounds))
 	assert.Equal(t, "shadowsocks", options.Outbounds[1].Type, "current config should win duplicate tags")
 	assert.Equal(t, []string{

--- a/backend/radiance_test.go
+++ b/backend/radiance_test.go
@@ -126,6 +126,9 @@ func TestAppendManagedServerOptionsIncludesRetainedLanternServers(t *testing.T) 
 			{Tag: "current", Type: "shadowsocks"},
 			{Tag: "retained-current", Type: "shadowsocks"},
 		},
+		Endpoints: []option.Endpoint{
+			{Tag: "current-endpoint", Type: "wireguard"},
+		},
 	}
 	managed := []*servers.Server{
 		{
@@ -133,6 +136,12 @@ func TestAppendManagedServerOptionsIncludesRetainedLanternServers(t *testing.T) 
 			Type:      "hysteria2",
 			IsLantern: true,
 			Options:   option.Outbound{Tag: "retained-current", Type: "hysteria2"},
+		},
+		{
+			Tag:       "server-alias-for-current",
+			Type:      "hysteria2",
+			IsLantern: true,
+			Options:   option.Outbound{Tag: "current", Type: "hysteria2"},
 		},
 		{
 			Tag:       "retained-missing",
@@ -147,6 +156,24 @@ func TestAppendManagedServerOptionsIncludesRetainedLanternServers(t *testing.T) 
 			Options:   option.Outbound{Tag: "user-missing", Type: "trojan"},
 		},
 		{
+			Tag:       "fallback-tag",
+			Type:      "shadowsocks",
+			IsLantern: true,
+			Options:   option.Outbound{Type: "shadowsocks"},
+		},
+		{
+			Tag:       "retained-endpoint",
+			Type:      "wireguard",
+			IsLantern: true,
+			Options:   option.Endpoint{Tag: "retained-endpoint", Type: "wireguard"},
+		},
+		{
+			Tag:       "server-alias-for-current-endpoint",
+			Type:      "wireguard",
+			IsLantern: true,
+			Options:   option.Endpoint{Tag: "current-endpoint", Type: "wireguard"},
+		},
+		{
 			Tag:       "metadata-only",
 			IsLantern: true,
 		},
@@ -159,14 +186,27 @@ func TestAppendManagedServerOptionsIncludesRetainedLanternServers(t *testing.T) 
 		"retained-current",
 		"retained-missing",
 		"user-missing",
+		"fallback-tag",
 	}, outboundTags(options.Outbounds))
 	assert.Equal(t, "shadowsocks", options.Outbounds[1].Type, "current config should win duplicate tags")
+	assert.Equal(t, []string{
+		"current-endpoint",
+		"retained-endpoint",
+	}, endpointTags(options.Endpoints))
 }
 
 func outboundTags(outbounds []option.Outbound) []string {
 	tags := make([]string, 0, len(outbounds))
 	for _, out := range outbounds {
 		tags = append(tags, out.Tag)
+	}
+	return tags
+}
+
+func endpointTags(endpoints []option.Endpoint) []string {
+	tags := make([]string, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		tags = append(tags, endpoint.Tag)
 	}
 	return tags
 }

--- a/backend/radiance_test.go
+++ b/backend/radiance_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sagernet/sing-box/option"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -117,4 +118,55 @@ func TestLanternServersToEvict(t *testing.T) {
 			assert.ElementsMatch(t, tt.want, got)
 		})
 	}
+}
+
+func TestAppendManagedServerOptionsIncludesRetainedLanternServers(t *testing.T) {
+	options := option.Options{
+		Outbounds: []option.Outbound{
+			{Tag: "current", Type: "shadowsocks"},
+			{Tag: "retained-current", Type: "shadowsocks"},
+		},
+	}
+	managed := []*servers.Server{
+		{
+			Tag:       "retained-current",
+			Type:      "hysteria2",
+			IsLantern: true,
+			Options:   option.Outbound{Tag: "retained-current", Type: "hysteria2"},
+		},
+		{
+			Tag:       "retained-missing",
+			Type:      "shadowsocks",
+			IsLantern: true,
+			Options:   option.Outbound{Tag: "retained-missing", Type: "shadowsocks"},
+		},
+		{
+			Tag:       "user-missing",
+			Type:      "trojan",
+			IsLantern: false,
+			Options:   option.Outbound{Tag: "user-missing", Type: "trojan"},
+		},
+		{
+			Tag:       "metadata-only",
+			IsLantern: true,
+		},
+	}
+
+	appendManagedServerOptions(&options, managed)
+
+	assert.Equal(t, []string{
+		"current",
+		"retained-current",
+		"retained-missing",
+		"user-missing",
+	}, outboundTags(options.Outbounds))
+	assert.Equal(t, "shadowsocks", options.Outbounds[1].Type, "current config should win duplicate tags")
+}
+
+func outboundTags(outbounds []option.Outbound) []string {
+	tags := make([]string, 0, len(outbounds))
+	for _, out := range outbounds {
+		tags = append(tags, out.Tag)
+	}
+	return tags
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved managed server option assembly to consistently retain existing outbound/endpoint entries while avoiding duplicates via tag-based deduplication.
  * Ensured retained and user server options remain connectable for cold-start by merging managed options without overwriting existing “current” settings (including outbound type).
* **Tests**
  * Added coverage for merging managed lantern and non-lantern server options, including endpoint alias retention and conflict behavior preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->