### PR TITLE
ci(stale): grant contents: read so private action resolves

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,7 +29,8 @@ concurrency:
 jobs:
   stale:
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      contents: read
     steps:
       - uses: getlantern/automation/actions/stale-bot@main
         with:


### PR DESCRIPTION
Restores `GITHUB_TOKEN`'s `contents: read` scope on the stale job so the runner can fetch the private `getlantern/automation` action — `permissions: {}` was blocking the `uses:` resolver.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation permissions to allow a background cleanup job to read repository contents as needed.
  * No changes to scheduled behavior, notifications, or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->