### PR TITLE
Harden startup

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -102,10 +102,12 @@ type Options struct {
 // NewLocalBackend performs global initialization and returns a new LocalBackend instance.
 // It should be called once at the start of the application.
 func NewLocalBackend(ctx context.Context, opts Options) (*LocalBackend, error) {
-	// Invariant: only return IO errors (failure to read or write a file). Every
-	// other failure (e.g. parse errors from incompatible on-disk state) must be
-	// logged and degraded, never returned, so a user can always construct a
-	// backend and report an issue.
+	// Invariant: a user must always be able to construct a backend and report an
+	// issue, even when on-disk state is unreadable or incompatible (e.g. after a
+	// downgrade). Failures loading the server manager, split tunnel, and config
+	// are logged and degraded, never returned. The only fatal path is
+	// common.Init, which fails only when the data directory or settings file
+	// can't be created or read — i.e. the app genuinely cannot run.
 
 	// Must run before common.Init: it reads RADIANCE_VERSION once and
 	// freezes it, so a later Setenv is ignored by the header-fill path.

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -47,6 +47,8 @@ const tracerName = "github.com/getlantern/radiance/backend"
 
 // LocalBackend ties all the core functionality of Radiance together. It manages the configuration,
 // servers, VPN connection, account management, issue reporting, and telemetry for the application.
+//
+// A nil LocalBackend is valid for reporting issues.
 type LocalBackend struct {
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -100,6 +102,11 @@ type Options struct {
 // NewLocalBackend performs global initialization and returns a new LocalBackend instance.
 // It should be called once at the start of the application.
 func NewLocalBackend(ctx context.Context, opts Options) (*LocalBackend, error) {
+	// Invariant: only return IO errors (failure to read or write a file). Every
+	// other failure (e.g. parse errors from incompatible on-disk state) must be
+	// logged and degraded, never returned, so a user can always construct a
+	// backend and report an issue.
+
 	// Must run before common.Init: it reads RADIANCE_VERSION once and
 	// freezes it, so a later Setenv is ignored by the header-fill path.
 	var envOverrideErrs error
@@ -108,11 +115,11 @@ func NewLocalBackend(ctx context.Context, opts Options) (*LocalBackend, error) {
 			envOverrideErrs = errors.Join(envOverrideErrs, fmt.Errorf("apply env override %q: %w", k, err))
 		}
 	}
-	if envOverrideErrs != nil {
-		return nil, fmt.Errorf("failed to apply environment overrides: %w", envOverrideErrs)
-	}
 	if err := common.Init(opts.DataDir, opts.LogDir, opts.LogLevel); err != nil {
 		return nil, fmt.Errorf("failed to initialize common components: %w", err)
+	}
+	if envOverrideErrs != nil {
+		slog.Warn("Failed to apply some env overrides", "error", envOverrideErrs)
 	}
 	if opts.Locale == "" {
 		if tag, err := locale.Detect(); err != nil {
@@ -145,14 +152,14 @@ func NewLocalBackend(ctx context.Context, opts Options) (*LocalBackend, error) {
 		dataDir, slog.Default().With("service", "server_manager"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create server manager: %w", err)
+		slog.Error("Loading server manager", "error", err)
 	}
 
 	splitTunnelMgr, err := vpn.NewSplitTunnelHandler(
 		dataDir, slog.Default().With("service", "split_tunnel"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create split tunnel manager: %w", err)
+		slog.Error("Loading split tunnel handler", "error", err)
 	}
 
 	vpnClient := vpn.NewVPNClient(dataDir, slog.Default().With("service", "vpn"), opts.PlatformInterface)
@@ -335,23 +342,60 @@ func (r *LocalBackend) Sessions(limit int) []vpn.Session {
 // Issue Report //
 //////////////////
 
+type issueReportMetadata struct {
+	country            string
+	deviceID           string
+	reporter           *issue.IssueReporter
+	splitTunnelEnabled bool
+}
+
+// buildIssueReportMetadata gathers the backend state needed to file an issue
+// report. It is safe to call with a nil or partially initialized backend.
+func (r *LocalBackend) buildIssueReportMetadata() issueReportMetadata {
+	meta := issueReportMetadata{
+		country: settings.GetString(settings.CountryCodeKey),
+	}
+
+	if r == nil {
+		meta.reporter = issue.NewIssueReporter(kindling.HTTPClient())
+		return meta
+	}
+	if r.issueReporter != nil {
+		meta.reporter = r.issueReporter
+	} else {
+		meta.reporter = issue.NewIssueReporter(kindling.HTTPClient())
+	}
+	meta.deviceID = r.deviceID
+
+	// get country from the config returned by the backend
+	if r.confHandler != nil {
+		if cfg, err := r.confHandler.GetConfig(); err != nil {
+			slog.Warn("failed to get config", "error", err)
+		} else {
+			meta.country = cfg.Country
+		}
+	}
+
+	if r.splitTunnelMgr != nil {
+		meta.splitTunnelEnabled = r.splitTunnelMgr.IsEnabled()
+	}
+
+	return meta
+}
+
 // ReportIssue allows the user to report an issue with the application. It collects relevant
 // information about the user's environment such as country, device ID, user ID, subscription level,
 // and locale, and log files to include in the report.
+//
+// ReportIssue is safe to call with a nil receiver.
 func (r *LocalBackend) ReportIssue(issueType issue.IssueType, description, email string, additionalAttachments []string, attachments []*issue.Attachment) error {
 	ctx, span := otel.Tracer(tracerName).Start(context.Background(), "report_issue")
 	defer span.End()
-	// get country from the config returned by the backend
-	var country string
-	cfg, err := r.confHandler.GetConfig()
-	if err != nil {
-		slog.Warn("Failed to get config", "error", err)
-	} else {
-		country = cfg.Country
-	}
+
+	meta := r.buildIssueReportMetadata()
 
 	attachmentPaths := baseIssueAttachments()
-	if r.splitTunnelMgr.IsEnabled() {
+	if meta.splitTunnelEnabled {
 		attachmentPaths = append(attachmentPaths, filepath.Join(settings.GetString(settings.DataPathKey), internal.SplitTunnelFileName))
 	}
 	attachmentPaths = append(attachmentPaths, additionalAttachments...)
@@ -360,16 +404,15 @@ func (r *LocalBackend) ReportIssue(issueType issue.IssueType, description, email
 		Type:                  issueType,
 		Description:           description,
 		Email:                 email,
-		CountryCode:           country,
-		DeviceID:              r.deviceID,
+		CountryCode:           meta.country,
+		DeviceID:              meta.deviceID,
 		UserID:                settings.GetString(settings.UserIDKey),
 		SubscriptionLevel:     settings.GetString(settings.UserLevelKey),
 		Locale:                settings.GetString(settings.LocaleKey),
 		Attachments:           attachments,
 		AdditionalAttachments: attachmentPaths,
 	}
-	err = r.issueReporter.Report(ctx, report)
-	if err != nil {
+	if err := meta.reporter.Report(ctx, report); err != nil {
 		slog.Error("Failed to report issue", "error", err)
 		return traces.RecordError(ctx, fmt.Errorf("failed to report issue: %w", err))
 	}

--- a/backend/radiance_test.go
+++ b/backend/radiance_test.go
@@ -1,6 +1,9 @@
 package backend
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -8,8 +11,37 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/getlantern/radiance/internal"
 	"github.com/getlantern/radiance/servers"
 )
+
+// TestNewLocalBackendToleratesInvalidOnDiskState guards the init hardening:
+// invalid-but-readable on-disk state must not make NewLocalBackend fatal, so a
+// user can always report an issue. Every fixture is readable, so a returned
+// error can only come from parsing — a non-IO failure that must stay non-fatal.
+func TestNewLocalBackendToleratesInvalidOnDiskState(t *testing.T) {
+	dataDir := t.TempDir()
+	logDir := t.TempDir()
+	// setupDirectories honors these env vars over the Options paths; pin them so
+	// the resolved data dir is exactly where the invalid files are staged.
+	t.Setenv("RADIANCE_DATA_PATH", dataDir)
+	t.Setenv("RADIANCE_LOG_PATH", logDir)
+
+	invalidFiles := map[string][]byte{
+		"settings.json":              []byte(`{invalid json}`),
+		internal.ConfigFileName:      []byte(`{"options":{"outbounds":[{"type":"future-proto"}]}}`),
+		internal.ServersFileName:     []byte(`[{"tag":"bad","type":"future-proto","outbound":{"tag":"bad","type":"future-proto"}}]`),
+		internal.SplitTunnelFileName: []byte(`{"version":3,"rules":[{"unknown_field":true}]}`),
+	}
+	for name, content := range invalidFiles {
+		require.NoError(t, os.WriteFile(filepath.Join(dataDir, name), content, 0o600))
+	}
+
+	backend, err := NewLocalBackend(context.Background(), Options{DataDir: dataDir, LogDir: logDir, LogLevel: "error"})
+	require.NoError(t, err, "invalid but readable on-disk state must not make initialization fatal")
+	require.NotNil(t, backend)
+	t.Cleanup(backend.Close)
+}
 
 func TestExhaustionGate_AllowRateLimitsBelowGap(t *testing.T) {
 	prev := defaultExhaustionRefetchGap

--- a/common/settings/settings.go
+++ b/common/settings/settings.go
@@ -108,21 +108,24 @@ func InitSettings(fileDir string) error {
 	}
 	k.filePath = filepath.Join(fileDir, settingsFileName)
 	migrateLegacySettingsIfNeeded(fileDir, k.filePath)
-	k.initialized = true
 	switch err := loadSettings(k.filePath); {
 	case errors.Is(err, fs.ErrNotExist):
 		slog.Warn("settings file not found", "path", k.filePath) // file may not have been created yet
-		return save()
+		if err := save(); err != nil {
+			return err
+		}
 	case errors.Is(err, errParseSettings):
 		// An invalid settings file must not be fatal: quarantine it, then start
 		// from in-memory defaults and overwrite the bad file with them.
 		slog.Error("Settings file is invalid; starting from defaults", "path", k.filePath, "error", err)
 		quarantineInvalidSettings(k.filePath)
-		return save()
+		if err := save(); err != nil {
+			return err
+		}
 	case err != nil:
-		k.initialized = false
 		return fmt.Errorf("loading settings: %w", err)
 	}
+	k.initialized = true
 	return nil
 }
 

--- a/common/settings/settings.go
+++ b/common/settings/settings.go
@@ -66,9 +66,16 @@ const (
 	// migrateLegacySettingsIfNeeded reads it from there so Pro state
 	// survives the rename.
 	legacySettingsFileName = "local.json"
+
+	settingsInvalidFileName = "settings.invalid.json"
 )
 
 var ErrNotExist = errors.New("key does not exist")
+
+// errParseSettings marks a settings file that exists but isn't valid JSON. It
+// distinguishes a recoverable invalid file (quarantine + start from defaults)
+// from a genuine read failure, which stays fatal.
+var errParseSettings = errors.New("settings file is not valid JSON")
 
 func (k _key) String() string { return string(k) }
 
@@ -101,14 +108,21 @@ func InitSettings(fileDir string) error {
 	}
 	k.filePath = filepath.Join(fileDir, settingsFileName)
 	migrateLegacySettingsIfNeeded(fileDir, k.filePath)
+	k.initialized = true
 	switch err := loadSettings(k.filePath); {
 	case errors.Is(err, fs.ErrNotExist):
 		slog.Warn("settings file not found", "path", k.filePath) // file may not have been created yet
 		return save()
+	case errors.Is(err, errParseSettings):
+		// An invalid settings file must not be fatal: quarantine it, then start
+		// from in-memory defaults and overwrite the bad file with them.
+		slog.Error("Settings file is invalid; starting from defaults", "path", k.filePath, "error", err)
+		quarantineInvalidSettings(k.filePath)
+		return save()
 	case err != nil:
+		k.initialized = false
 		return fmt.Errorf("loading settings: %w", err)
 	}
-	k.initialized = true
 	return nil
 }
 
@@ -254,10 +268,27 @@ func loadSettings(path string) error {
 	}
 	kk := koanf.New(".")
 	if err := kk.Load(rawbytes.Provider(contents), json.Parser()); err != nil {
-		return fmt.Errorf("parsing settings: %w", err)
+		return fmt.Errorf("parsing settings: %w", errors.Join(errParseSettings, err))
 	}
 	k.k = kk
 	return nil
+}
+
+// quarantineInvalidSettings copies an invalid settings file aside to
+// settings.invalid.json so a fresh default file can replace it in place while
+// the original remains available for diagnostics.
+func quarantineInvalidSettings(path string) {
+	rawSettings, err := atomicfile.ReadFile(path)
+	if err != nil {
+		slog.Error("reading invalid settings for quarantine", "path", path, "error", err)
+		return
+	}
+	invalidPath := filepath.Join(filepath.Dir(path), settingsInvalidFileName)
+	if err := atomicfile.WriteFile(invalidPath, rawSettings, fileperm.File); err != nil {
+		slog.Error("writing invalid settings copy", "path", invalidPath, "error", err)
+		return
+	}
+	slog.Warn("quarantined invalid settings for diagnostics", "path", invalidPath)
 }
 
 func Get(key _key) any {

--- a/common/settings/settings_test.go
+++ b/common/settings/settings_test.go
@@ -105,6 +105,20 @@ func TestInitSettings(t *testing.T) {
 		require.NoError(t, os.WriteFile(path, content, 0644), "failed to create test config file")
 		require.Error(t, loadSettings(path), "expected error for invalid config file")
 	})
+
+	t.Run("invalid config file recovers", func(t *testing.T) {
+		Reset()
+		t.Cleanup(Reset)
+		tempDir := t.TempDir()
+		path := filepath.Join(tempDir, settingsFileName)
+		require.NoError(t, os.WriteFile(path, []byte(`{invalid json}`), 0644))
+
+		require.NoError(t, InitSettings(tempDir), "an invalid settings file must not block initialization")
+
+		invalidPath := filepath.Join(tempDir, settingsInvalidFileName)
+		assert.FileExists(t, invalidPath, "the invalid file must be preserved for diagnostics")
+		assert.NoError(t, loadSettings(path), "settings.json must be rewritten with a parseable default")
+	})
 }
 
 func TestMigrateLegacySettingsIfNeeded(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -391,7 +391,8 @@ func load(path string) (*Config, error) {
 	}
 
 	// try to migrate from old format if parsing fails
-	// TODO(3/06, garmr-ulfr): remove this migration code after a few releases
+	// TODO: remove this migration once the old config format no longer appears
+	// on disk in the field.
 	if migrated, mErr := migrateToNewFmt(rawConfig); mErr == nil {
 		saveConfig(migrated, path)
 		return migrated, nil
@@ -401,6 +402,8 @@ func load(path string) (*Config, error) {
 	// sing-box can't decode a newer on-disk config. Quarantine it so it stops
 	// re-failing on every start and is preserved for diagnostics, then start
 	// with no config; the next successful fetch repopulates config.json.
+	slog.Warn("config file is invalid; quarantining and starting without a config",
+		"path", path, "error", err)
 	quarantineInvalidConfig(path, rawConfig)
 	return nil, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -394,7 +394,9 @@ func load(path string) (*Config, error) {
 	// TODO: remove this migration once the old config format no longer appears
 	// on disk in the field.
 	if migrated, mErr := migrateToNewFmt(rawConfig); mErr == nil {
-		saveConfig(migrated, path)
+		if err := saveConfig(migrated, path); err != nil {
+			return nil, fmt.Errorf("saving migrated config: %w", err)
+		}
 		return migrated, nil
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -377,7 +377,7 @@ func (ch *ConfigHandler) loadConfig() error {
 }
 
 func load(path string) (*Config, error) {
-	buf, err := atomicfile.ReadFile(path)
+	rawConfig, err := atomicfile.ReadFile(path)
 	if errors.Is(err, fs.ErrNotExist) {
 		return nil, nil // No config file yet
 	}
@@ -385,18 +385,41 @@ func load(path string) (*Config, error) {
 		return nil, fmt.Errorf("reading config file: %w", err)
 	}
 	ctx := box.BaseContext()
-	cfg, err := singjson.UnmarshalExtendedContext[*Config](ctx, buf)
-	if err != nil {
-		// try to migrate from old format if parsing fails
-		// TODO(3/06, garmr-ulfr): remove this migration code after a few releases
-		if cfg, err = migrateToNewFmt(buf); err == nil {
-			saveConfig(cfg, path)
-		}
+	cfg, err := singjson.UnmarshalExtendedContext[*Config](ctx, rawConfig)
+	if err == nil {
+		return cfg, nil
 	}
-	if err != nil {
-		return nil, fmt.Errorf("parsing config: %w", err)
+
+	// try to migrate from old format if parsing fails
+	// TODO(3/06, garmr-ulfr): remove this migration code after a few releases
+	if migrated, mErr := migrateToNewFmt(rawConfig); mErr == nil {
+		saveConfig(migrated, path)
+		return migrated, nil
 	}
-	return cfg, nil
+
+	// The config is unparseable — most likely a downgrade where this build's
+	// sing-box can't decode a newer on-disk config. Quarantine it so it stops
+	// re-failing on every start and is preserved for diagnostics, then start
+	// with no config; the next successful fetch repopulates config.json.
+	quarantineInvalidConfig(path, rawConfig)
+	return nil, nil
+}
+
+// quarantineInvalidConfig moves an unparseable config aside to
+// config.invalid.json so it no longer blocks loading on subsequent starts while
+// remaining available for diagnostics.
+func quarantineInvalidConfig(path string, buf []byte) {
+	invalidPath := filepath.Join(filepath.Dir(path), internal.ConfigInvalidFileName)
+	if err := atomicfile.WriteFile(invalidPath, buf, fileperm.File); err != nil {
+		// Keep the original in place when the copy fails so the unparseable
+		// config isn't lost entirely; the next fetch overwrites it regardless.
+		slog.Error("writing invalid config copy; leaving original in place", "path", invalidPath, "error", err)
+		return
+	}
+	slog.Warn("quarantined unparseable config for diagnostics", "path", invalidPath)
+	if err := os.Remove(path); err != nil {
+		slog.Error("removing unparseable config file", "path", path, "error", err)
+	}
 }
 
 func migrateToNewFmt(data []byte) (*Config, error) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -46,6 +46,23 @@ func TestSaveConfig(t *testing.T) {
 	// Verify the content matches the expected config
 	assert.Equal(t, expectedConfig, actualConfig, "Saved config should match the expected config")
 }
+func TestLoadQuarantinesUnparseableConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, internal.ConfigFileName)
+	// An outbound type this build's sing-box can't decode — the shape a
+	// downgrade leaves behind.
+	require.NoError(t, os.WriteFile(configPath,
+		[]byte(`{"options":{"outbounds":[{"tag":"x","type":"future-proto"}]}}`), 0o600))
+
+	cfg, err := load(configPath)
+	require.NoError(t, err, "unparseable config must not be a fatal error")
+	assert.Nil(t, cfg, "no config should be returned for an unparseable file")
+
+	assert.NoFileExists(t, configPath, "unparseable config.json should be moved aside")
+	invalidPath := filepath.Join(tempDir, internal.ConfigInvalidFileName)
+	assert.FileExists(t, invalidPath, "unparseable config should be quarantined for diagnostics")
+}
+
 func TestGetConfig(t *testing.T) {
 	// Setup temporary directory for testing
 	tempDir := t.TempDir()

--- a/config/fetcher_test.go
+++ b/config/fetcher_test.go
@@ -19,6 +19,8 @@ import (
 
 func TestFetchConfig(t *testing.T) {
 	settings.InitSettings(t.TempDir())
+	defer settings.Reset()
+
 	settings.Set(settings.DeviceIDKey, "mock-device-id")
 	settings.Set(settings.UserIDKey, 1234567890)
 	settings.Set(settings.TokenKey, "mock-legacy-token")
@@ -119,9 +121,11 @@ func TestUserIDFormatMatchesMain(t *testing.T) {
 		{name: "small id", set: true, value: 42, expect: "42"},
 		{name: "large id (exercises float64 JSON round-trip)", set: true, value: 1234567890, expect: "1234567890"},
 	}
+	require.NoError(t, settings.InitSettings(t.TempDir()))
+	defer settings.Reset()
+
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			require.NoError(t, settings.InitSettings(t.TempDir()))
 			settings.Clear(settings.UserIDKey)
 			if tc.set {
 				require.NoError(t, settings.Set(settings.UserIDKey, tc.value))

--- a/internal/paths.go
+++ b/internal/paths.go
@@ -7,12 +7,15 @@ import (
 )
 
 const (
-	DebugBoxOptionsFileName = "debug-box-options.json"
-	ConfigFileName          = "config.json"
-	ServersFileName         = "servers.json"
-	SplitTunnelFileName     = "split-tunnel.json"
-	LogFileName             = "lantern.log"
-	CrashLogFileName        = "lantern-crash.log"
+	DebugBoxOptionsFileName    = "debug-box-options.json"
+	ConfigFileName             = "config.json"
+	ConfigInvalidFileName      = "config.invalid.json"
+	ServersFileName            = "servers.json"
+	ServersInvalidFileName     = "servers.invalid.json"
+	SplitTunnelFileName        = "split-tunnel.json"
+	SplitTunnelInvalidFileName = "split-tunnel.invalid.json"
+	LogFileName                = "lantern.log"
+	CrashLogFileName           = "lantern-crash.log"
 )
 
 func DefaultDataPath() string {

--- a/servers/manager.go
+++ b/servers/manager.go
@@ -6,6 +6,7 @@ package servers
 import (
 	"bytes"
 	"context"
+	stdjson "encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -213,6 +214,11 @@ type Manager struct {
 }
 
 // NewManager creates a new Manager instance, loading server options from disk.
+//
+// The returned Manager is always usable, even when the error is non-nil:
+// loadServers salvages every parseable server, so a partial load (e.g. an
+// on-disk entry this build can't decode after a downgrade) yields a working
+// Manager plus an error describing what was dropped.
 func NewManager(dataPath string, logger *slog.Logger) (*Manager, error) {
 	mgr := &Manager{
 		servers:     make(map[string]*Server),
@@ -225,8 +231,7 @@ func NewManager(dataPath string, logger *slog.Logger) (*Manager, error) {
 
 	mgr.logger.Debug("Loading servers", "file", mgr.serversFile)
 	if err := mgr.loadServers(); err != nil {
-		mgr.logger.Error("Failed to load servers", "file", mgr.serversFile, "error", err)
-		return nil, fmt.Errorf("failed to load servers from file: %w", err)
+		return mgr, fmt.Errorf("failed to load servers from file: %w", err)
 	}
 	mgr.logger.Log(nil, log.LevelTrace, "Loaded servers")
 	return mgr, nil
@@ -458,29 +463,71 @@ const (
 	modeUser    = "user"
 )
 
+// loadServers reads servers.json into the in-memory map, salvaging every
+// parseable entry. A single unparseable server — e.g. an outbound type or option
+// field this build's sing-box doesn't recognize after a version downgrade — is
+// skipped rather than discarding the whole file.
+//
+// It returns a non-nil error enumerating any skipped entries (or a wholly
+// unparseable file); the in-memory state is still valid when it does.
 func (m *Manager) loadServers() error {
-	buf, err := atomicfile.ReadFile(m.serversFile)
+	rawServersFile, err := atomicfile.ReadFile(m.serversFile)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil // file doesn't exist
 	}
 	if err != nil {
-		return fmt.Errorf("read server file %q: %w", m.serversFile, err)
+		return fmt.Errorf("read servers file %q: %w", m.serversFile, err)
 	}
-	buf = bytes.TrimSpace(buf)
-	ctx := box.BaseContext()
-
-	if len(buf) > 0 && buf[0] == '[' {
-		loaded, err := json.UnmarshalExtendedContext[[]*Server](ctx, buf)
-		if err != nil {
-			return fmt.Errorf("unmarshal servers: %w", err)
-		}
-		for _, srv := range loaded {
-			m.servers[srv.Tag] = srv
-		}
+	rawServersFile = bytes.TrimSpace(rawServersFile)
+	if len(rawServersFile) == 0 {
 		return nil
 	}
 
-	// Fall back to old format: map[string]Options and mirgrate to new format on save.
+	if rawServersFile[0] == '[' {
+		return m.loadServerList(rawServersFile)
+	}
+
+	return m.loadOldFormat(rawServersFile)
+}
+
+// loadServerList handles the current array-based on-disk format and salvages
+// every entry that can still be decoded by this build.
+func (m *Manager) loadServerList(buf []byte) error {
+	var rawServers []stdjson.RawMessage
+	if err := stdjson.Unmarshal(buf, &rawServers); err != nil {
+		m.quarantineInvalidServers(buf)
+		return fmt.Errorf("servers file is not a valid JSON array: %w", err)
+	}
+
+	var skippedErrors []error
+	for _, rawServer := range rawServers {
+		srv := new(Server)
+		if err := srv.UnmarshalJSON(rawServer); err != nil {
+			skippedErrors = append(skippedErrors, fmt.Errorf("server %q: %w", serverTag(rawServer), err))
+			continue
+		}
+		m.servers[srv.Tag] = srv
+	}
+
+	if len(skippedErrors) > 0 {
+		m.quarantineInvalidServers(buf)
+		return fmt.Errorf("skipped %d of %d server(s): %w",
+			len(skippedErrors), len(rawServers), errors.Join(skippedErrors...))
+	}
+
+	return nil
+}
+
+// loadOldFormat handles the legacy map[string]Options layout and migrates it to
+// the current format on the next save. Unlike the array path it does not salvage
+// per-element: a downgrade-incompatible entry fails the whole map, in which case
+// the file is quarantined and the map is left empty. This is acceptable because
+// the old format predates the types that introduce downgrade hazards and is
+// being phased out.
+//
+// TODO: remove once the legacy map layout no longer appears on disk in the field.
+func (m *Manager) loadOldFormat(buf []byte) error {
+	ctx := box.BaseContext()
 	type oldOptions struct {
 		Outbounds   []option.Outbound            `json:"outbounds,omitempty"`
 		Endpoints   []option.Endpoint            `json:"endpoints,omitempty"`
@@ -489,7 +536,8 @@ func (m *Manager) loadServers() error {
 	}
 	old, err := json.UnmarshalExtendedContext[map[string]oldOptions](ctx, buf)
 	if err != nil {
-		return fmt.Errorf("unmarshal server options: %w", err)
+		m.quarantineInvalidServers(buf)
+		return fmt.Errorf("unmarshal legacy server options: %w", err)
 	}
 	for group, opts := range old {
 		isLantern := group == modeLantern
@@ -514,8 +562,36 @@ func (m *Manager) loadServers() error {
 			m.servers[ep.Tag] = srv
 		}
 	}
-	// Re-save in new format
-	return m.saveServers()
+	if err := m.saveServers(); err != nil {
+		return fmt.Errorf("re-saving migrated servers in new format: %w", err)
+	}
+	return nil
+}
+
+// serverTag extracts just the tag from a raw server entry to label the
+// skipped-entry error when the full entry failed to parse. Returns
+// "<unknown>" if even the tag is unreadable.
+func serverTag(raw []byte) string {
+	var tag struct {
+		Tag string `json:"tag"`
+	}
+	_ = stdjson.Unmarshal(raw, &tag)
+	if tag.Tag == "" {
+		return "<unknown>"
+	}
+	return tag.Tag
+}
+
+// quarantineInvalidServers copies the unparseable servers file aside for
+// diagnostics. servers.json is intentionally left in place so entries skipped
+// by this build remain available to a later re-upgrade.
+func (m *Manager) quarantineInvalidServers(buf []byte) {
+	invalidPath := filepath.Join(filepath.Dir(m.serversFile), internal.ServersInvalidFileName)
+	if err := atomicfile.WriteFile(invalidPath, buf, fileperm.File); err != nil {
+		m.logger.Error("Writing invalid servers copy", "path", invalidPath, "error", err)
+		return
+	}
+	m.logger.Warn("Preserved unparseable servers file for diagnostics", "path", invalidPath)
 }
 
 // Lantern Server Manager Integration

--- a/servers/manager_test.go
+++ b/servers/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -274,6 +275,82 @@ func TestRetryableHTTPClient(t *testing.T) {
 	resp, err := cli.Do(request)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+// validServerJSON returns the on-wire JSON for a parseable shadowsocks server
+// with the given tag.
+func validServerJSON(t *testing.T, tag string) []byte {
+	t.Helper()
+	srv := &Server{
+		Tag:  tag,
+		Type: "shadowsocks",
+		Options: option.Outbound{
+			Tag:  tag,
+			Type: "shadowsocks",
+			Options: &option.ShadowsocksOutboundOptions{
+				ServerOptions: option.ServerOptions{Server: "9.9.9.9", ServerPort: 443},
+				Method:        "chacha20-ietf-poly1305",
+				Password:      "pw",
+			},
+		},
+	}
+	b, err := srv.MarshalJSON()
+	require.NoError(t, err)
+	return b
+}
+
+func TestLoadServersSalvagesParseableEntries(t *testing.T) {
+	mgr := testManager(t)
+	// One valid entry and one whose outbound type this build can't decode (the
+	// shape a downgrade produces). The invalidServerJSON entry must not discard the good one.
+	invalidServerJSON := []byte(`{"tag":"bad","type":"future-proto","outbound":{"tag":"bad","type":"future-proto"}}`)
+	serverJSON := []byte("[" + string(validServerJSON(t, "good")) + "," + string(invalidServerJSON) + "]")
+	require.NoError(t, os.WriteFile(mgr.serversFile, serverJSON, 0o600))
+
+	err := mgr.loadServers()
+	require.Error(t, err, "skipped entries must be reported to the caller")
+	assert.Contains(t, err.Error(), "skipped 1 of 2")
+
+	_, found := mgr.GetServerByTag("good")
+	assert.True(t, found, "parseable server must be loaded")
+	_, found = mgr.GetServerByTag("bad")
+	assert.False(t, found, "unparseable server must be skipped")
+
+	invalidPath := filepath.Join(filepath.Dir(mgr.serversFile), internal.ServersInvalidFileName)
+	assert.FileExists(t, invalidPath, "skipped entries must be preserved for diagnostics")
+	assert.FileExists(t, mgr.serversFile, "servers.json must be left in place for re-upgrade")
+}
+
+func TestLoadServersMalformedListStartsEmpty(t *testing.T) {
+	mgr := testManager(t)
+	require.NoError(t, os.WriteFile(mgr.serversFile, []byte("[ this is not json"), 0o600))
+
+	require.Error(t, mgr.loadServers(), "a malformed file must be reported to the caller")
+	assert.Empty(t, mgr.AllServers(), "no servers should be loaded from a malformed file")
+
+	invalidPath := filepath.Join(filepath.Dir(mgr.serversFile), internal.ServersInvalidFileName)
+	assert.FileExists(t, invalidPath, "malformed file must be quarantined for diagnostics")
+}
+
+func TestLoadServersMissingFileIsClean(t *testing.T) {
+	mgr := testManager(t)
+	require.NoError(t, mgr.loadServers(), "a missing servers file is not an error")
+	assert.Empty(t, mgr.AllServers())
+	invalidPath := filepath.Join(filepath.Dir(mgr.serversFile), internal.ServersInvalidFileName)
+	assert.NoFileExists(t, invalidPath, "nothing to quarantine when there is no file")
+}
+
+func TestNewManagerReturnsUsableManagerOnLoadError(t *testing.T) {
+	dataDir := t.TempDir()
+	invalidServerJSON := []byte(`{"tag":"bad","type":"future-proto","outbound":{"tag":"bad","type":"future-proto"}}`)
+	serverJSON := []byte("[" + string(validServerJSON(t, "good")) + "," + string(invalidServerJSON) + "]")
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, internal.ServersFileName), serverJSON, 0o600))
+
+	mgr, err := NewManager(dataDir, log.NoOpLogger())
+	require.Error(t, err, "a partial load must surface an error")
+	require.NotNil(t, mgr, "manager must be usable despite the load error")
+	_, found := mgr.GetServerByTag("good")
+	assert.True(t, found, "salvaged server must be available from the returned manager")
 }
 
 func testManager(t *testing.T) *Manager {

--- a/vpn/split_tunnel.go
+++ b/vpn/split_tunnel.go
@@ -38,10 +38,17 @@ type SplitTunnel struct {
 	logger       *slog.Logger
 }
 
+// NewSplitTunnelHandler creates a SplitTunnel handler, loading the saved rule
+// set from disk.
+//
+// The returned handler is always usable, even when the error is non-nil: an
+// unreadable or unparseable rule file — e.g. one this build's sing-box can't
+// decode after a version downgrade — falls back to the default no-op rule,
+// yielding a working handler plus an error describing the failure.
 func NewSplitTunnelHandler(dataPath string, logger *slog.Logger) (*SplitTunnel, error) {
 	s := newSplitTunnel(dataPath, logger)
 	if err := s.loadRule(); err != nil {
-		return nil, fmt.Errorf("loading split tunnel rule file %s: %w", s.ruleFile, err)
+		return s, fmt.Errorf("loading split tunnel rule file %s: %w", s.ruleFile, err)
 	}
 	return s, nil
 }
@@ -262,13 +269,14 @@ func isEmptyRule(rule O.DefaultHeadlessRule) bool {
 }
 
 func (s *SplitTunnel) loadRule() error {
-	content, err := atomicfile.ReadFile(s.ruleFile)
+	rawRuleSet, err := atomicfile.ReadFile(s.ruleFile)
 	// the file should exist at this point, so we don't need to check for fs.ErrNotExist
 	if err != nil {
 		return fmt.Errorf("reading rule file %s: %w", s.ruleFile, err)
 	}
-	ruleSet, err := json.UnmarshalExtended[O.PlainRuleSetCompat](content)
+	ruleSet, err := json.UnmarshalExtended[O.PlainRuleSetCompat](rawRuleSet)
 	if err != nil {
+		s.quarantineInvalidRuleSet(rawRuleSet)
 		return fmt.Errorf("unmarshalling rule file %s: %w", s.ruleFile, err)
 	}
 	rules := ruleSet.Options.Rules
@@ -353,6 +361,18 @@ func (s *SplitTunnel) loadRule() error {
 		"file", s.ruleFile, "filters", s.Filters().String(), "enabled", s.IsEnabled(),
 	)
 	return nil
+}
+
+// quarantineInvalidRuleSet copies the unparseable rule file aside to
+// split-tunnel.invalid.json for diagnostics. The original is left in place so a
+// later re-upgrade can still read rules this build couldn't.
+func (s *SplitTunnel) quarantineInvalidRuleSet(content []byte) {
+	invalidPath := filepath.Join(filepath.Dir(s.ruleFile), internal.SplitTunnelInvalidFileName)
+	if err := atomicfile.WriteFile(invalidPath, content, fileperm.File); err != nil {
+		s.logger.Error("Writing invalid split tunnel copy", "path", invalidPath, "error", err)
+		return
+	}
+	s.logger.Warn("Preserved unparseable split tunnel file for diagnostics", "path", invalidPath)
 }
 
 func defaultRule() O.LogicalHeadlessRule {

--- a/vpn/split_tunnel_test.go
+++ b/vpn/split_tunnel_test.go
@@ -4,6 +4,7 @@ package vpn
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -18,8 +19,30 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/getlantern/radiance/common/atomicfile"
+	"github.com/getlantern/radiance/internal"
 	rlog "github.com/getlantern/radiance/log"
 )
+
+func TestNewSplitTunnelHandlerQuarantinesInvalidRuleFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	ruleFile := filepath.Join(tmpDir, internal.SplitTunnelFileName)
+	// A rule file this build's sing-box can't decode — the shape a downgrade
+	// leaves behind. Staged before construction so newSplitTunnel won't replace it.
+	require.NoError(t, atomicfile.WriteFile(ruleFile,
+		[]byte(`{"version":3,"rules":[{"unknown_field":true}]}`), 0o600))
+
+	st, err := NewSplitTunnelHandler(tmpDir, rlog.NoOpLogger())
+	require.Error(t, err, "an unparseable rule file must be reported to the caller")
+	require.NotNil(t, st, "handler must be usable despite the load error")
+
+	// Falls back to the default no-op rule.
+	assert.Empty(t, st.Filters().Domain)
+	assert.False(t, st.IsEnabled())
+
+	invalidPath := filepath.Join(tmpDir, internal.SplitTunnelInvalidFileName)
+	assert.FileExists(t, invalidPath, "the unparseable file must be preserved for diagnostics")
+	assert.FileExists(t, ruleFile, "split-tunnel.json must be left in place for re-upgrade")
+}
 
 func TestEnableDisableIsEnabled(t *testing.T) {
 	st := newSplitTunnel(t.TempDir(), rlog.NoOpLogger())


### PR DESCRIPTION
This pull request improves the robustness of initialization and issue reporting in the backend, ensuring that invalid or unparseable on-disk state (such as corrupted or downgraded config and settings files) never blocks startup or prevents users from reporting issues. Instead of fatal errors, such files are quarantined for diagnostics and the application continues with defaults. The changes also add comprehensive tests for these behaviors.

**Initialization hardening and error handling:**

- The backend now tolerates invalid but readable on-disk state (e.g., corrupted or downgraded `settings.json`, `config.json`, `servers.json`, `split-tunnel.json`), logging errors and quarantining unparseable files instead of failing to start. This guarantees users can always report issues even after failed upgrades or file corruption. [[1]](diffhunk://#diff-d7a5115ab346da59601a056266b297ad60b2db8ce5434ba7cd67023d47d5097bR105-R109) [[2]](diffhunk://#diff-d7a5115ab346da59601a056266b297ad60b2db8ce5434ba7cd67023d47d5097bL111-R123) [[3]](diffhunk://#diff-d7a5115ab346da59601a056266b297ad60b2db8ce5434ba7cd67023d47d5097bL148-R162) [[4]](diffhunk://#diff-06faddd10552eb57bc69081e8049bc00777c9fce3f5c2973a1f909bff4480cefR111-L111) [[5]](diffhunk://#diff-06faddd10552eb57bc69081e8049bc00777c9fce3f5c2973a1f909bff4480cefL257-R293) [[6]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L380-L399) [[7]](diffhunk://#diff-b55eb9cf9656297ea718f5d3345b5d9f2454a1a5cef82ec17a39b477db8f148dR217-R221) [[8]](diffhunk://#diff-b55eb9cf9656297ea718f5d3345b5d9f2454a1a5cef82ec17a39b477db8f148dL228-R234)

- Quarantine logic is added for all key files: invalid files are copied aside as `.invalid.json` variants (e.g., `settings.invalid.json`, `config.invalid.json`) for diagnostics, and the application starts with defaults. [[1]](diffhunk://#diff-06faddd10552eb57bc69081e8049bc00777c9fce3f5c2973a1f909bff4480cefL257-R293) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L380-L399) [[3]](diffhunk://#diff-4d1fba65007b20239762f11c93153d024610ed2e65e4e6b1d28b5169e85c5b53R12-R16)

**Issue reporting improvements:**

- `LocalBackend` and `ReportIssue` are now safe to call with a nil or partially initialized backend, ensuring issue reporting always works. Metadata gathering for issue reports is refactored for safety and clarity. [[1]](diffhunk://#diff-d7a5115ab346da59601a056266b297ad60b2db8ce5434ba7cd67023d47d5097bR50-R51) [[2]](diffhunk://#diff-d7a5115ab346da59601a056266b297ad60b2db8ce5434ba7cd67023d47d5097bR345-R398) [[3]](diffhunk://#diff-d7a5115ab346da59601a056266b297ad60b2db8ce5434ba7cd67023d47d5097bL363-R415)

**Testing and validation:**

- New and updated tests verify that initialization recovers gracefully from invalid on-disk state and that invalid files are properly quarantined for diagnostics. [[1]](diffhunk://#diff-112a98aad994c74638c3bd13f96c82b1da080d909116a97df72d70401c6f70a2R4-R45) [[2]](diffhunk://#diff-99115065f7ef376df8c5d702cae970fe85f34ff846e4059fb73068a244c1a4bcR108-R121) [[3]](diffhunk://#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82R49-R65)

**Minor test hygiene:**

- Some tests now ensure settings state is reset and cleaned up between runs. [[1]](diffhunk://#diff-7ba16797e42350c53b41e8b4cab7b67d7922c2ff020cf022e2c2b08566fe08daR22-R23) [[2]](diffhunk://#diff-7ba16797e42350c53b41e8b4cab7b67d7922c2ff020cf022e2c2b08566fe08daR124-L124)

closes getlantern/engineering/issues/3298

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * App startup is now more resilient when saved settings, config, server list, or split-tunnel rules are invalid.
  * Problem files are preserved in a separate “invalid” copy for diagnostics, while the app can still start with available valid data.
  * Partial data in server lists is now salvaged when possible instead of blocking all server loading.
  * Issue reports now work more reliably even when backend state is only partially initialized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->