### PR TITLE
deps: bump domainfront + kindling (legit SNI for fronting)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,9 +33,9 @@ require (
 	github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c
 	github.com/getlantern/common v1.2.1-0.20260326210434-cb69537aaf46
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac
-	github.com/getlantern/domainfront v0.0.0-20260624004218-93591749d736
+	github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3
-	github.com/getlantern/kindling v0.0.0-20260624005117-737fcffe2860
+	github.com/getlantern/kindling v0.0.0-20260625002640-7cdf7184420c
 	github.com/getlantern/lantern-box v0.0.95
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wd
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac/go.mod h1:0+wlia2hljruM7rhjzBMFhve011lGRO0OxjVSOcXBoQ=
-github.com/getlantern/domainfront v0.0.0-20260624004218-93591749d736 h1:Y5d0XP7ammE/ryHj8fPR3JKBYKmOQaYQFN31oF3my7E=
-github.com/getlantern/domainfront v0.0.0-20260624004218-93591749d736/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
+github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b h1:cM+Cwgg6EN279knxvHc4vd3MyNOpZk/49TLlg2F78Rk=
+github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
 github.com/getlantern/errors v1.0.4 h1:i2iR1M9GKj4WuingpNqJ+XQEw6i6dnAgKAmLj6ZB3X0=
 github.com/getlantern/errors v1.0.4/go.mod h1:/Foq8jtSDGP8GOXzAjeslsC4Ar/3kB+UiQH+WyV4pzY=
 github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65 h1:NlQedYmPI3pRAXJb+hLVVDGqfvvXGRPV8vp7XOjKAZ0=
@@ -244,8 +244,8 @@ github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 h1:cSrD9ryDfTV2y
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770/go.mod h1:GOQsoDnEHl6ZmNIL+5uVo+JWRFWozMEp18Izcb++H+A=
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvdWv+YvXDqADVwjxM0DyABg2x4UgLVKU9McKI=
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
-github.com/getlantern/kindling v0.0.0-20260624005117-737fcffe2860 h1:QPS7mJMor1Zfd/+/Au4DKlVBobz3k0hn8fcIV+LP92Q=
-github.com/getlantern/kindling v0.0.0-20260624005117-737fcffe2860/go.mod h1:hVrWMg592ICfNj9gbfV7Xsa6Bpb4TV2UCVAo0ssMFMk=
+github.com/getlantern/kindling v0.0.0-20260625002640-7cdf7184420c h1:F4/LE+5zehr6AUfuJBab3iubscOOTdFZxwYldIpLgg8=
+github.com/getlantern/kindling v0.0.0-20260625002640-7cdf7184420c/go.mod h1:rN6O8pIQ9nc7Gyvtf2GGSjiWEFIApGsRCHkgYz0h3Ak=
 github.com/getlantern/lantern-box v0.0.95 h1:tsgjKQjWjPy3ZyCIYijT91W3XJY+8XENxb6mUogthI0=
 github.com/getlantern/lantern-box v0.0.95/go.mod h1:yQhnLpnDY17+c/s+4WiiUhun3HtoHNj5NFb355ThKQk=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=


### PR DESCRIPTION
## Summary

Bump the fronting stack to pick up the legit-SNI work:

- `getlantern/domainfront` → `v0.0.0-20260625001429-518c0256669b` (**domainfront#11**)
- `getlantern/kindling` → `v0.0.0-20260625002640-7cdf7184420c` (**kindling#41**)

## What it enables

`ExpandedProvider` now lets providers front with a **legit SNI** instead of the conspicuous no-SNI every client uses today (the production client — this repo's `kindling/fronted/NewFronted` — passes no country code, which previously left every arbitrary-SNI strategy inert):

- **`default` frontingsnis applies with no country code** → akamai sends its arbitrary SNIs (real akamai-customer domains) globally (validated: no regression vs no-SNI).
- **Baked-in per-masquerade SNI preserved** → aliyun can pin `www.mobgslb.tbcache.com`, the service domain its edges actually accept (~83%, vs ~17% for `img.alicdn.com`).
- **SNI-path cert verified against the front Domain** (not chain-only) → closes a MITM gap; doesn't break akamai (whose arbitrary SNI is a decoy the served cert doesn't cover — verified the cert is valid for the Domain).

## Validation

`go.mod` change is **only** these two deps (`go mod tidy` run; `go.mod`+`go.sum` committed together). The packages that consume domainfront — `./kindling/...` incl. `kindling/fronted` — build and test green.

> ⚠️ Note: `cmd/lantern` currently fails to build on `main` (`ipc.NewClient` signature mismatch at `cmd/lantern/lantern.go:170`). This is **pre-existing and unrelated** to this bump — it reproduces on `main` with these changes stashed. Flagging so it's not attributed to this PR; it should be fixed separately.

## Rollout

Last link: lantern bumps radiance next. Companion lantern-cloud#2897 sets aliyun's front SNI. Backward-safe (pre-bump clients omit SNI as today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a couple of bundled libraries to newer versions, which may improve stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->