### PR TITLE
feature(issue): include most recent rotated log backup in archive

### DIFF
--- a/issue/archive.go
+++ b/issue/archive.go
@@ -3,12 +3,19 @@ package issue
 import (
 	"archive/zip"
 	"bytes"
+	"compress/gzip"
 	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 )
+
+// maxLogReadFactor bounds how much uncompressed log to read toward an archive:
+// maxArchiveSize * maxLogReadFactor bytes. Even with poor compression, the
+// archive can't need more than this to reach its size budget.
+const maxLogReadFactor int64 = 20
 
 // buildIssueArchive creates a zip archive containing all .log files found in
 // logDir plus additional attachment files. The primary log (lantern.log) is
@@ -42,7 +49,98 @@ func buildIssueArchive(logDir string, additionalFiles []string, maxSize int64) (
 
 	attachments := readExtraFiles(additionalFiles)
 
+	primaryPath := filepath.Join(logDir, logArchiveName)
+	primaryLogData = prependMostRecentBackup(primaryPath, primaryLogData, maxSize)
+
 	return fitArchive(primaryLogData, secondaryLogs, attachments, maxSize)
+}
+
+// prependMostRecentBackup prepends the newest rotated gzip backup, if present,
+// so a mid-session rotation does not lose earlier log history.
+func prependMostRecentBackup(primaryLogPath string, current []byte, maxArchiveSize int64) []byte {
+	backupPath, ok := findMostRecentCompressedBackup(primaryLogPath)
+	if !ok {
+		return current
+	}
+
+	maxRead := maxArchiveSize * maxLogReadFactor
+	backupData, err := readGzipTail(backupPath, maxRead)
+	if err != nil {
+		slog.Warn("unable to read compressed log backup", "path", backupPath, "error", err)
+		return current
+	}
+	if len(backupData) == 0 {
+		return current
+	}
+	if backupData[len(backupData)-1] != '\n' {
+		backupData = append(backupData, '\n')
+	}
+
+	return append(backupData, current...)
+}
+
+// findMostRecentCompressedBackup returns the newest rotated gzip backup for the
+// primary log path. Lumberjack timestamps sort lexically, so the largest match
+// is the newest file.
+func findMostRecentCompressedBackup(primaryLogPath string) (string, bool) {
+	dir := filepath.Dir(primaryLogPath)
+	base := filepath.Base(primaryLogPath)
+	ext := filepath.Ext(base)
+	name := strings.TrimSuffix(base, ext)
+
+	// The "name-*.ext.gz" wildcard also matches siblings such as
+	// lantern-crash-*.log.gz, so this relies on lantern.log being the only
+	// gzip-rotated lantern-* log in dir.
+	pattern := filepath.Join(dir, name+"-*"+ext+".gz")
+	matches, err := filepath.Glob(pattern)
+	if err != nil || len(matches) == 0 {
+		return "", false
+	}
+
+	latest := matches[0]
+	for _, match := range matches[1:] {
+		if match > latest {
+			latest = match
+		}
+	}
+
+	return latest, true
+}
+
+// readGzipTail returns up to maxRead bytes from the end of the decompressed file.
+// The tail is kept rather than the head because it is the history nearest in time
+// to the current log; memory stays bounded to ~maxRead even when the backup
+// decompresses to more.
+func readGzipTail(path string, maxRead int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return nil, err
+	}
+	defer gz.Close()
+
+	var tail []byte
+	chunk := make([]byte, 32*1024)
+	for {
+		n, readErr := gz.Read(chunk)
+		if n > 0 {
+			tail = append(tail, chunk[:n]...)
+			if int64(len(tail)) > maxRead {
+				tail = append(tail[:0], tail[int64(len(tail))-maxRead:]...)
+			}
+		}
+		if readErr == io.EOF {
+			return tail, nil
+		}
+		if readErr != nil {
+			return nil, readErr
+		}
+	}
 }
 
 // globLogFiles returns all .log files in dir, sorted by filepath.Glob order.
@@ -74,9 +172,7 @@ func snapshotLogFile(logPath string, maxCompressed int64) ([]byte, error) {
 		return nil, nil
 	}
 
