### PR TITLE
config: advertise the non_selectable_outbounds capability

### DIFF
--- a/config/fetcher.go
+++ b/config/fetcher.go
@@ -85,6 +85,10 @@ func (f *fetcher) fetchConfig(ctx context.Context, preferred common.PreferredLoc
 		Backend:        C.SINGBOX,
 		Locale:         f.locale,
 		Protocols:      protocol.SupportedProtocols(),
+		// Advertise that we honor NonSelectableOutbounds (merge server-declared infra
+		// outbounds but keep them out of the proxy-selection groups) so the server can
+		// gate such outbounds on the capability rather than the client version.
+		Capabilities: []string{C.CapabilityNonSelectableOutbounds},
 	}
 	if preferred.Country != "" {
 		confReq.PreferredLocation = &preferred

--- a/config/fetcher_test.go
+++ b/config/fetcher_test.go
@@ -97,6 +97,8 @@ func TestFetchConfig(t *testing.T) {
 			assert.Equal(t, "1234567890", confReq.UserID,
 				"UserID must serialize as a base-10 decimal string matching main's format")
 			assert.Equal(t, privateKey.PublicKey().String(), confReq.WGPublicKey)
+			assert.Contains(t, confReq.Capabilities, C.CapabilityNonSelectableOutbounds,
+				"server-side infra-outbound gating depends on this advertisement")
 			if tt.preferredServerLoc != nil {
 				assert.Equal(t, tt.preferredServerLoc, confReq.PreferredLocation)
 			}

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/alexflint/go-arg v1.6.1
 	github.com/alitto/pond v1.9.2
 	github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c
-	github.com/getlantern/common v1.2.1-0.20260705172801-57aaafd97c1b
+	github.com/getlantern/common v1.2.1-0.20260706195926-fc97d4f20015
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac
 	github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/alexflint/go-arg v1.6.1
 	github.com/alitto/pond v1.9.2
 	github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c
-	github.com/getlantern/common v1.2.1-0.20260706195926-fc97d4f20015
+	github.com/getlantern/common v1.2.1-0.20260707190506-5d90dcb22437
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac
 	github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c h1:ZzxuhIWO295y4eE6
 github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c/go.mod h1:b5teAOFT+vpBqc2CHoz74QTEM15iOv1PLdQogwXcfrM=
 github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc h1:AVY56mzJHM4CBTrW9oBgpShB5S68gGunvk9GMvJrkzM=
 github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc/go.mod h1:bIxM6xon/ADgprn6tZXYdXGrUIMCzq6u8zO9rET50IE=
-github.com/getlantern/common v1.2.1-0.20260706195926-fc97d4f20015 h1:XG3qP/uJ3D+i18i5H8jLRvGN8O0IQauq/KoGMOLNaQ8=
-github.com/getlantern/common v1.2.1-0.20260706195926-fc97d4f20015/go.mod h1:eSSuV4bMPgQJnczBw+KWWqWNo1itzmVxC++qUBPRTt0=
+github.com/getlantern/common v1.2.1-0.20260707190506-5d90dcb22437 h1:CXx0ek+MzSbwtJANHGlAWX48jHGLlNC1EM2ZW8iDPXw=
+github.com/getlantern/common v1.2.1-0.20260707190506-5d90dcb22437/go.mod h1:eSSuV4bMPgQJnczBw+KWWqWNo1itzmVxC++qUBPRTt0=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c h1:ZzxuhIWO295y4eE6
 github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c/go.mod h1:b5teAOFT+vpBqc2CHoz74QTEM15iOv1PLdQogwXcfrM=
 github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc h1:AVY56mzJHM4CBTrW9oBgpShB5S68gGunvk9GMvJrkzM=
 github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc/go.mod h1:bIxM6xon/ADgprn6tZXYdXGrUIMCzq6u8zO9rET50IE=
-github.com/getlantern/common v1.2.1-0.20260705172801-57aaafd97c1b h1:R6YoZuQFLdArpovoMtPxa3ohqJzx6bpJ+BRxDaoMdWk=
-github.com/getlantern/common v1.2.1-0.20260705172801-57aaafd97c1b/go.mod h1:eSSuV4bMPgQJnczBw+KWWqWNo1itzmVxC++qUBPRTt0=
+github.com/getlantern/common v1.2.1-0.20260706195926-fc97d4f20015 h1:XG3qP/uJ3D+i18i5H8jLRvGN8O0IQauq/KoGMOLNaQ8=
+github.com/getlantern/common v1.2.1-0.20260706195926-fc97d4f20015/go.mod h1:eSSuV4bMPgQJnczBw+KWWqWNo1itzmVxC++qUBPRTt0=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=


### PR DESCRIPTION
## What

Advertise `common.CapabilityNonSelectableOutbounds` (`"non_selectable_outbounds"`) in the config request's `Capabilities` (`config/fetcher.go`).

## Why

radiance#549 made this client honor `ConfigResponse.NonSelectableOutbounds` — it merges server-declared infrastructure outbounds into the box config so their references resolve, but excludes them from **both** proxy-selection groups (auto/URLTest and the manual selector). Advertising the capability lets **lantern-cloud gate infrastructure outbounds on it instead of the client version.**

The concrete case is the **proxyless rule-set download_detour** (lantern-cloud#2936): a client that *doesn't* honor `NonSelectableOutbounds` would let its URLTest auto-select the low-latency direct+frag dialer and route traffic through it, exposing the real IP. Because this capability is added in the same client that has #549's handling, "advertises it" ⟺ "handles it safely" — a true capability signal, and one gate covers **every future infra outbound** with no new client release.

(The client already advertises the outline outbound *type* `"outline"` via its auto-derived supported-protocols list, but that predates #549, so it can't be the gate — old clients report it too. This is a distinct, explicitly-added capability.)

## Dependencies

- **getlantern/common#28** adds `ConfigRequest.Capabilities` + the constant. **Merged** — `go.mod` now points at the merge commit on `common` main (`5d90dcb`).
- **Server half:** getlantern/lantern-cloud#2936 gates the proxyless detour on this capability.

## Testing

`go build ./config/...`, gofmt clean; `go test ./config/` passes against merged `common` main. (The advertised value round-trips through `common`'s `TestCapabilitiesRoundTrip`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGpKfgkbfdJwwsTaouMDoR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Config fetches now advertise support for non-selectable outbounds, enabling servers to return configs that use this capability.
* **Chores**
  * Updated a shared dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->