### PR TITLE
Fix IPv6 fake-IP routing for dual-stack DNS

### DIFF
--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -245,8 +245,7 @@ func baseRoutingRules() []O.Rule {
 	//       here so split-tunnel, smart-routed, and config-routed direct paths keep
 	//       their QUIC. Added in buildOptions.
 	// 8.    Reject IPv6 (::/0), only when the TUN captured a v6 address; placed here so
-	//       direct-routed v6 is preserved while non-fake-IP proxied v6 fails fast. Added
-	//       in buildOptions.
+	//       direct-routed v6 is preserved while remaining IPv6 fails fast. Added in buildOptions.
 	// 9,10. Group rules for auto and manual selector modes (added in buildOptions).
 	// 11.   Catch-all blocking rule (added in buildOptions). Traffic not covered
 	//       by previous rules must not automatically bypass the VPN.
@@ -374,9 +373,8 @@ func rejectQUICRule() O.Rule {
 	}
 }
 
-// rejectIPv6Rule rejects non-fake-IP IPv6 destinations as a backstop for
-// literals, HTTPS-record hints, or apps using their own DNS. The default reject
-// method fails fast; "drop" would blackhole and stall.
+// rejectIPv6Rule rejects IPv6 destinations that reach this late in route order.
+// The default reject method fails fast; "drop" would blackhole and stall.
 func rejectIPv6Rule() O.Rule {
 	return O.Rule{
 		Type: C.RuleTypeDefault,

--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -234,7 +234,7 @@ func hasTunInbound(inbounds []O.Inbound) bool {
 func baseRoutingRules() []O.Rule {
 	// routing rules are evaluated in the order they are defined and the first matching rule
 	// is applied. So order is important here.
-	// The rules MUST be in this order to ensure proper functionality:
+	// The rules MUST be in this order for proper behavior:
 	// 1.    Enable traffic sniffing
 	// 2.    Hijack DNS to allow sing-box to handle DNS requests
 	// 3.    Route bypass proxy traffic directly (for kindling connections)
@@ -244,12 +244,12 @@ func baseRoutingRules() []O.Rule {
 	// 7.    Reject QUIC (UDP/443) for any UDP/443 not already matched above; placed
 	//       here so split-tunnel, smart-routed, and config-routed direct paths keep
 	//       their QUIC. Added in buildOptions.
-	// 8.    Reject IPv6 (::/0), only when the TUN captured a v6 address; placed here
-	//       so direct-routed v6 is preserved while proxied v6 fails over to IPv4. Added
-	//	      in buildOptions.
+	// 8.    Reject IPv6 (::/0), only when the TUN captured a v6 address; placed here so
+	//       direct-routed v6 is preserved while non-fake-IP proxied v6 fails fast. Added
+	//       in buildOptions.
 	// 9,10. Group rules for auto and manual selector modes (added in buildOptions).
-	// 11.   Catch-all blocking rule (added in buildOptions). This ensures that any traffic not covered
-	//       by previous rules does not automatically bypass the VPN.
+	// 11.   Catch-all blocking rule (added in buildOptions). Traffic not covered
+	//       by previous rules must not automatically bypass the VPN.
 	//
 	// * DO NOT change the order of these rules unless you know what you're doing. Changing these
 	//   rules or their order can break certain functionalities like DNS resolution, smart connect,
@@ -374,11 +374,9 @@ func rejectQUICRule() O.Rule {
 	}
 }
 
-// rejectIPv6Rule rejects all IPv6 destinations so applications fall back to IPv4 —
-// a backstop for v6 that escapes AAAA suppression (literal addresses, HTTPS-record
-// hints, apps using their own DNS). The default reject method (ICMP unreachable /
-// RST) makes Happy Eyeballs fail over at once; "drop" would blackhole and stall.
-// Must be appended after the direct-routing rules so intentionally-direct v6 is kept.
+// rejectIPv6Rule rejects non-fake-IP IPv6 destinations as a backstop for
+// literals, HTTPS-record hints, or apps using their own DNS. The default reject
+// method fails fast; "drop" would blackhole and stall.
 func rejectIPv6Rule() O.Rule {
 	return O.Rule{
 		Type: C.RuleTypeDefault,
@@ -485,7 +483,7 @@ func buildOptions(bOptions BoxOptions) (O.Options, error) {
 	opts.Route.Rules = append(opts.Route.Rules, selectModeRule(AutoSelectTag))
 	opts.Route.Rules = append(opts.Route.Rules, selectModeRule(ManualSelectTag))
 
-	// catch-all rule to ensure no fallthrough
+	// catch-all rule so traffic cannot fall through
 	opts.Route.Rules = append(opts.Route.Rules, catchAllBlockerRule())
 	slog.Debug("Finished building options", "env", common.Env())
 
@@ -533,8 +531,9 @@ func mergeAndCollectTags(dst, src *O.Options) []string {
 	// overwrite base DNS options with config from src (server)
 	if src.DNS != nil {
 		dns := *src.DNS
-		// prepend the AAAA suppression rule to ensure it fails over quickly.
-		dns.Rules = append([]O.DNSRule{suppressAAAARule()}, dns.Rules...)
+		dns.Servers = slices.Clone(src.DNS.Servers)
+		dns.Rules = slices.Clone(src.DNS.Rules)
+		addFakeIPDNSFallback(&dns)
 		dst.DNS = &dns
 	}
 

--- a/vpn/boxoptions_test.go
+++ b/vpn/boxoptions_test.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/miekg/dns"
 	C "github.com/sagernet/sing-box/constant"
 	O "github.com/sagernet/sing-box/option"
 	"github.com/sagernet/sing/common/json"
@@ -205,6 +206,53 @@ func TestBuildOptions_WATERDirOverride(t *testing.T) {
 	// Original struct must not be mutated.
 	assert.Equal(t, "/tmp/stale", waterOutbound.Options.(*lbO.WATEROutboundOptions).Dir,
 		"buildOptions must not mutate the caller's WATEROutboundOptions")
+}
+
+func TestMergeAndCollectTags_AddsDualStackFakeIPDNS(t *testing.T) {
+	srcRule := O.DNSRule{
+		Type: C.RuleTypeDefault,
+		DefaultOptions: O.DefaultDNSRule{
+			RawDefaultDNSRule: O.RawDefaultDNSRule{
+				Domain: []string{"direct.example"},
+			},
+			DNSRuleAction: O.DNSRuleAction{
+				Action: C.RuleActionTypeRoute,
+				RouteOptions: O.DNSRouteActionOptions{
+					Server: "dns_local",
+				},
+			},
+		},
+	}
+	src := O.Options{
+		DNS: &O.DNSOptions{
+			RawDNSOptions: O.RawDNSOptions{
+				Servers: []O.DNSServerOptions{
+					newDNSServerOptions(C.DNSTypeLocal, "dns_local", "", ""),
+				},
+				Rules: []O.DNSRule{srcRule},
+				Final: "dns_local",
+			},
+		},
+	}
+
+	var dst O.Options
+	mergeAndCollectTags(&dst, &src)
+
+	require.NotNil(t, dst.DNS, "expected merged DNS options")
+	require.Len(t, dst.DNS.Rules, 2, "expected source DNS rule plus fake-IP fallback")
+	assert.Equal(t, srcRule, dst.DNS.Rules[0], "source DNS rules should keep their priority")
+
+	fakeRule := dst.DNS.Rules[1].DefaultOptions
+	assert.Equal(t, C.RuleActionTypeRoute, fakeRule.Action)
+	assert.Equal(t, fakeIPServerTag, fakeRule.RouteOptions.Server)
+	assert.Contains(t, fakeRule.QueryType, O.DNSQueryType(dns.TypeA))
+	assert.Contains(t, fakeRule.QueryType, O.DNSQueryType(dns.TypeAAAA))
+
+	server := requireFakeIPServer(t, dst.DNS.Servers)
+	requireDualStackFakeIPServer(t, server)
+
+	require.Len(t, src.DNS.Servers, 1, "merge must not mutate source DNS servers")
+	require.Len(t, src.DNS.Rules, 1, "merge must not mutate source DNS rules")
 }
 
 func contains[S ~[]E, E any](t *testing.T, s S, e E) bool {
@@ -476,10 +524,9 @@ func TestHasGlobalIPv6Using(t *testing.T) {
 	})
 }
 
-// TestBuildOptions_RejectsQUICAfterDirectRules pins the placement of the QUIC
-// reject: it must follow the split-tunnel and smart-routing rules (so a
-// direct-routed domain keeps its QUIC) and precede the selector rules (so
-// QUIC bound for the proxy is rejected).
+// TestBuildOptions_RejectsIPv6WhenCaptured pins the placement of the IPv6
+// reject: direct-routed IPv6 must run first, and only non-fake-IP proxied IPv6
+// should fail fast before the selector rules.
 func TestBuildOptions_RejectsIPv6WhenCaptured(t *testing.T) {
 	cfg := testConfig(t)
 	opts, err := buildOptions(BoxOptions{
@@ -514,7 +561,7 @@ func TestBuildOptions_RejectsIPv6WhenCaptured(t *testing.T) {
 	require.NotEqual(t, -1, splitIdx, "expected split-tunnel rule in built options")
 	require.NotEqual(t, -1, selectorIdx, "expected at least one selector mode rule in built options")
 	assert.Greater(t, rejectIdx, splitIdx, "IPv6 reject must come after split-tunnel so split-direct v6 keeps flowing")
-	assert.Less(t, rejectIdx, selectorIdx, "IPv6 reject must come before selector rules so proxied v6 is rejected")
+	assert.Less(t, rejectIdx, selectorIdx, "IPv6 reject must come before selector rules so non-fake-IP proxied v6 is rejected")
 }
 
 func TestRejectIPv6Rule(t *testing.T) {

--- a/vpn/boxoptions_test.go
+++ b/vpn/boxoptions_test.go
@@ -209,6 +209,7 @@ func TestBuildOptions_WATERDirOverride(t *testing.T) {
 }
 
 func TestMergeAndCollectTags_AddsDualStackFakeIPDNS(t *testing.T) {
+	srcServer := newDNSServerOptions(C.DNSTypeLocal, "dns_local", "", "")
 	srcRule := O.DNSRule{
 		Type: C.RuleTypeDefault,
 		DefaultOptions: O.DefaultDNSRule{
@@ -227,7 +228,7 @@ func TestMergeAndCollectTags_AddsDualStackFakeIPDNS(t *testing.T) {
 		DNS: &O.DNSOptions{
 			RawDNSOptions: O.RawDNSOptions{
 				Servers: []O.DNSServerOptions{
-					newDNSServerOptions(C.DNSTypeLocal, "dns_local", "", ""),
+					srcServer,
 				},
 				Rules: []O.DNSRule{srcRule},
 				Final: "dns_local",
@@ -253,6 +254,8 @@ func TestMergeAndCollectTags_AddsDualStackFakeIPDNS(t *testing.T) {
 
 	require.Len(t, src.DNS.Servers, 1, "merge must not mutate source DNS servers")
 	require.Len(t, src.DNS.Rules, 1, "merge must not mutate source DNS rules")
+	assert.Equal(t, srcServer, src.DNS.Servers[0], "merge must not rewrite source DNS servers")
+	assert.Equal(t, srcRule, src.DNS.Rules[0], "merge must not rewrite source DNS rules")
 }
 
 func contains[S ~[]E, E any](t *testing.T, s S, e E) bool {
@@ -525,8 +528,8 @@ func TestHasGlobalIPv6Using(t *testing.T) {
 }
 
 // TestBuildOptions_RejectsIPv6WhenCaptured pins the placement of the IPv6
-// reject: direct-routed IPv6 must run first, and only non-fake-IP proxied IPv6
-// should fail fast before the selector rules.
+// reject: direct-routed IPv6 must run first, and remaining IPv6 should fail
+// fast before the selector rules.
 func TestBuildOptions_RejectsIPv6WhenCaptured(t *testing.T) {
 	cfg := testConfig(t)
 	opts, err := buildOptions(BoxOptions{
@@ -561,7 +564,7 @@ func TestBuildOptions_RejectsIPv6WhenCaptured(t *testing.T) {
 	require.NotEqual(t, -1, splitIdx, "expected split-tunnel rule in built options")
 	require.NotEqual(t, -1, selectorIdx, "expected at least one selector mode rule in built options")
 	assert.Greater(t, rejectIdx, splitIdx, "IPv6 reject must come after split-tunnel so split-direct v6 keeps flowing")
-	assert.Less(t, rejectIdx, selectorIdx, "IPv6 reject must come before selector rules so non-fake-IP proxied v6 is rejected")
+	assert.Less(t, rejectIdx, selectorIdx, "IPv6 reject must come before selector rules so remaining v6 is rejected")
 }
 
 func TestRejectIPv6Rule(t *testing.T) {

--- a/vpn/dnsoptions.go
+++ b/vpn/dnsoptions.go
@@ -162,8 +162,8 @@ func addFakeIPDNSFallback(dnsOptions *option.DNSOptions) {
 	}
 }
 
-// setFakeIPServer returns the fake-IP server tag, replacing any existing
-// fake-IP entry with Radiance's dual-stack ranges.
+// setFakeIPServer returns the fake-IP server tag, replacing the first fake-IP
+// entry it finds with Radiance's dual-stack ranges.
 func setFakeIPServer(servers *[]option.DNSServerOptions) string {
 	fakeIP := fakeIPServer()
 	for i := range *servers {

--- a/vpn/dnsoptions.go
+++ b/vpn/dnsoptions.go
@@ -3,6 +3,7 @@ package vpn
 import (
 	"log/slog"
 	"net/netip"
+	"slices"
 	"strings"
 
 	"github.com/miekg/dns"
@@ -11,6 +12,12 @@ import (
 	"github.com/sagernet/sing/common/json/badoption"
 
 	"github.com/getlantern/radiance/common/settings"
+)
+
+const (
+	fakeIPServerTag = "dns_fakeip"
+	fakeIPv4Range   = "198.18.0.0/15"
+	fakeIPv6Range   = "fc00::/18"
 )
 
 // buildDNSServers returns a list of three DNSServerOptions, a local DNS server
@@ -31,14 +38,6 @@ func buildDNSServers() []option.DNSServerOptions {
 					},
 				},
 			},
-		},
-	}
-	ipv4Prefix := badoption.Prefix(netip.MustParsePrefix("198.18.0.0/15"))
-	fakeIP := option.DNSServerOptions{
-		Tag:  "dns_fakeip",
-		Type: constant.DNSTypeFakeIP,
-		Options: &option.FakeIPDNSServerOptions{
-			Inet4Range: &ipv4Prefix,
 		},
 	}
 
@@ -67,7 +66,7 @@ func buildDNSServers() []option.DNSServerOptions {
 	return []option.DNSServerOptions{
 		remote,
 		local,
-		fakeIP,
+		fakeIPServer(),
 	}
 }
 
@@ -111,56 +110,88 @@ func normalizeLocale(locale string) string {
 	return strings.ReplaceAll(strings.ReplaceAll(strings.ToUpper(locale), "-", ""), "_", "")
 }
 
-// buildDNSRules routes A queries to the fake-IP server and suppresses AAAA so
-// applications fall back to IPv4.
+// buildDNSRules routes address queries to fake-IP so routing keeps domain
+// context for both IPv4 and IPv6 destinations.
 func buildDNSRules() []option.DNSRule {
-	return []option.DNSRule{suppressAAAARule(), fakeipRule()}
-
+	return []option.DNSRule{fakeIPRule(fakeIPServerTag)}
 }
 
-func fakeipServer() option.DNSServerOptions {
-	ipv4Prefix := badoption.Prefix(netip.MustParsePrefix("198.18.0.0/15"))
+// fakeIPServer returns the dual-stack fake-IP DNS server. The IPv6 range keeps
+// AAAA answers domain-aware instead of sending raw IPv6 destinations to routing.
+func fakeIPServer() option.DNSServerOptions {
+	ipv4Prefix := badoption.Prefix(netip.MustParsePrefix(fakeIPv4Range))
+	ipv6Prefix := badoption.Prefix(netip.MustParsePrefix(fakeIPv6Range))
 	return option.DNSServerOptions{
-		Tag:  "dns_fakeip",
+		Tag:  fakeIPServerTag,
 		Type: constant.DNSTypeFakeIP,
 		Options: &option.FakeIPDNSServerOptions{
 			Inet4Range: &ipv4Prefix,
+			Inet6Range: &ipv6Prefix,
 		},
 	}
-
 }
 
-func fakeipRule() option.DNSRule {
+// fakeIPRule routes address queries to fake-IP so route matching can recover
+// the queried domain before evaluating IP fallback rules.
+func fakeIPRule(serverTag string) option.DNSRule {
 	return option.DNSRule{
 		Type: constant.RuleTypeDefault,
 		DefaultOptions: option.DefaultDNSRule{
 			RawDefaultDNSRule: option.RawDefaultDNSRule{
-				QueryType: badoption.Listable[option.DNSQueryType]{option.DNSQueryType(dns.TypeA)},
+				QueryType: badoption.Listable[option.DNSQueryType]{
+					option.DNSQueryType(dns.TypeA),
+					option.DNSQueryType(dns.TypeAAAA),
+				},
 			},
 			DNSRuleAction: option.DNSRuleAction{
 				Action: constant.RuleActionTypeRoute,
 				RouteOptions: option.DNSRouteActionOptions{
-					Server: "dns_fakeip",
+					Server: serverTag,
 				},
 			},
 		},
 	}
 }
 
-// suppressAAAARule answers AAAA queries with NODATA (NOERROR and no records) so
-// applications see no IPv6 address and connect over IPv4.
-func suppressAAAARule() option.DNSRule {
-	noError := option.DNSRCode(dns.RcodeSuccess)
-	return option.DNSRule{
-		Type: constant.RuleTypeDefault,
-		DefaultOptions: option.DefaultDNSRule{
-			RawDefaultDNSRule: option.RawDefaultDNSRule{
-				QueryType: badoption.Listable[option.DNSQueryType]{option.DNSQueryType(dns.TypeAAAA)},
-			},
-			DNSRuleAction: option.DNSRuleAction{
-				Action:            constant.RuleActionTypePredefined,
-				PredefinedOptions: option.DNSRouteActionPredefined{Rcode: &noError},
-			},
-		},
+// addFakeIPDNSFallback appends the dual-stack fake-IP path to server DNS
+// options while keeping server-supplied rules ahead of the fallback.
+func addFakeIPDNSFallback(dnsOptions *option.DNSOptions) {
+	serverTag := setFakeIPServer(&dnsOptions.Servers)
+	if !hasAddressFakeIPRule(dnsOptions.Rules, serverTag) {
+		dnsOptions.Rules = append(dnsOptions.Rules, fakeIPRule(serverTag))
 	}
+}
+
+// setFakeIPServer returns the fake-IP server tag, replacing any existing
+// fake-IP entry with Radiance's dual-stack ranges.
+func setFakeIPServer(servers *[]option.DNSServerOptions) string {
+	fakeIP := fakeIPServer()
+	for i := range *servers {
+		if (*servers)[i].Type != constant.DNSTypeFakeIP {
+			continue
+		}
+		if (*servers)[i].Tag == "" {
+			(*servers)[i].Tag = fakeIPServerTag
+		}
+		fakeIP.Tag = (*servers)[i].Tag
+		(*servers)[i] = fakeIP
+		return fakeIP.Tag
+	}
+	*servers = append(*servers, fakeIP)
+	return fakeIP.Tag
+}
+
+// hasAddressFakeIPRule reports whether A and AAAA queries already route to the
+// fake-IP server.
+func hasAddressFakeIPRule(rules []option.DNSRule, serverTag string) bool {
+	for _, rule := range rules {
+		opts := rule.DefaultOptions
+		if opts.Action == constant.RuleActionTypeRoute &&
+			opts.RouteOptions.Server == serverTag &&
+			slices.Contains(opts.QueryType, option.DNSQueryType(dns.TypeA)) &&
+			slices.Contains(opts.QueryType, option.DNSQueryType(dns.TypeAAAA)) {
+			return true
+		}
+	}
+	return false
 }

--- a/vpn/dnsoptions_test.go
+++ b/vpn/dnsoptions_test.go
@@ -1,6 +1,7 @@
 package vpn
 
 import (
+	"net/netip"
 	"slices"
 	"testing"
 
@@ -148,27 +149,49 @@ func TestLocalDNSIP(t *testing.T) {
 	}
 }
 
-func TestBuildDNSRules_SuppressesAAAA(t *testing.T) {
+func TestBuildDNSServers_FakeIPDualStack(t *testing.T) {
+	server := requireFakeIPServer(t, buildDNSServers())
+	requireDualStackFakeIPServer(t, server)
+}
+
+func TestBuildDNSRules_RoutesAddressQueriesToFakeIP(t *testing.T) {
 	rules := buildDNSRules()
 
-	var fakeIP, aaaa *option.DefaultDNSRule
+	var fakeIP, suppressedAAAA *option.DefaultDNSRule
 	for i := range rules {
 		d := &rules[i].DefaultOptions
 		switch {
-		case d.Action == constant.RuleActionTypeRoute && d.RouteOptions.Server == "dns_fakeip":
+		case d.Action == constant.RuleActionTypeRoute && d.RouteOptions.Server == fakeIPServerTag:
 			fakeIP = d
-		case slices.Contains(d.QueryType, option.DNSQueryType(dns.TypeAAAA)):
-			aaaa = d
+		case d.Action == constant.RuleActionTypePredefined &&
+			slices.Contains(d.QueryType, option.DNSQueryType(dns.TypeAAAA)):
+			suppressedAAAA = d
 		}
 	}
 
 	require.NotNil(t, fakeIP, "expected a fake-IP route rule")
 	assert.Contains(t, fakeIP.QueryType, option.DNSQueryType(dns.TypeA), "fake-IP rule should handle A queries")
-	assert.NotContains(t, fakeIP.QueryType, option.DNSQueryType(dns.TypeAAAA), "fake-IP rule must not handle AAAA — AAAA is suppressed")
+	assert.Contains(t, fakeIP.QueryType, option.DNSQueryType(dns.TypeAAAA), "fake-IP rule should handle AAAA queries")
+	assert.Nil(t, suppressedAAAA, "AAAA should not be suppressed before fake-IP can preserve domain routing")
+}
 
-	require.NotNil(t, aaaa, "expected an AAAA suppression rule")
-	assert.Equal(t, constant.RuleActionTypePredefined, aaaa.Action, "AAAA rule should use the predefined action")
-	require.NotNil(t, aaaa.PredefinedOptions.Rcode, "AAAA predefined rule must set an rcode")
-	assert.Equal(t, dns.RcodeSuccess, int(*aaaa.PredefinedOptions.Rcode), "AAAA suppression must return NODATA (NOERROR), not NXDOMAIN")
-	assert.Empty(t, aaaa.PredefinedOptions.Answer, "AAAA suppression must return no answer records (NODATA)")
+func requireFakeIPServer(t *testing.T, servers []option.DNSServerOptions) option.DNSServerOptions {
+	t.Helper()
+	idx := slices.IndexFunc(servers, func(server option.DNSServerOptions) bool {
+		return server.Type == constant.DNSTypeFakeIP
+	})
+	require.NotEqual(t, -1, idx, "expected a fake-IP DNS server")
+	return servers[idx]
+}
+
+func requireDualStackFakeIPServer(t *testing.T, server option.DNSServerOptions) {
+	t.Helper()
+	assert.Equal(t, fakeIPServerTag, server.Tag, "fake-IP server should use the routing tag")
+	require.Equal(t, constant.DNSTypeFakeIP, server.Type, "expected fake-IP server type")
+	opts, ok := server.Options.(*option.FakeIPDNSServerOptions)
+	require.True(t, ok, "expected fake-IP server options")
+	require.NotNil(t, opts.Inet4Range, "fake-IP server should have an IPv4 range")
+	require.NotNil(t, opts.Inet6Range, "fake-IP server should have an IPv6 range")
+	assert.Equal(t, fakeIPv4Range, opts.Inet4Range.Build(netip.Prefix{}).String())
+	assert.Equal(t, fakeIPv6Range, opts.Inet6Range.Build(netip.Prefix{}).String())
 }

--- a/vpn/dnsoptions_test.go
+++ b/vpn/dnsoptions_test.go
@@ -178,7 +178,7 @@ func TestBuildDNSRules_RoutesAddressQueriesToFakeIP(t *testing.T) {
 func requireFakeIPServer(t *testing.T, servers []option.DNSServerOptions) option.DNSServerOptions {
 	t.Helper()
 	idx := slices.IndexFunc(servers, func(server option.DNSServerOptions) bool {
-		return server.Type == constant.DNSTypeFakeIP
+		return server.Type == constant.DNSTypeFakeIP && server.Tag == fakeIPServerTag
 	})
 	require.NotEqual(t, -1, idx, "expected a fake-IP DNS server")
 	return servers[idx]


### PR DESCRIPTION
Proposed fix for https://github.com/getlantern/engineering/issues/3649

Routes both A and AAAA queries through dual-stack fake-IP so domain rules can handle IPv6 DNS results before the IPv6 reject fallback.

Server DNS overrides also keep this fake-IP fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dual-stack fake-IP DNS handling so both IPv4 (A) and IPv6 (AAAA) queries can be routed consistently.
  * DNS fallback is applied without changing the existing DNS rules structure.
* **Bug Fixes**
  * Improved DNS merge behavior to avoid unintended mutation and to apply the correct fallback when overwriting DNS settings.
  * Refined IPv6 rejection ordering to block proxied IPv6 more reliably.
* **Documentation**
  * Updated routing-order guidance to clarify rule evaluation placement.
* **Tests**
  * Expanded coverage for dual-stack fake-IP DNS behavior and updated IPv6 ordering assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->