-	// Cap the amount we read: even with poor compression, we'd never need more
-	// than maxCompressed * 20 bytes of uncompressed log to fill the archive.
-	maxRead := maxCompressed * 20
+	maxRead := maxCompressed * maxLogReadFactor
 	readSize := size
 	if readSize > maxRead {
 		readSize = maxRead

--- a/issue/archive.go
+++ b/issue/archive.go
@@ -10,12 +10,22 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
-// maxLogReadFactor bounds how much uncompressed log to read toward an archive:
-// maxArchiveSize * maxLogReadFactor bytes. Even with poor compression, the
-// archive can't need more than this to reach its size budget.
-const maxLogReadFactor int64 = 20
+const (
+	// maxLogReadFactor bounds how much uncompressed log to read toward an archive:
+	// maxArchiveSize * maxLogReadFactor bytes. Logs compress by at most roughly this
+	// factor, so reading more than this can never be needed to reach the compressed
+	// size budget.
+	maxLogReadFactor int64 = 20
+	// backupTimeFormat matches the timestamp format used in rotated backup
+	// filenames: "<log-name>-<timestamp>.log.gz".
+	backupTimeFormat = "2006-01-02T15-04-05.000"
+
+	logExt    = ".log"
+	backupExt = ".log.gz"
+)
 
 // buildIssueArchive creates a zip archive containing all .log files found in
 // logDir plus additional attachment files. The primary log (lantern.log) is
@@ -23,7 +33,7 @@ const maxLogReadFactor int64 = 20
 // greedily if space permits. The total compressed archive size will not exceed
 // maxSize bytes.
 func buildIssueArchive(logDir string, additionalFiles []string, maxSize int64) ([]byte, error) {
-	logFiles := globLogFiles(logDir)
+	logFiles := globFiles(logDir, "*.log")
 
 	var primaryLogData []byte
 	var secondaryLogs []extraFile
@@ -63,8 +73,12 @@ func prependMostRecentBackup(primaryLogPath string, current []byte, maxArchiveSi
 		return current
 	}
 
-	maxRead := maxArchiveSize * maxLogReadFactor
-	backupData, err := readGzipTail(backupPath, maxRead)
+	remaining := maxArchiveSize*maxLogReadFactor - int64(len(current))
+	if remaining <= 0 {
+		return current
+	}
+
+	backupData, err := readGzipTail(backupPath, remaining)
 	if err != nil {
 		slog.Warn("unable to read compressed log backup", "path", backupPath, "error", err)
 		return current
@@ -79,32 +93,39 @@ func prependMostRecentBackup(primaryLogPath string, current []byte, maxArchiveSi
 	return append(backupData, current...)
 }
 
-// findMostRecentCompressedBackup returns the newest rotated gzip backup for the
-// primary log path. Lumberjack timestamps sort lexically, so the largest match
-// is the newest file.
 func findMostRecentCompressedBackup(primaryLogPath string) (string, bool) {
 	dir := filepath.Dir(primaryLogPath)
 	base := filepath.Base(primaryLogPath)
-	ext := filepath.Ext(base)
-	name := strings.TrimSuffix(base, ext)
+	logName := strings.TrimSuffix(base, logExt)
 
-	// The "name-*.ext.gz" wildcard also matches siblings such as
-	// lantern-crash-*.log.gz, so this relies on lantern.log being the only
-	// gzip-rotated lantern-* log in dir.
-	pattern := filepath.Join(dir, name+"-*"+ext+".gz")
-	matches, err := filepath.Glob(pattern)
-	if err != nil || len(matches) == 0 {
+	matches := globFiles(dir, logName+"-*"+backupExt)
+	if len(matches) == 0 {
 		return "", false
 	}
 
-	latest := matches[0]
-	for _, match := range matches[1:] {
-		if match > latest {
-			latest = match
+	var latestPath string
+	var latestTimestamp time.Time
+	for _, match := range matches {
+		timestamp, ok := parseBackupTimestamp(match, logName)
+		if ok && timestamp.After(latestTimestamp) {
+			latestTimestamp = timestamp
+			latestPath = match
 		}
 	}
 
-	return latest, true
+	return latestPath, latestPath != ""
+}
+
+func parseBackupTimestamp(path, logName string) (time.Time, bool) {
+	filename := filepath.Base(path)
+	prefix := logName + "-"
+	if !strings.HasPrefix(filename, prefix) || !strings.HasSuffix(filename, backupExt) {
+		return time.Time{}, false
+	}
+
+	timestamp := filename[len(prefix) : len(filename)-len(backupExt)]
+	ts, err := time.Parse(backupTimeFormat, timestamp)
+	return ts, err == nil
 }
 
 // readGzipTail returns up to maxRead bytes from the end of the decompressed file.
@@ -112,6 +133,10 @@ func findMostRecentCompressedBackup(primaryLogPath string) (string, bool) {
 // to the current log; memory stays bounded to ~maxRead even when the backup
 // decompresses to more.
 func readGzipTail(path string, maxRead int64) ([]byte, error) {
+	if maxRead <= 0 {
+		return nil, nil
+	}
+
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -143,11 +168,10 @@ func readGzipTail(path string, maxRead int64) ([]byte, error) {
 	}
 }
 
-// globLogFiles returns all .log files in dir, sorted by filepath.Glob order.
-func globLogFiles(dir string) []string {
-	matches, err := filepath.Glob(filepath.Join(dir, "*.log"))
+func globFiles(dir, pattern string) []string {
+	matches, err := filepath.Glob(filepath.Join(dir, pattern))
 	if err != nil {
-		slog.Warn("unable to glob log files", "dir", dir, "error", err)
+		slog.Warn("unable to glob files", "dir", dir, "pattern", pattern, "error", err)
 		return nil
 	}
 	return matches

--- a/issue/archive_test.go
+++ b/issue/archive_test.go
@@ -84,31 +84,30 @@ func TestSnapshotLogFile(t *testing.T) {
 	})
 }
 
-func TestGlobLogFiles(t *testing.T) {
-	t.Run("finds all log files", func(t *testing.T) {
+func TestGlobFiles(t *testing.T) {
+	t.Run("returns matching .log files", func(t *testing.T) {
 		dir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "lantern.log"), []byte("main"), 0644))
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "lantern-crash.log"), []byte("crash"), 0644))
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "other.txt"), []byte("not a log"), 0644))
 
-		files := globLogFiles(dir)
+		files := globFiles(dir, "*.log")
 		require.Len(t, files, 2)
 		bases := make([]string, len(files))
 		for i, f := range files {
 			bases[i] = filepath.Base(f)
 		}
-		assert.Contains(t, bases, "lantern.log")
-		assert.Contains(t, bases, "lantern-crash.log")
+		assert.ElementsMatch(t, []string{"lantern-crash.log", "lantern.log"}, bases)
 	})
 
 	t.Run("returns nil for empty dir", func(t *testing.T) {
 		dir := t.TempDir()
-		files := globLogFiles(dir)
+		files := globFiles(dir, "*.log")
 		assert.Nil(t, files)
 	})
 
 	t.Run("returns nil for nonexistent dir", func(t *testing.T) {
-		files := globLogFiles("/nonexistent/dir")
+		files := globFiles("/nonexistent/dir", "*.log")
 		assert.Nil(t, files)
 	})
 }
@@ -481,6 +480,21 @@ func TestMostRecentCompressedBackup(t *testing.T) {
 		_, ok := findMostRecentCompressedBackup(filepath.Join(dir, "lantern.log"))
 		assert.False(t, ok)
 	})
