### PR TITLE
feat(backend): report selection-history failures to the bandit endpoint

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -900,17 +900,15 @@ func (r *LocalBackend) runSelectionReporter(ctx context.Context, storage vpn.Aut
 // cycle so a changed cadence takes effect the next tick and a dropped interval
 // stops the loop within one cycle.
 func runReportLoop(ctx context.Context, interval func() time.Duration, report func()) {
-	ticker := time.NewTicker(1)
 	for {
 		wait := interval()
 		if wait <= 0 {
 			return
 		}
-		ticker.Reset(wait)
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
+		case <-time.After(wait):
 			report()
 		}
 	}

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -951,6 +951,9 @@ func runReportLoop(ctx context.Context, interval func() time.Duration, report fu
 }
 
 func (r *LocalBackend) reportSelectionHistory(ctx context.Context, storage vpn.AutoSelectHistoryStorage) {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "report_selection_history")
+	defer span.End()
+
 	cfg, _ := r.confHandler.GetConfig()
 	if cfg == nil || len(cfg.BanditReportTokens) == 0 {
 		return
@@ -963,6 +966,7 @@ func (r *LocalBackend) reportSelectionHistory(ctx context.Context, storage vpn.A
 	defer cancel()
 	if err := r.selectionReporter.report(ctx, snapshot, cfg.BanditReportTokens); err != nil {
 		slog.Warn("Failed to report selection history", "error", err)
+		span.RecordError(err)
 	}
 }
 

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -77,6 +77,7 @@ type LocalBackend struct {
 
 	stopSelectionHistoryListener context.CancelFunc
 	selectionHistoryMu           sync.Mutex
+	selectionReporter            *selectionReporter
 
 	exhaustionGate exhaustionGate
 }
@@ -174,14 +175,15 @@ func NewLocalBackend(ctx context.Context, opts Options) (*LocalBackend, error) {
 		Logger:        slog.Default().With("service", "config_handler"),
 	}
 	r := &LocalBackend{
-		ctx:            ctx,
-		cancel:         cancel,
-		issueReporter:  issue.NewIssueReporter(kindling.HTTPClient()),
-		accountClient:  accountClient,
-		confHandler:    config.NewConfigHandler(ctx, cOpts),
-		srvManager:     svrMgr,
-		vpnClient:      vpnClient,
-		splitTunnelMgr: splitTunnelMgr,
+		ctx:               ctx,
+		cancel:            cancel,
+		issueReporter:     issue.NewIssueReporter(kindling.HTTPClient()),
+		selectionReporter: newSelectionReporter(kindling.HTTPClient()),
+		accountClient:     accountClient,
+		confHandler:       config.NewConfigHandler(ctx, cOpts),
+		srvManager:        svrMgr,
+		vpnClient:         vpnClient,
+		splitTunnelMgr:    splitTunnelMgr,
 		shutdownFuncs: []func() error{
 			telemetry.Close, kindling.Close,
 		},
@@ -816,6 +818,10 @@ func (r *LocalBackend) updateSelectionHistoryListener(status vpn.VPNStatus) {
 			}
 		})
 		go r.runSelectionHistoryListener(ctx, storage, hook)
+		if r.selectionReportInterval() > 0 {
+			r.selectionReporter.reset()
+			go r.runSelectionReporter(ctx, storage)
+		}
 		slog.Debug("Started selection history listener")
 	case vpn.Disconnected, vpn.ErrorStatus:
 		if r.stopSelectionHistoryListener != nil {
@@ -852,16 +858,77 @@ func (r *LocalBackend) runSelectionHistoryListener(ctx context.Context, storage 
 }
 
 func (r *LocalBackend) flushSelectionHistory(storage vpn.AutoSelectHistoryStorage) {
-	results := make(map[string]servers.SelectionHistory)
+	history := r.collectSelectionHistory(storage)
+	if len(history) == 0 {
+		return
+	}
+
+	if err := r.srvManager.UpdateSelectionHistory(history); err != nil {
+		slog.Warn("Failed to persist selection history", "error", err)
+	}
+}
+
+func (r *LocalBackend) collectSelectionHistory(storage vpn.AutoSelectHistoryStorage) map[string]servers.SelectionHistory {
+	history := make(map[string]servers.SelectionHistory)
 	for _, srv := range r.srvManager.AllServers() {
 		if h := storage.Load(srv.Tag); h != nil {
-			results[srv.Tag] = *h
+			history[srv.Tag] = *h
 		}
 	}
-	if len(results) > 0 {
-		if err := r.srvManager.UpdateSelectionHistory(results); err != nil {
-			slog.Warn("Failed to persist selection history", "error", err)
+	return history
+}
+
+// selectionReportInterval is the server-configured report cadence. Zero is
+// returned if reporting is disabled or the config is unavailable.
+func (r *LocalBackend) selectionReportInterval() time.Duration {
+	cfg, _ := r.confHandler.GetConfig()
+	if cfg == nil || cfg.RouteSelectionReportIntervalSeconds <= 0 {
+		return 0
+	}
+
+	return time.Duration(cfg.RouteSelectionReportIntervalSeconds) * time.Second
+}
+
+func (r *LocalBackend) runSelectionReporter(ctx context.Context, storage vpn.AutoSelectHistoryStorage) {
+	runReportLoop(ctx, r.selectionReportInterval, func() {
+		r.reportSelectionHistory(ctx, storage)
+	})
+}
+
+// runReportLoop calls report once per interval() until the context is canceled
+// or interval() returns a non-positive duration. The interval is re-derived each
+// cycle so a changed cadence takes effect the next tick and a dropped interval
+// stops the loop within one cycle.
+func runReportLoop(ctx context.Context, interval func() time.Duration, report func()) {
+	ticker := time.NewTicker(1)
+	for {
+		wait := interval()
+		if wait <= 0 {
+			return
 		}
+		ticker.Reset(wait)
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			report()
+		}
+	}
+}
+
+func (r *LocalBackend) reportSelectionHistory(ctx context.Context, storage vpn.AutoSelectHistoryStorage) {
+	cfg, _ := r.confHandler.GetConfig()
+	if cfg == nil || len(cfg.BanditReportTokens) == 0 {
+		return
+	}
+	snapshot := r.collectSelectionHistory(storage)
+	if len(snapshot) == 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, selectionReportTimeout)
+	defer cancel()
+	if err := r.selectionReporter.report(ctx, snapshot, cfg.BanditReportTokens); err != nil {
+		slog.Warn("Failed to report selection history", "error", err)
 	}
 }
 

--- a/backend/selection_reporter.go
+++ b/backend/selection_reporter.go
@@ -40,7 +40,7 @@ type selectionReportEntry struct {
 }
 
 type selectionReportRequest struct {
-	Reports []selectionReportEntry `json:"reports"`
+	Reports []selectionReportEntry `json:"entries"`
 }
 
 // selectionReporter sends route-selection failure history to the server.

--- a/backend/selection_reporter.go
+++ b/backend/selection_reporter.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/getlantern/kindling"
 	"github.com/getlantern/lantern-box/adapter"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/getlantern/radiance/common"
 	"github.com/getlantern/radiance/servers"
@@ -108,6 +110,7 @@ func (sr *selectionReporter) report(
 	snapshot map[string]servers.SelectionHistory,
 	tokens map[string]string,
 ) error {
+	span := trace.SpanFromContext(ctx)
 	now := sr.now()
 	prepared := sr.prepareReport(now, snapshot, tokens)
 	if len(prepared.entries) == 0 {
@@ -120,6 +123,10 @@ func (sr *selectionReporter) report(
 		return nil
 	}
 
+	span.AddEvent("selection_report", trace.WithAttributes(
+		attribute.Int("entries", len(prepared.entries)),
+		attribute.Int("skippedNoToken", prepared.skippedNoToken),
+	))
 	if err := sr.post(ctx, prepared.entries); err != nil {
 		return err
 	}

--- a/backend/selection_reporter.go
+++ b/backend/selection_reporter.go
@@ -1,0 +1,261 @@
+package backend
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/getlantern/kindling"
+	"github.com/getlantern/lantern-box/adapter"
+
+	"github.com/getlantern/radiance/common"
+	"github.com/getlantern/radiance/servers"
+)
+
+const (
+	// banditReportPath is joined onto the config API base URL.
+	banditReportPath = "/bandit/report"
+
+	selectionReportTimeout = 30 * time.Second
+)
+
+// selectionReportEntry is one route's reported failure window.
+type selectionReportEntry struct {
+	// ReportToken is the server-issued opaque HMAC token for the route.
+	ReportToken string `json:"report_token"`
+	// Failures is the list of failures since the last confirmed report.
+	Failures []adapter.UserFailure `json:"failures"`
+	// WindowSeconds is the elapsed accumulation period for the failures, measured
+	// from the last confirmed report.
+	WindowSeconds int `json:"window_seconds"`
+}
+
+type selectionReportRequest struct {
+	Reports []selectionReportEntry `json:"reports"`
+}
+
+// selectionReporter sends route-selection failure history to the server.
+//
+// Reporting is watermark-based:
+//   - each successful report advances the tag's watermark to the report time
+//   - later reports include only failures newer than that watermark
+//   - failed reports do not advance the watermark, so data is retried
+//
+// reset() starts a new reporting epoch for a new connection session.
+type selectionReporter struct {
+	httpClient *http.Client
+	reportURL  string
+	now        func() time.Time
+
+	mu sync.Mutex
+	// epoch is bumped by reset and guards a lagging report from writing into a newer connection's state.
+	epoch uint64
+	// baseline is the anchor for a tag's first report, set per connection by reset.
+	baseline time.Time
+	// lastReported maps each tag to its last confirmed report timestamp.
+	lastReported map[string]time.Time
+}
+
+// reporterState is an immutable snapshot of reporter state used to build a
+// report outside the mutex.
+type reporterState struct {
+	epoch        uint64
+	baseline     time.Time
+	lastReported map[string]time.Time
+}
+
+// selectionReportPayload contains the payload and metadata needed to update
+// lastReported after a successful POST.
+type selectionReportPayload struct {
+	epoch          uint64
+	entries        []selectionReportEntry
+	reportedTags   []string
+	skippedNoToken int
+}
+
+func newSelectionReporter(httpClient *http.Client) *selectionReporter {
+	return &selectionReporter{
+		httpClient:   httpClient,
+		reportURL:    common.GetBaseURL() + banditReportPath,
+		now:          time.Now,
+		lastReported: make(map[string]time.Time),
+	}
+}
+
+// reset clears every tag's lastReported timestamp and re-anchors the first
+// report window to the current time. It should be called when a new VPN
+// connection session starts.
+func (sr *selectionReporter) reset() {
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+
+	sr.epoch++
+	sr.baseline = sr.now()
+	sr.lastReported = make(map[string]time.Time)
+}
+
+// report posts reportable failures for all tokened tags in snapshot.
+// If nothing is reportable, it returns nil without sending a request.
+func (sr *selectionReporter) report(
+	ctx context.Context,
+	snapshot map[string]servers.SelectionHistory,
+	tokens map[string]string,
+) error {
+	now := sr.now()
+	prepared := sr.prepareReport(now, snapshot, tokens)
+	if len(prepared.entries) == 0 {
+		if prepared.skippedNoToken > 0 {
+			slog.Debug(
+				"Selection report skipped: no reportable entries",
+				"skippedNoToken", prepared.skippedNoToken,
+			)
+		}
+		return nil
+	}
+
+	if err := sr.post(ctx, prepared.entries); err != nil {
+		return err
+	}
+
+	sr.markReported(prepared.epoch, now, prepared.reportedTags)
+	slog.Debug(
+		"Reported selection history",
+		"entries", len(prepared.entries),
+		"skippedNoToken", prepared.skippedNoToken,
+	)
+	return nil
+}
+
+// prepareReport converts a snapshot into a POST payload using a point-in-time
+// copy of reporter state.
+func (sr *selectionReporter) prepareReport(
+	now time.Time,
+	snapshot map[string]servers.SelectionHistory,
+	tokens map[string]string,
+) selectionReportPayload {
+	state := sr.snapshotState()
+	result := selectionReportPayload{epoch: state.epoch}
+
+	for _, tag := range sortedSnapshotTags(snapshot) {
+		token := tokens[tag]
+		if token == "" {
+			result.skippedNoToken++
+			continue
+		}
+
+		lastReported := state.lastReported[tag]
+		if lastReported.IsZero() {
+			lastReported = state.baseline
+		}
+
+		failures := failuresSince(snapshot[tag].UserFailures, lastReported)
+		if len(failures) == 0 {
+			continue
+		}
+
+		result.entries = append(result.entries, selectionReportEntry{
+			ReportToken:   token,
+			Failures:      failures,
+			WindowSeconds: reportWindowSeconds(now, lastReported),
+		})
+		result.reportedTags = append(result.reportedTags, tag)
+	}
+
+	return result
+}
+
+// snapshotState copies the mutable reporter state so report preparation can run
+// without holding the mutex.
+func (sr *selectionReporter) snapshotState() reporterState {
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+
+	lastReported := make(map[string]time.Time, len(sr.lastReported))
+	for tag, ts := range sr.lastReported {
+		lastReported[tag] = ts
+	}
+
+	return reporterState{
+		epoch:        sr.epoch,
+		baseline:     sr.baseline,
+		lastReported: lastReported,
+	}
+}
+
+// markReported advances lastReported for the tags that were successfully sent.
+// If reset() ran during the POST, the epoch will differ and the stale update is
+// discarded.
+func (sr *selectionReporter) markReported(epoch uint64, reportedAt time.Time, tags []string) {
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+
+	if sr.epoch != epoch {
+		return
+	}
+
+	for _, tag := range tags {
+		sr.lastReported[tag] = reportedAt
+	}
+}
+
+func (sr *selectionReporter) post(ctx context.Context, entries []selectionReportEntry) error {
+	body, err := json.Marshal(selectionReportRequest{Reports: entries})
+	if err != nil {
+		return fmt.Errorf("marshal selection report: %w", err)
+	}
+	req, err := common.NewRequestWithHeaders(ctx, http.MethodPost, sr.reportURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build selection report request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	// The payload is a stateless snapshot, so transport-level retry/failover is safe.
+	req.Header.Set(kindling.IdempotentHeader, "1")
+
+	resp, err := sr.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("post selection report: %w", err)
+	}
+	defer resp.Body.Close()
+
+	io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("selection report rejected: %s", resp.Status)
+	}
+	return nil
+}
+
+// sortedSnapshotTags returns snapshot keys in stable order to keep payload
+// generation deterministic.
+func sortedSnapshotTags(snapshot map[string]servers.SelectionHistory) []string {
+	tags := make([]string, 0, len(snapshot))
+	for tag := range snapshot {
+		tags = append(tags, tag)
+	}
+	sort.Strings(tags)
+	return tags
+}
+
+// failuresSince returns only failures strictly newer than since.
+func failuresSince(failures []adapter.UserFailure, since time.Time) []adapter.UserFailure {
+	filtered := make([]adapter.UserFailure, 0, len(failures))
+	for _, failure := range failures {
+		if failure.At.After(since) {
+			filtered = append(filtered, failure)
+		}
+	}
+	return filtered
+}
+
+// reportWindowSeconds converts a report window to whole seconds and clamps it
+// to a minimum of 1.
+func reportWindowSeconds(now, since time.Time) int {
+	seconds := int(now.Sub(since).Seconds())
+	return max(1, seconds)
+}

--- a/backend/selection_reporter_test.go
+++ b/backend/selection_reporter_test.go
@@ -22,7 +22,7 @@ import (
 // so a test can advance time deterministically between report calls.
 func testReporter(t *testing.T, url string) (*selectionReporter, *time.Time) {
 	t.Helper()
-	clock := time.Unix(0, 0)
+	clock := time.Unix(0, 0).UTC()
 	sr := &selectionReporter{
 		httpClient:   http.DefaultClient,
 		reportURL:    url,
@@ -56,7 +56,7 @@ func reportAt(
 ) error {
 	t.Helper()
 
-	*clock = time.Unix(int64(at), 0)
+	*clock = time.Unix(int64(at), 0).UTC()
 	return sr.report(t.Context(), snapshot, tokens)
 }
 
@@ -81,8 +81,8 @@ func TestSelectionReporter_Report_PostsTokenedEntries(t *testing.T) {
 			ReportToken:   "tok-1",
 			WindowSeconds: 300,
 			Failures: []lbA.UserFailure{
-				{At: time.Unix(1, 0), Kind: lbA.UserFailureDial},
-				{At: time.Unix(2, 0), Kind: lbA.UserFailureReset},
+				{At: time.Unix(1, 0).UTC(), Kind: lbA.UserFailureDial},
+				{At: time.Unix(2, 0).UTC(), Kind: lbA.UserFailureReset},
 			},
 		},
 	}
@@ -107,8 +107,8 @@ func TestSelectionReporter_Report_SkipsTagsWithoutTokenOrFailures(t *testing.T) 
 	defer srv.Close()
 
 	snapshot := map[string]servers.SelectionHistory{
-		"has-token":    {UserFailures: []lbA.UserFailure{{At: time.Unix(1, 0), Kind: lbA.UserFailureStall}}},
-		"no-token":     {UserFailures: []lbA.UserFailure{{At: time.Unix(1, 0), Kind: lbA.UserFailureStall}}},
+		"has-token":    {UserFailures: []lbA.UserFailure{{At: time.Unix(1, 0).UTC(), Kind: lbA.UserFailureStall}}},
+		"no-token":     {UserFailures: []lbA.UserFailure{{At: time.Unix(1, 0).UTC(), Kind: lbA.UserFailureStall}}},
 		"no-failures":  {},
 		"token-nofail": {},
 	}
@@ -127,7 +127,7 @@ func TestSelectionReporter_Report_NoopWhenNothingReportable(t *testing.T) {
 	defer srv.Close()
 
 	snapshot := map[string]servers.SelectionHistory{
-		"a": {UserFailures: []lbA.UserFailure{{At: time.Unix(1, 0), Kind: lbA.UserFailureStall}}},
+		"a": {UserFailures: []lbA.UserFailure{{At: time.Unix(1, 0).UTC(), Kind: lbA.UserFailureStall}}},
 	}
 	// No token for "a" → nothing attributable → no request.
 	require.NoError(t, reportAt(t, sr, clock, 300, snapshot, map[string]string{}))
@@ -140,7 +140,7 @@ func TestSelectionReporter_Report_ErrorOnNon2xx(t *testing.T) {
 	defer srv.Close()
 
 	snapshot := map[string]servers.SelectionHistory{
-		"a": {UserFailures: []lbA.UserFailure{{At: time.Unix(1, 0), Kind: lbA.UserFailureStall}}},
+		"a": {UserFailures: []lbA.UserFailure{{At: time.Unix(1, 0).UTC(), Kind: lbA.UserFailureStall}}},
 	}
 	assert.Error(t, reportAt(t, sr, clock, 300, snapshot, map[string]string{"a": "tok"}))
 	assert.True(t, sr.lastReported["a"].IsZero(), "lastReported should not change when the POST fails")
@@ -158,14 +158,14 @@ func TestSelectionReporter_Report_DrainsAndWidensWindow(t *testing.T) {
 	tokens := map[string]string{"a": "tok"}
 
 	require.NoError(t, reportAt(t, sr, clock, 100, map[string]servers.SelectionHistory{
-		"a": history(lbA.UserFailure{At: time.Unix(10, 0), Kind: lbA.UserFailureDial}),
+		"a": history(lbA.UserFailure{At: time.Unix(10, 0).UTC(), Kind: lbA.UserFailureDial}),
 	}, tokens))
 
 	// The already-reported failure is still in the sliding window, plus a new one.
 	require.NoError(t, reportAt(t, sr, clock, 200, map[string]servers.SelectionHistory{
 		"a": history(
-			lbA.UserFailure{At: time.Unix(10, 0), Kind: lbA.UserFailureDial},
-			lbA.UserFailure{At: time.Unix(150, 0), Kind: lbA.UserFailureStall},
+			lbA.UserFailure{At: time.Unix(10, 0).UTC(), Kind: lbA.UserFailureDial},
+			lbA.UserFailure{At: time.Unix(150, 0).UTC(), Kind: lbA.UserFailureStall},
 		),
 	}, tokens))
 
@@ -201,7 +201,7 @@ func TestSelectionReporter_Report_RetainsFailuresAfterFailedPost(t *testing.T) {
 
 	tokens := map[string]string{"a": "tok"}
 	snapshot := map[string]servers.SelectionHistory{
-		"a": {UserFailures: []lbA.UserFailure{{At: time.Unix(10, 0), Kind: lbA.UserFailureReset}}},
+		"a": {UserFailures: []lbA.UserFailure{{At: time.Unix(10, 0).UTC(), Kind: lbA.UserFailureReset}}},
 	}
 
 	require.Error(t, reportAt(t, sr, clock, 100, snapshot, tokens))
@@ -227,14 +227,14 @@ func TestSelectionReporter_Reset_ReanchorsWindow(t *testing.T) {
 	tokens := map[string]string{"a": "tok"}
 
 	require.NoError(t, reportAt(t, sr, clock, 100, map[string]servers.SelectionHistory{
-		"a": history(lbA.UserFailure{At: time.Unix(10, 0), Kind: lbA.UserFailureDial}),
+		"a": history(lbA.UserFailure{At: time.Unix(10, 0).UTC(), Kind: lbA.UserFailureDial}),
 	}, tokens))
 
-	*clock = time.Unix(500, 0)
+	*clock = time.Unix(500, 0).UTC()
 	sr.reset()
 
 	require.NoError(t, reportAt(t, sr, clock, 560, map[string]servers.SelectionHistory{
-		"a": history(lbA.UserFailure{At: time.Unix(520, 0), Kind: lbA.UserFailureStall}),
+		"a": history(lbA.UserFailure{At: time.Unix(520, 0).UTC(), Kind: lbA.UserFailureStall}),
 	}, tokens))
 
 	got := decodeReportRequest(t, body)
@@ -259,7 +259,7 @@ func TestSelectionReporter_Report_ResetDuringPostDropsStaleWatermark(t *testing.
 	sr.reportURL = srv.URL
 
 	require.NoError(t, reportAt(t, sr, clock, 100, map[string]servers.SelectionHistory{
-		"a": history(lbA.UserFailure{At: time.Unix(10, 0), Kind: lbA.UserFailureDial}),
+		"a": history(lbA.UserFailure{At: time.Unix(10, 0).UTC(), Kind: lbA.UserFailureDial}),
 	}, map[string]string{"a": "tok"}))
 	<-reset
 

--- a/backend/selection_reporter_test.go
+++ b/backend/selection_reporter_test.go
@@ -1,0 +1,304 @@
+package backend
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	lbA "github.com/getlantern/lantern-box/adapter"
+
+	"github.com/getlantern/radiance/servers"
+)
+
+// testReporter builds a reporter whose clock is driven by the returned pointer,
+// so a test can advance time deterministically between report calls.
+func testReporter(t *testing.T, url string) (*selectionReporter, *time.Time) {
+	t.Helper()
+	clock := time.Unix(0, 0)
+	sr := &selectionReporter{
+		httpClient:   http.DefaultClient,
+		reportURL:    url,
+		now:          func() time.Time { return clock },
+		baseline:     clock,
+		lastReported: make(map[string]time.Time),
+	}
+	return sr, &clock
+}
+
+func testReporterWithServer(t *testing.T, handler http.HandlerFunc) (*selectionReporter, *time.Time, *httptest.Server) {
+	t.Helper()
+
+	srv := httptest.NewServer(handler)
+	sr, clock := testReporter(t, srv.URL)
+	sr.httpClient = srv.Client()
+	return sr, clock, srv
+}
+
+func history(failures ...lbA.UserFailure) servers.SelectionHistory {
+	return servers.SelectionHistory{UserFailures: failures}
+}
+
+func reportAt(
+	t *testing.T,
+	sr *selectionReporter,
+	clock *time.Time,
+	at int,
+	snapshot map[string]servers.SelectionHistory,
+	tokens map[string]string,
+) error {
+	t.Helper()
+
+	*clock = time.Unix(int64(at), 0)
+	return sr.report(t.Context(), snapshot, tokens)
+}
+
+func decodeReportRequest(t *testing.T, body []byte) selectionReportRequest {
+	t.Helper()
+
+	var got selectionReportRequest
+	require.NoError(t, json.Unmarshal(body, &got))
+	return got
+}
+
+func TestSelectionReporter_Report_PostsTokenedEntries(t *testing.T) {
+	var gotBody []byte
+	sr, clock, srv := testReporterWithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	want := []selectionReportEntry{
+		{
+			ReportToken:   "tok-1",
+			WindowSeconds: 300,
+			Failures: []lbA.UserFailure{
+				{At: time.Unix(1, 0), Kind: lbA.UserFailureDial},
+				{At: time.Unix(2, 0), Kind: lbA.UserFailureReset},
+			},
+		},
+	}
+	snapshot := map[string]servers.SelectionHistory{
+		"srv-1": {
+			UserFailures: want[0].Failures,
+		},
+	}
+	tokens := map[string]string{"srv-1": want[0].ReportToken}
+	require.NoError(t, reportAt(t, sr, clock, want[0].WindowSeconds, snapshot, tokens))
+
+	got := decodeReportRequest(t, gotBody)
+	assert.Equal(t, want, got.Reports, "the report request must contain the tokened failures and window")
+}
+
+func TestSelectionReporter_Report_SkipsTagsWithoutTokenOrFailures(t *testing.T) {
+	var gotBody []byte
+	sr, clock, srv := testReporterWithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	snapshot := map[string]servers.SelectionHistory{
+		"has-token":    {UserFailures: []lbA.UserFailure{{At: time.Unix(1, 0), Kind: lbA.UserFailureStall}}},
+		"no-token":     {UserFailures: []lbA.UserFailure{{At: time.Unix(1, 0), Kind: lbA.UserFailureStall}}},
+		"no-failures":  {},
+		"token-nofail": {},
+	}
+	tokens := map[string]string{"has-token": "tok", "no-failures": "tok2", "token-nofail": "tok3"}
+	require.NoError(t, reportAt(t, sr, clock, 300, snapshot, tokens))
+
+	got := decodeReportRequest(t, gotBody)
+	require.Len(t, got.Reports, 1, "only the tag with both a token and failures is reported")
+	assert.Equal(t, "tok", got.Reports[0].ReportToken)
+}
+
+func TestSelectionReporter_Report_NoopWhenNothingReportable(t *testing.T) {
+	sr, clock, srv := testReporterWithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(t, "report should not POST when there are no tokened entries")
+	})
+	defer srv.Close()
+
+	snapshot := map[string]servers.SelectionHistory{
+		"a": {UserFailures: []lbA.UserFailure{{At: time.Unix(1, 0), Kind: lbA.UserFailureStall}}},
+	}
+	// No token for "a" → nothing attributable → no request.
+	require.NoError(t, reportAt(t, sr, clock, 300, snapshot, map[string]string{}))
+}
+
+func TestSelectionReporter_Report_ErrorOnNon2xx(t *testing.T) {
+	sr, clock, srv := testReporterWithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	defer srv.Close()
+
+	snapshot := map[string]servers.SelectionHistory{
+		"a": {UserFailures: []lbA.UserFailure{{At: time.Unix(1, 0), Kind: lbA.UserFailureStall}}},
+	}
+	assert.Error(t, reportAt(t, sr, clock, 300, snapshot, map[string]string{"a": "tok"}))
+	assert.True(t, sr.lastReported["a"].IsZero(), "lastReported should not change when the POST fails")
+}
+
+func TestSelectionReporter_Report_DrainsAndWidensWindow(t *testing.T) {
+	var bodies [][]byte
+	sr, clock, srv := testReporterWithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, body)
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	tokens := map[string]string{"a": "tok"}
+
+	require.NoError(t, reportAt(t, sr, clock, 100, map[string]servers.SelectionHistory{
+		"a": history(lbA.UserFailure{At: time.Unix(10, 0), Kind: lbA.UserFailureDial}),
+	}, tokens))
+
+	// The already-reported failure is still in the sliding window, plus a new one.
+	require.NoError(t, reportAt(t, sr, clock, 200, map[string]servers.SelectionHistory{
+		"a": history(
+			lbA.UserFailure{At: time.Unix(10, 0), Kind: lbA.UserFailureDial},
+			lbA.UserFailure{At: time.Unix(150, 0), Kind: lbA.UserFailureStall},
+		),
+	}, tokens))
+
+	require.Len(t, bodies, 2, "both reports carry a fresh failure and POST")
+
+	r1 := decodeReportRequest(t, bodies[0])
+	r2 := decodeReportRequest(t, bodies[1])
+
+	require.Len(t, r1.Reports[0].Failures, 1)
+	assert.Equal(t, time.Unix(10, 0).UTC(), r1.Reports[0].Failures[0].At.UTC())
+	assert.Equal(t, 100, r1.Reports[0].WindowSeconds, "first window is now - baseline")
+
+	require.Len(t, r2.Reports[0].Failures, 1, "the already-reported failure is drained")
+	assert.Equal(t, time.Unix(150, 0).UTC(), r2.Reports[0].Failures[0].At.UTC())
+	assert.Equal(t, 100, r2.Reports[0].WindowSeconds, "second window is now - first report instant")
+}
+
+// A failed POST must not drop the failures it tried to send: the next report
+// re-sends them over a widened window rather than losing them.
+func TestSelectionReporter_Report_RetainsFailuresAfterFailedPost(t *testing.T) {
+	var fail atomic.Bool
+	fail.Store(true)
+	var lastBody []byte
+	sr, clock, srv := testReporterWithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if fail.Load() {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		lastBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	tokens := map[string]string{"a": "tok"}
+	snapshot := map[string]servers.SelectionHistory{
+		"a": {UserFailures: []lbA.UserFailure{{At: time.Unix(10, 0), Kind: lbA.UserFailureReset}}},
+	}
+
+	require.Error(t, reportAt(t, sr, clock, 100, snapshot, tokens))
+
+	fail.Store(false)
+	require.NoError(t, reportAt(t, sr, clock, 200, snapshot, tokens))
+
+	got := decodeReportRequest(t, lastBody)
+	require.Len(t, got.Reports, 1)
+	require.Len(t, got.Reports[0].Failures, 1, "the failure survived the failed POST and is re-sent")
+	assert.Equal(t, time.Unix(10, 0).UTC(), got.Reports[0].Failures[0].At.UTC())
+	assert.Equal(t, 200, got.Reports[0].WindowSeconds, "window widens to now - baseline after the retry")
+}
+
+func TestSelectionReporter_Reset_ReanchorsWindow(t *testing.T) {
+	var body []byte
+	sr, clock, srv := testReporterWithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	tokens := map[string]string{"a": "tok"}
+
+	require.NoError(t, reportAt(t, sr, clock, 100, map[string]servers.SelectionHistory{
+		"a": history(lbA.UserFailure{At: time.Unix(10, 0), Kind: lbA.UserFailureDial}),
+	}, tokens))
+
+	*clock = time.Unix(500, 0)
+	sr.reset()
+
+	require.NoError(t, reportAt(t, sr, clock, 560, map[string]servers.SelectionHistory{
+		"a": history(lbA.UserFailure{At: time.Unix(520, 0), Kind: lbA.UserFailureStall}),
+	}, tokens))
+
+	got := decodeReportRequest(t, body)
+	require.Len(t, got.Reports, 1)
+	assert.Equal(t, 60, got.Reports[0].WindowSeconds, "window is measured from the reset baseline")
+}
+
+// A report whose POST straddles a reset (a reconnect) must not write its
+// watermark into the new connection's state, or that tag's first post-reconnect
+// report would measure its window from the stale instant.
+func TestSelectionReporter_Report_ResetDuringPostDropsStaleWatermark(t *testing.T) {
+	sr, clock := testReporter(t, "")
+	reset := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Reset lands while the POST is in flight, mimicking a reconnect.
+		sr.reset()
+		close(reset)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	sr.httpClient = srv.Client()
+	sr.reportURL = srv.URL
+
+	require.NoError(t, reportAt(t, sr, clock, 100, map[string]servers.SelectionHistory{
+		"a": history(lbA.UserFailure{At: time.Unix(10, 0), Kind: lbA.UserFailureDial}),
+	}, map[string]string{"a": "tok"}))
+	<-reset
+
+	assert.True(t, sr.lastReported["a"].IsZero(), "a watermark from a report that straddled reset must be dropped")
+}
+
+func TestRunReportLoop_StopsWhenIntervalDropsToZero(t *testing.T) {
+	intervals := []time.Duration{time.Millisecond, time.Millisecond, 0}
+	i := 0
+	interval := func() time.Duration {
+		if i >= len(intervals) {
+			return 0
+		}
+		d := intervals[i]
+		i++
+		return d
+	}
+	var reports int
+	runReportLoop(t.Context(), interval, func() { reports++ })
+	assert.Equal(t, 2, reports, "one report per positive interval before the disabling zero")
+}
+
+func TestRunReportLoop_NeverStartsWhenDisabled(t *testing.T) {
+	var reports int
+	runReportLoop(t.Context(), func() time.Duration { return 0 }, func() { reports++ })
+	assert.Zero(t, reports, "a disabled interval reports nothing")
+}
+
+func TestRunReportLoop_StopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	done := make(chan struct{})
+	go func() {
+		runReportLoop(ctx, func() time.Duration { return time.Hour }, func() {})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		assert.Fail(t, "runReportLoop did not stop after context cancel")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -31,12 +31,12 @@ require (
 	github.com/alexflint/go-arg v1.6.1
 	github.com/alitto/pond v1.9.2
 	github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c
-	github.com/getlantern/common v1.2.1-0.20260705172801-57aaafd97c1b
+	github.com/getlantern/common v1.2.1-0.20260707162341-64fe9ec72f43
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac
 	github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3
 	github.com/getlantern/kindling v0.0.0-20260625002640-7cdf7184420c
-	github.com/getlantern/lantern-box v0.0.100
+	github.com/getlantern/lantern-box v0.0.101-0.20260707172850-b5037237bcc5
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/alexflint/go-arg v1.6.1
 	github.com/alitto/pond v1.9.2
 	github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c
-	github.com/getlantern/common v1.2.1-0.20260707162341-64fe9ec72f43
+	github.com/getlantern/common v1.2.1-0.20260708083946-cc657b08792c
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac
 	github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3
 	github.com/getlantern/kindling v0.0.0-20260625002640-7cdf7184420c
-	github.com/getlantern/lantern-box v0.0.101-0.20260707172850-b5037237bcc5
+	github.com/getlantern/lantern-box v0.0.101
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvd
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260625002640-7cdf7184420c h1:F4/LE+5zehr6AUfuJBab3iubscOOTdFZxwYldIpLgg8=
 github.com/getlantern/kindling v0.0.0-20260625002640-7cdf7184420c/go.mod h1:rN6O8pIQ9nc7Gyvtf2GGSjiWEFIApGsRCHkgYz0h3Ak=
-github.com/getlantern/lantern-box v0.0.101-0.20260707172850-b5037237bcc5 h1:7FoLHuMumPH75PSFATf2B/Zy5bSFZ8IuDs3Ud/W+V80=
-github.com/getlantern/lantern-box v0.0.101-0.20260707172850-b5037237bcc5/go.mod h1:yQhnLpnDY17+c/s+4WiiUhun3HtoHNj5NFb355ThKQk=
+github.com/getlantern/lantern-box v0.0.101 h1:HXJWgpv48B5lo9d9p4Q0crYi3X3YIn+tJMh/F3sbyH0=
+github.com/getlantern/lantern-box v0.0.101/go.mod h1:yQhnLpnDY17+c/s+4WiiUhun3HtoHNj5NFb355ThKQk=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395/go.mod h1:3JpJgwi4KEI6rS9loOAvcBp+F2jP65d0tTg2GQcTPBU=
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 h1:3BwvWj0JZzFEvNNiMhCu4bf60nqcIuQpTYb00Ezm1ag=

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c h1:ZzxuhIWO295y4eE6
 github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c/go.mod h1:b5teAOFT+vpBqc2CHoz74QTEM15iOv1PLdQogwXcfrM=
 github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc h1:AVY56mzJHM4CBTrW9oBgpShB5S68gGunvk9GMvJrkzM=
 github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc/go.mod h1:bIxM6xon/ADgprn6tZXYdXGrUIMCzq6u8zO9rET50IE=
-github.com/getlantern/common v1.2.1-0.20260705172801-57aaafd97c1b h1:R6YoZuQFLdArpovoMtPxa3ohqJzx6bpJ+BRxDaoMdWk=
-github.com/getlantern/common v1.2.1-0.20260705172801-57aaafd97c1b/go.mod h1:eSSuV4bMPgQJnczBw+KWWqWNo1itzmVxC++qUBPRTt0=
+github.com/getlantern/common v1.2.1-0.20260707162341-64fe9ec72f43 h1:Gr2JpgLcv1yhmobvSlkd3emxw4ohx1XJcCg7LvFiy+g=
+github.com/getlantern/common v1.2.1-0.20260707162341-64fe9ec72f43/go.mod h1:eSSuV4bMPgQJnczBw+KWWqWNo1itzmVxC++qUBPRTt0=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=
@@ -246,8 +246,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvd
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260625002640-7cdf7184420c h1:F4/LE+5zehr6AUfuJBab3iubscOOTdFZxwYldIpLgg8=
 github.com/getlantern/kindling v0.0.0-20260625002640-7cdf7184420c/go.mod h1:rN6O8pIQ9nc7Gyvtf2GGSjiWEFIApGsRCHkgYz0h3Ak=
-github.com/getlantern/lantern-box v0.0.100 h1:mnWdy4lfPBABtu8ClWQ/8qzfV5PAJWjrbKapk37dw/o=
-github.com/getlantern/lantern-box v0.0.100/go.mod h1:yQhnLpnDY17+c/s+4WiiUhun3HtoHNj5NFb355ThKQk=
+github.com/getlantern/lantern-box v0.0.101-0.20260707172850-b5037237bcc5 h1:7FoLHuMumPH75PSFATf2B/Zy5bSFZ8IuDs3Ud/W+V80=
+github.com/getlantern/lantern-box v0.0.101-0.20260707172850-b5037237bcc5/go.mod h1:yQhnLpnDY17+c/s+4WiiUhun3HtoHNj5NFb355ThKQk=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395/go.mod h1:3JpJgwi4KEI6rS9loOAvcBp+F2jP65d0tTg2GQcTPBU=
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 h1:3BwvWj0JZzFEvNNiMhCu4bf60nqcIuQpTYb00Ezm1ag=

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c h1:ZzxuhIWO295y4eE6
 github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c/go.mod h1:b5teAOFT+vpBqc2CHoz74QTEM15iOv1PLdQogwXcfrM=
 github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc h1:AVY56mzJHM4CBTrW9oBgpShB5S68gGunvk9GMvJrkzM=
 github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc/go.mod h1:bIxM6xon/ADgprn6tZXYdXGrUIMCzq6u8zO9rET50IE=
-github.com/getlantern/common v1.2.1-0.20260707162341-64fe9ec72f43 h1:Gr2JpgLcv1yhmobvSlkd3emxw4ohx1XJcCg7LvFiy+g=
-github.com/getlantern/common v1.2.1-0.20260707162341-64fe9ec72f43/go.mod h1:eSSuV4bMPgQJnczBw+KWWqWNo1itzmVxC++qUBPRTt0=
+github.com/getlantern/common v1.2.1-0.20260708083946-cc657b08792c h1:Hpxu12ORnAcyYuIqV2yAqrmDAnTaY1Cd3yL7TvFB6ME=
+github.com/getlantern/common v1.2.1-0.20260708083946-cc657b08792c/go.mod h1:eSSuV4bMPgQJnczBw+KWWqWNo1itzmVxC++qUBPRTt0=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=


### PR DESCRIPTION
## Summary

Adds a periodic reporter that POSTs each route's user-traffic failure history (dial/stall/reset, tagged by kind) to `/v1/bandit/report`, so the bandit can weigh real data-plane outcomes rather than just probe reachability.

- **Drain by watermark** — each successful report advances a per-tag high-water mark; later reports send only failures newer than it, so nothing is double-reported. A failed POST leaves the mark unmoved, so those failures are retried over a widened window rather than dropped.
- **`window_seconds`** is the actual elapsed accumulation period per entry, not the configured interval.
- **Epoch guard** — a report whose POST straddles a reconnect can't write a stale watermark into the new session's state.
- **Interval loop** re-derives the server-configured cadence each cycle and stops within one cycle when it is dropped. Reporting is gated on `RouteSelectionReportIntervalSeconds` (zero/absent disables it); routes are attributed via server-issued `BanditReportTokens`, both read from the config response.

## Depends on

- getlantern/lantern-box#286 — provides the typed `UserFailure` history this reads. The `lantern-box` bump in this PR points at that branch.

closes getlantern/engineering#3676.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added periodic, session-aware selection-history reporting while the VPN connection is active.
  * Reports include a rolling window of recent selection failures and idempotent request metadata.
* **Bug Fixes**
  * Improved resilience to failed submissions: retries resend the correct failures without corrupting subsequent reporting.
  * Fixed reconnect/session reset so reporting windows and watermarks re-anchor cleanly each connection.
* **Tests**
  * Added comprehensive automated coverage for reporting cadence, windowing, retry behavior, and cancellation/timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->