### PR TITLE
ci: add stale bot workflow (90d/30d)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,38 @@
+name: Stale Bot
+
+on:
+  schedule:
+    - cron: "0 9 * * 1-5"
+  workflow_dispatch:
+    inputs:
+      stale_days:
+        description: "Days of inactivity before a PR is marked stale"
+        type: number
+        default: 90
+      close_days:
+        description: "Days after stale label before closing"
+        type: number
+        default: 30
+      exempt:
+        description: "Comma-separated labels that exempt a PR from being marked stale"
+        type: string
+        default: ''
+      dry_run:
+        description: "Dry run (no actions taken)"
+        type: boolean
+        default: false
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getlantern/automation/actions/stale-bot@main
+        with:
+          repos: getlantern/radiance
+          stale-days: ${{ inputs.stale_days || 90 }}
+          close-days: ${{ inputs.close_days || 30 }}
+          exempt: ${{ inputs.exempt }}
+          fallback-channel: '#engineering-organization'
+          dry-run: ${{ inputs.dry_run == true }}
+          github-token: ${{ secrets.GH_TEAMLANTERN_TOKEN }}
+          slack-token: ${{ secrets.SLACK_GLOBOT_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - uses: getlantern/automation/actions/stale-bot@main
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,6 +22,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: stale
+  cancel-in-progress: false
+
 jobs:
   stale:
     runs-on: ubuntu-latest
@@ -29,11 +33,11 @@ jobs:
     steps:
       - uses: getlantern/automation/actions/stale-bot@main
         with:
-          repos: getlantern/radiance
-          stale-days: ${{ inputs.stale_days || 90 }}
-          close-days: ${{ inputs.close_days || 30 }}
-          exempt: ${{ inputs.exempt }}
+          repos: ${{ github.repository }}
+          stale-days: ${{ github.event.inputs.stale_days || 90 }}
+          close-days: ${{ github.event.inputs.close_days || 30 }}
+          exempt: ${{ github.event.inputs.exempt }}
           fallback-channel: '#engineering-organization'
-          dry-run: ${{ inputs.dry_run == true }}
+          dry-run: ${{ github.event.inputs.dry_run == 'true' }}
           github-token: ${{ secrets.GH_TEAMLANTERN_TOKEN }}
           slack-token: ${{ secrets.SLACK_GLOBOT_TOKEN }}


### PR DESCRIPTION
Repo-local stale bot for radiance (90d stale / 30d close), replacing the run from getlantern/automation. Ref: Adam's thread https://wdynhnkxvsdx.slack.com/archives/C01K9DJ1ES2/p1782814592541699.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a scheduled “Stale Bot” GitHub Actions workflow to help keep the repository tidy.
  * Runs automatically on weekdays (Mon–Fri) and supports manual execution with configurable stale/close timing, exempt labels, and dry-run preview.
  * Includes concurrency control to avoid overlapping runs, and uses repository secrets for notification channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->