+
+	t.Run("ignores siblings the glob matches but lumberjack did not produce", func(t *testing.T) {
+		dir := t.TempDir()
+		primary := filepath.Join(dir, "lantern.log")
+		backup := filepath.Join(dir, "lantern-2026-06-15T15-31-02.000.log.gz")
+		require.NoError(t, os.WriteFile(backup, nil, 0644))
+		// A crash-log sibling the "lantern-*.log.gz" glob also matches; its later
+		// timestamp would win a naive newest-wins comparison, but it is not a
+		// rotation of lantern.log and must be rejected.
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "lantern-crash-2026-06-15T16-00-00.000.log.gz"), nil, 0644))
+
+		got, ok := findMostRecentCompressedBackup(primary)
+		require.True(t, ok)
+		assert.Equal(t, backup, got)
+	})
 }
 
 func TestReadGzipTail(t *testing.T) {
@@ -587,8 +601,9 @@ func TestBuildIssueArchiveIncludesCompressedBackup(t *testing.T) {
 		copy(backup, "BACKUPHEADMARKER")
 		writeGzipFile(t, filepath.Join(dir, "lantern-2026-06-15T15-31-02.000.log.gz"), backup)
 
-		// Budget fits a 256 KiB tail but not 512 KiB, so the trim must drop the
-		// prepended backup (oldest) and keep the current log (newest).
+		// 200 KiB current + 400 KiB backup (incompressible) exceed the 384 KiB
+		// budget, so the tail-trim must drop the prepended backup (oldest) and
+		// keep the current log (newest).
 		result, err := buildIssueArchive(dir, nil, 384*1024)
 		require.NoError(t, err)
 		primary := primaryContent(t, result)

--- a/issue/archive_test.go
+++ b/issue/archive_test.go
@@ -3,6 +3,7 @@ package issue
 import (
 	"archive/zip"
 	"bytes"
+	"compress/gzip"
 	"crypto/rand"
 	"io"
 	"os"
@@ -235,9 +236,7 @@ func TestFitArchive(t *testing.T) {
 	t.Run("log truncated to tail when too large", func(t *testing.T) {
 		// Use incompressible random data (2MB) with a budget that fits ~1-2
 		// chunks (256KB each) but not the full log.
-		logData := make([]byte, 2*1024*1024) // 2MB
-		_, err := rand.Read(logData)
-		require.NoError(t, err)
+		logData := randomBytes(t, 2*1024*1024) // 2MB random
 
 		maxSize := int64(512 * 1024) // 512KB
 
@@ -275,9 +274,7 @@ func TestSearchMaxLogTail(t *testing.T) {
 	})
 
 	t.Run("truncates incompressible data", func(t *testing.T) {
-		logData := make([]byte, 1024*1024) // 1MB random
-		_, err := rand.Read(logData)
-		require.NoError(t, err)
+		logData := randomBytes(t, 1024*1024) // 1MB random
 
 		maxSize := int64(300 * 1024) // 300KB
 		tailSize := searchMaxLogTail(logData, maxSize)
@@ -393,10 +390,8 @@ func TestBuildIssueArchive(t *testing.T) {
 	t.Run("archive respects maxSize", func(t *testing.T) {
 		dir := t.TempDir()
 		// Write incompressible data (2MB).
-		logContent := make([]byte, 2*1024*1024)
-		_, err := rand.Read(logContent)
-		require.NoError(t, err)
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "lantern.log"), logContent, 0644))
+		logData := randomBytes(t, 2*1024*1024)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "lantern.log"), logData, 0644))
 
 		maxSize := int64(512 * 1024)
 		result, err := buildIssueArchive(dir, nil, maxSize)
@@ -407,7 +402,7 @@ func TestBuildIssueArchive(t *testing.T) {
 		entries := readZipEntries(t, result)
 		require.Len(t, entries, 1)
 		content := entries[0].content
-		assert.Equal(t, string(logContent[len(logContent)-len(content):]), content)
+		assert.Equal(t, string(logData[len(logData)-len(content):]), content)
 	})
 
 	t.Run("snapshot excludes data written after call", func(t *testing.T) {
@@ -454,4 +449,158 @@ func readZipEntries(t *testing.T, data []byte) []zipEntry {
 		entries = append(entries, zipEntry{name: f.Name, content: string(body)})
 	}
 	return entries
+}
+
+func writeGzipFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	_, err := gz.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0644))
+}
+
+func TestMostRecentCompressedBackup(t *testing.T) {
+	t.Run("picks newest by lexical timestamp order", func(t *testing.T) {
+		dir := t.TempDir()
+		primary := filepath.Join(dir, "lantern.log")
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "lantern-2026-06-15T15-31-02.000.log.gz"), nil, 0644))
+		newest := filepath.Join(dir, "lantern-2026-06-15T16-02-44.000.log.gz")
+		require.NoError(t, os.WriteFile(newest, nil, 0644))
+
+		got, ok := findMostRecentCompressedBackup(primary)
+		require.True(t, ok)
+		assert.Equal(t, newest, got)
+	})
+
+	t.Run("false when no compressed backup", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "lantern-2026-06-15T15-31-02.000.log"), nil, 0644))
+
+		_, ok := findMostRecentCompressedBackup(filepath.Join(dir, "lantern.log"))
+		assert.False(t, ok)
+	})
+}
+
+func TestReadGzipTail(t *testing.T) {
+	t.Run("round-trips content within cap", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "backup.log.gz")
+		writeGzipFile(t, path, []byte("old line 1\nold line 2\n"))
+
+		data, err := readGzipTail(path, 1024)
+		require.NoError(t, err)
+		assert.Equal(t, "old line 1\nold line 2\n", string(data))
+	})
+
+	t.Run("keeps the tail when over cap", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "backup.log.gz")
+		writeGzipFile(t, path, []byte("0123456789"))
+
+		data, err := readGzipTail(path, 4)
+		require.NoError(t, err)
+		assert.Equal(t, "6789", string(data))
+	})
+
+	t.Run("keeps the tail across multiple read chunks", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "backup.log.gz")
+		content := append(bytes.Repeat([]byte("A"), 100*1024), []byte("TAILMARKER")...)
+		writeGzipFile(t, path, content)
+
+		data, err := readGzipTail(path, 10)
+		require.NoError(t, err)
+		assert.Equal(t, "TAILMARKER", string(data))
+	})
+
+	t.Run("error on non-gzip input", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "backup.log.gz")
+		require.NoError(t, os.WriteFile(path, []byte("not gzip data"), 0644))
+
+		_, err := readGzipTail(path, 1024)
+		assert.Error(t, err)
+	})
+}
+
+func TestBuildIssueArchiveIncludesCompressedBackup(t *testing.T) {
+	primaryContent := func(t *testing.T, result []byte) string {
+		t.Helper()
+		for _, e := range readZipEntries(t, result) {
+			if e.name == logArchiveName {
+				return e.content
+			}
+		}
+		t.Fatalf("no %s entry in archive", logArchiveName)
+		return ""
+	}
+
+	t.Run("orders backup before current", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "lantern.log"), []byte("current line\n"), 0644))
+		writeGzipFile(t, filepath.Join(dir, "lantern-2026-06-15T15-31-02.000.log.gz"), []byte("rotated line\n"))
+
+		result, err := buildIssueArchive(dir, nil, 1024*1024)
+		require.NoError(t, err)
+		assert.Equal(t, "rotated line\ncurrent line\n", primaryContent(t, result))
+	})
+
+	t.Run("inserts newline when backup lacks trailing newline", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "lantern.log"), []byte("current line\n"), 0644))
+		writeGzipFile(t, filepath.Join(dir, "lantern-2026-06-15T15-31-02.000.log.gz"), []byte("rotated line"))
+
+		result, err := buildIssueArchive(dir, nil, 1024*1024)
+		require.NoError(t, err)
+		assert.Equal(t, "rotated line\ncurrent line\n", primaryContent(t, result))
+	})
+
+	t.Run("falls back to current on corrupt backup", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "lantern.log"), []byte("current line\n"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "lantern-2026-06-15T15-31-02.000.log.gz"), []byte("not gzip"), 0644))
+
+		result, err := buildIssueArchive(dir, nil, 1024*1024)
+		require.NoError(t, err)
+		assert.Equal(t, "current line\n", primaryContent(t, result))
+	})
+
+	t.Run("ignores empty backup", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "lantern.log"), []byte("current line\n"), 0644))
+		writeGzipFile(t, filepath.Join(dir, "lantern-2026-06-15T15-31-02.000.log.gz"), nil)
+
+		result, err := buildIssueArchive(dir, nil, 1024*1024)
+		require.NoError(t, err)
+		assert.Equal(t, "current line\n", primaryContent(t, result))
+	})
+
+	t.Run("trims oldest backup bytes first when over budget", func(t *testing.T) {
+		dir := t.TempDir()
+		current := randomBytes(t, 200*1024)
+		copy(current[len(current)-len("CURRENTTAILMARKER"):], "CURRENTTAILMARKER")
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "lantern.log"), current, 0644))
+
+		backup := randomBytes(t, 400*1024)
+		copy(backup, "BACKUPHEADMARKER")
+		writeGzipFile(t, filepath.Join(dir, "lantern-2026-06-15T15-31-02.000.log.gz"), backup)
+
+		// Budget fits a 256 KiB tail but not 512 KiB, so the trim must drop the
+		// prepended backup (oldest) and keep the current log (newest).
+		result, err := buildIssueArchive(dir, nil, 384*1024)
+		require.NoError(t, err)
+		primary := primaryContent(t, result)
+		assert.Contains(t, primary, "CURRENTTAILMARKER")
+		assert.NotContains(t, primary, "BACKUPHEADMARKER")
+	})
+}
+
+func randomBytes(t *testing.T, n int) []byte {
+	t.Helper()
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	require.NoError(t, err)
+	return b
 }


