### PR TITLE
fix(vpn): apply mobile memory limits on iOS only

### DIFF
--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -183,7 +183,8 @@ func (t *tunnel) init(ctx context.Context, options string, platformIfce libbox.P
 	t.closers = append(t.closers, lb)
 	t.lbService = lb
 
-	if common.IsMobile() {
+	if common.IsIOS() {
+		// only set memory limits on iOS since Android doesn't appear to apply any restrictions.
 		setMobileMemoryLimits()
 	}
 


### PR DESCRIPTION
This pull request updates the logic for setting memory limits in the `tunnel` initialization process. Now, memory limits are only set on iOS devices, rather than on all mobile platforms.

Platform-specific behavior:

* Changed the condition from `common.IsMobile()` to `common.IsIOS()` in `tunnel.go` to ensure memory limits are only applied on iOS, since Android does not enforce these restrictions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mobile memory tuning now applies only on iOS, preventing Android devices from using iOS-specific memory restrictions.
  * Improved platform handling for better behavior across mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->