### PR TITLE
ci(stale): check out private action with PAT

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -32,7 +32,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: getlantern/automation/actions/stale-bot@main
+      # public → private `uses:` is blocked; check out with a PAT.
+      - uses: actions/checkout@v4
+        with:
+          repository: getlantern/automation
+          ref: main
+          token: ${{ secrets.GH_TEAMLANTERN_TOKEN }}
+          path: .automation
+      - uses: ./.automation/actions/stale-bot
         with:
           repos: ${{ github.repository }}
           stale-days: ${{ github.event.inputs.stale_days || 90 }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -38,6 +38,7 @@ jobs:
           repository: getlantern/automation
           ref: main
           token: ${{ secrets.GH_TEAMLANTERN_TOKEN }}
+          persist-credentials: false
           path: .automation
       - uses: ./.automation/actions/stale-bot
         with:


### PR DESCRIPTION
Radiance is public and `getlantern/automation` is private; GitHub's org-share access model blocks a public repo from resolving `uses:` against a private one, so #553's `contents: read` fix wasn't enough. Fetching with `actions/checkout` + `GH_TEAMLANTERN_TOKEN` bypasses the resolver entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the automated “stale issues/PRs” workflow to run the stale-bot from a locally checked-out automation copy instead of invoking the remote action directly.
  * Kept the existing schedule and stale/close settings, including exemptions and dry-run behavior, while simplifying how the bot is executed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->