### PR DESCRIPTION
This pull request enhances the log archiving process by ensuring that the most recent rotated (gzip-compressed) log backup is included at the start of the main log in the issue archive, preserving more complete log history across log rotations. It also introduces robust helper functions and comprehensive tests for this new behavior.

**Log backup inclusion and ordering:**
- The `buildIssueArchive` function now prepends the most recent compressed backup (if present) to the primary log, ensuring that log history from before a rotation is not lost. The backup is trimmed to fit the archive size limit, and a newline is inserted if the backup doesn't end with one.

**Helper functions for backup handling:**
- Added `prependMostRecentBackup`, `findMostRecentCompressedBackup`, and `readGzipTail` to locate the latest compressed backup, read its decompressed tail efficiently, and combine it with the current log.
- Introduced `maxLogReadFactor` constant to consistently cap how much uncompressed log data is read, replacing magic numbers. [[1]](diffhunk://#diff-e1747d137e525bb2c011c3f6a5968caeb5dfbad026c27efd490351250a618f50R6-R19) [[2]](diffhunk://#diff-e1747d137e525bb2c011c3f6a5968caeb5dfbad026c27efd490351250a618f50L77-R175)

**Testing improvements:**
- Added extensive tests for backup detection, reading, and integration into the archive, including edge cases like corrupt or empty backups, and correct ordering of backup and current log data. (F5b814d6L450R450)
- Refactored tests to use a new `randomBytes` helper for generating incompressible random data, improving clarity and consistency. [[1]](diffhunk://#diff-213de489f65fd3e4ac6bb678f3b59d4411bf1a03217c3fd858b5e6de813b3bb4L238-R239) [[2]](diffhunk://#diff-213de489f65fd3e4ac6bb678f3b59d4411bf1a03217c3fd858b5e6de813b3bb4L278-R277) [[3]](diffhunk://#diff-213de489f65fd3e4ac6bb678f3b59d4411bf1a03217c3fd858b5e6de813b3bb4L396-R394) [[4]](diffhunk://#diff-213de489f65fd3e4ac6bb678f3b59d4411bf1a03217c3fd858b5e6de813b3bb4L410-R405) F5b814d6L450R450)

**Test utilities:**
- Added `writeGzipFile` and `randomBytes` helpers to simplify test setup for compressed log files and random data generation. (F5b814d6L450R450)

**Dependency updates:**
- Imported the standard library `compress/gzip` package in both implementation and test files to support reading and writing gzip-compressed logs. [[1]](diffhunk://#diff-e1747d137e525bb2c011c3f6a5968caeb5dfbad026c27efd490351250a618f50R6-R19) [[2]](diffhunk://#diff-213de489f65fd3e4ac6bb678f3b59d4411bf1a03217c3fd858b5e6de813b3bb4R6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Issue archives now include the latest available rotated compressed log backup, giving more complete log bundles for troubleshooting.
  * Archive generation is more reliable when backups are missing, empty, or corrupted, and preserves proper log ordering and line breaks.

* **Tests**
  * Expanded automated coverage for archive creation and compressed backup handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->