### PR TITLE
fix: skipping amp transport based on country

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
+	"strings"
 	"sync"
 
 	"time"
@@ -223,11 +224,12 @@ func (r *LocalBackend) Start() {
 	r.startAutoSelectedListener()
 	r.startSessionAutoSelectListener()
 
-	// Track the country on every config response, not just the first: it feeds
-	// issue reports and gates which transports kindling wires up (AMP is
-	// disabled in China), and the country can change while the app runs.
-	events.SubscribeContext(r.ctx, func(evt config.NewConfigEvent) {
+	// The server derives the country from the client IP, so it's stable for the
+	// session: react once to record it for issue reports and to apply the
+	// country-specific transport policy (AMP is disabled in China).
+	events.SubscribeOnce(func(evt config.NewConfigEvent) {
 		setCountryCodeFromConfig(evt.New)
+		applyTransportPolicy()
 	})
 	// update VPN outbounds when new config is received
 	events.SubscribeContext(r.ctx, func(evt config.NewConfigEvent) {
@@ -248,6 +250,7 @@ func (r *LocalBackend) applyCurrentConfig() bool {
 		return false
 	}
 	setCountryCodeFromConfig(cfg)
+	applyTransportPolicy()
 	r.applyConfig(cfg)
 	return true
 }
@@ -290,33 +293,33 @@ func (r *LocalBackend) applyConfig(cfg *config.Config) {
 	}
 }
 
-// countryUpdateMu serializes country transitions: config events are dispatched
-// in independent goroutines (events.Emit), so the read-modify-write on
-// CountryCodeKey and the kindling rebuild must not interleave.
-var countryUpdateMu sync.Mutex
-
-// setCountryCodeFromConfig stores the config country for diagnostics and, when
-// the change flips the per-country transport policy (AMP is disabled in China),
-// rebuilds kindling so it re-applies. The rebuild is a full teardown of the
-// transport stack, so it is gated on an actual policy flip rather than any
-// country change. An explicit country override takes precedence and suppresses
-// both.
+// setCountryCodeFromConfig stores the config country for diagnostics unless
+// an explicit country override is active.
 func setCountryCodeFromConfig(cfg *config.Config) {
 	if env.GetString(env.Country) != "" || cfg == nil || cfg.Country == "" {
 		return
 	}
-	countryUpdateMu.Lock()
-	defer countryUpdateMu.Unlock()
-	prev := settings.GetString(settings.CountryCodeKey)
-	if cfg.Country == prev {
-		return
-	}
 	if err := settings.Set(settings.CountryCodeKey, cfg.Country); err != nil {
 		slog.Error("failed to set country code in settings", "error", err)
-		return
 	}
 	slog.Info("Set country code from config", "country_code", cfg.Country)
-	if kindling.AMPEnabledForCountry(prev) != kindling.AMPEnabledForCountry(cfg.Country) {
+}
+
+// ampEnabledForCountry reports whether the AMP transport works from the given
+// country. AMP fronts through Google domains that are unreachable from China.
+func ampEnabledForCountry(country string) bool {
+	return !strings.EqualFold(country, "CN")
+}
+
+// applyTransportPolicy enables or disables the AMP transport based on the
+// user's country and rebuilds kindling when that changes the enabled set. The
+// env override takes precedence over the config-derived country in settings.
+func applyTransportPolicy() {
+	country := settings.GetString(settings.CountryCodeKey)
+	if override := env.GetString(env.Country); override != "" {
+		country = override
+	}
+	if kindling.EnableTransport(kindling.TransportAMP, ampEnabledForCountry(country)) {
 		kindling.Close()
 		kindling.Init()
 	}

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -223,16 +223,30 @@ func (r *LocalBackend) Start() {
 	r.startAutoSelectedListener()
 	r.startSessionAutoSelectListener()
 
-	// set country code in settings when new config is received so it can be included in issue reports
-	events.SubscribeOnce(func(evt config.NewConfigEvent) {
+	// Track the country from every config response: it feeds issue reports and
+	// gates which transports kindling wires up (AMP is disabled in China). When
+	// the country change flips that policy, rebuild kindling so it re-applies.
+	events.SubscribeContext(r.ctx, func(evt config.NewConfigEvent) {
 		if env.GetString(env.Country) != "" {
 			return // respect env override if set
 		}
-		if evt.New != nil && evt.New.Country != "" {
-			if err := settings.Set(settings.CountryCodeKey, evt.New.Country); err != nil {
-				slog.Error("failed to set country code in settings", "error", err)
+		if evt.New == nil || evt.New.Country == "" {
+			return
+		}
+		prev := settings.GetString(settings.CountryCodeKey)
+		if evt.New.Country == prev {
+			return
+		}
+		if err := settings.Set(settings.CountryCodeKey, evt.New.Country); err != nil {
+			slog.Error("failed to set country code in settings", "error", err)
+			return
+		}
+		slog.Info("Set country code from config response", "country_code", evt.New.Country)
+		if kindling.AMPEnabledForCountry(prev) != kindling.AMPEnabledForCountry(evt.New.Country) {
+			if err := kindling.Close(); err != nil {
+				slog.Error("failed to close kindling before country rebuild", "error", err)
 			}
-			slog.Info("Set country code from config response", "country_code", evt.New.Country)
+			kindling.Init()
 		}
 	})
 	// update VPN outbounds when new config is received

--- a/kindling/client.go
+++ b/kindling/client.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/getlantern/radiance/bypass"
 	"github.com/getlantern/radiance/common"
+	"github.com/getlantern/radiance/common/env"
 	"github.com/getlantern/radiance/common/reporting"
 	"github.com/getlantern/radiance/common/settings"
 	"github.com/getlantern/radiance/kindling/dnstt"
@@ -189,7 +190,13 @@ func NewKindling(dataDir string) (*Client, error) {
 		}
 	}
 
-	if EnabledTransports[kindling.TransportAMP] && AMPEnabledForCountry(settings.GetString(settings.CountryCodeKey)) {
+	// env.Country overrides the config-derived country and isn't always mirrored
+	// into settings (e.g. RADIANCE_COUNTRY set at launch), so resolve it here.
+	country := settings.GetString(settings.CountryCodeKey)
+	if override := env.GetString(env.Country); override != "" {
+		country = override
+	}
+	if EnabledTransports[kindling.TransportAMP] && AMPEnabledForCountry(country) {
 		ampClient, err := fronted.NewAMPClient(updaterCtx, dataDir, logger)
 		if err != nil {
 			slog.Error("failed to create amp client", slog.Any("error", err))

--- a/kindling/client.go
+++ b/kindling/client.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/getlantern/radiance/bypass"
 	"github.com/getlantern/radiance/common"
-	"github.com/getlantern/radiance/common/env"
 	"github.com/getlantern/radiance/common/reporting"
 	"github.com/getlantern/radiance/common/settings"
 	"github.com/getlantern/radiance/kindling/dnstt"
@@ -27,12 +26,24 @@ import (
 	"github.com/getlantern/radiance/traces"
 )
 
+// TransportName identifies a transport that can be toggled via EnableTransport.
+type TransportName = kindling.TransportName
+
+// Transport names re-exported so callers configure transports through this
+// package without importing the upstream kindling library directly.
+const (
+	TransportAMP         = kindling.TransportAMP
+	TransportDomainfront = kindling.TransportDomainfront
+	TransportDNSTunnel   = kindling.TransportDNSTunnel
+	TransportSmart       = kindling.TransportSmart
+)
+
 var (
 	mu          sync.Mutex
 	initialized bool
 	k           *Client
-	// EnabledTransports gates which transports NewKindling wires up. Intended for tests; not a
-	// production toggle.
+	// EnabledTransports gates which transports NewKindling wires up. Toggle it
+	// through EnableTransport, then rebuild via Close+Init to apply the change.
 	EnabledTransports = map[kindling.TransportName]bool{
 		kindling.TransportDNSTunnel:   true,
 		kindling.TransportAMP:         true,
@@ -44,11 +55,16 @@ var (
 	transport http.RoundTripper
 )
 
-// AMPEnabledForCountry reports whether the AMP transport should be wired up for
-// the given country. AMP fronts through Google domains that are unreachable
-// from China, so racing it there only wastes connection attempts.
-func AMPEnabledForCountry(country string) bool {
-	return !strings.EqualFold(country, "CN")
+// EnableTransport sets whether NewKindling wires up the given transport and
+// reports whether that changed the current setting. The change takes effect on
+// the next rebuild (Close then Init). Call it before rebuilding, not
+// concurrently with one.
+func EnableTransport(transport TransportName, enable bool) bool {
+	if EnabledTransports[transport] == enable {
+		return false
+	}
+	EnabledTransports[transport] = enable
+	return true
 }
 
 func initKindling() {
@@ -190,13 +206,7 @@ func NewKindling(dataDir string) (*Client, error) {
 		}
 	}
 
-	// env.Country overrides the config-derived country and isn't always mirrored
-	// into settings (e.g. RADIANCE_COUNTRY set at launch), so resolve it here.
-	country := settings.GetString(settings.CountryCodeKey)
-	if override := env.GetString(env.Country); override != "" {
-		country = override
-	}
-	if EnabledTransports[kindling.TransportAMP] && AMPEnabledForCountry(country) {
+	if enabled := EnabledTransports[kindling.TransportAMP]; enabled {
 		ampClient, err := fronted.NewAMPClient(updaterCtx, dataDir, logger)
 		if err != nil {
 			slog.Error("failed to create amp client", slog.Any("error", err))

--- a/kindling/client.go
+++ b/kindling/client.go
@@ -43,6 +43,13 @@ var (
 	transport http.RoundTripper
 )
 
+// AMPEnabledForCountry reports whether the AMP transport should be wired up for
+// the given country. AMP fronts through Google domains that are unreachable
+// from China, so racing it there only wastes connection attempts.
+func AMPEnabledForCountry(country string) bool {
+	return !strings.EqualFold(country, "CN")
+}
+
 func initKindling() {
 	newK, err := NewKindling(settings.GetString(settings.DataPathKey))
 	if err != nil {
@@ -182,7 +189,7 @@ func NewKindling(dataDir string) (*Client, error) {
 		}
 	}
 
-	if enabled := EnabledTransports[kindling.TransportAMP]; enabled {
+	if EnabledTransports[kindling.TransportAMP] && AMPEnabledForCountry(settings.GetString(settings.CountryCodeKey)) {
 		ampClient, err := fronted.NewAMPClient(updaterCtx, dataDir, logger)
 		if err != nil {
 			slog.Error("failed to create amp client", slog.Any("error", err))

--- a/kindling/client_test.go
+++ b/kindling/client_test.go
@@ -9,16 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAMPEnabledForCountry(t *testing.T) {
-	wantEnabled := map[string]bool{
-		"":   true,
-		"US": true,
-		"CN": false,
-		"cn": false, // matching is case-insensitive
-	}
-	for country, want := range wantEnabled {
-		assert.Equal(t, want, AMPEnabledForCountry(country), "country=%q", country)
-	}
+func TestEnableTransport(t *testing.T) {
+	prev := EnabledTransports[kindling.TransportAMP]
+	t.Cleanup(func() { EnabledTransports[kindling.TransportAMP] = prev })
+
+	EnabledTransports[kindling.TransportAMP] = true
+	assert.True(t, EnableTransport(kindling.TransportAMP, false), "flipping the value reports a change")
+	assert.False(t, EnabledTransports[kindling.TransportAMP])
+	assert.False(t, EnableTransport(kindling.TransportAMP, false), "setting the same value reports no change")
 }
 
 func TestNewClient(t *testing.T) {

--- a/kindling/client_test.go
+++ b/kindling/client_test.go
@@ -9,6 +9,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestAMPEnabledForCountry(t *testing.T) {
+	wantEnabled := map[string]bool{
+		"":   true,
+		"US": true,
+		"CN": false,
+		"cn": false, // matching is case-insensitive
+	}
+	for country, want := range wantEnabled {
+		assert.Equal(t, want, AMPEnabledForCountry(country), "country=%q", country)
+	}
+}
+
 func TestNewClient(t *testing.T) {
 	transports := []kindling.TransportName{
 		kindling.TransportDomainfront,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transport settings can now be enabled/disabled via a public transport toggle API, with changes taking effect after the next rebuild.
  * Country-based transport policy is now applied immediately at startup and continues updating live while running (AMP enabled for all countries except China).

* **Bug Fixes**
  * Cached configuration loading now correctly reapplies the transport policy to match the resolved country and environment overrides.

* **Tests**
  * Added coverage for transport enable/disable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->