### PR TITLE
fix(bypass): use SOCKS5 so upstream dial failures propagate

### DIFF
--- a/bypass/bypass.go
+++ b/bypass/bypass.go
@@ -1,110 +1,60 @@
 package bypass
 
 import (
-	"bufio"
 	"context"
-	"fmt"
 	"net"
-	"net/http"
-	"net/url"
 	"time"
+
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+	"github.com/sagernet/sing/protocol/socks"
 )
 
 const (
 	// ProxyPort is the port for the local bypass proxy listener.
 	ProxyPort = 14985
 
-	// ProxyAddr is the address of the local bypass proxy listener in the VPN process.
-	ProxyAddr = "127.0.0.1:14985"
-
 	// BypassInboundTag is the sing-box inbound tag used for routing bypass traffic to direct.
 	BypassInboundTag = "bypass-in"
 
-	// connectTimeout is the default timeout for the HTTP CONNECT handshake
-	// when the caller's context has no deadline.
-	connectTimeout = 10 * time.Second
-
-	// dialTimeout is the timeout for establishing the initial TCP connection.
-	dialTimeout = 30 * time.Second
-
-	// dialKeepAlive is the interval for TCP keep-alive probes.
+	dialTimeout   = 30 * time.Second
 	dialKeepAlive = 30 * time.Second
 )
 
-// DialContext tries to connect through the local bypass proxy. If the proxy is
-// not reachable (VPN not running), it falls back to a direct dial.
+// proxyClient dials through the local bypass proxy. We use SOCKS5
+// because sing-box's HTTP inbound returns 200 OK for CONNECT before
+// the upstream connection is established, falsely signaling success
+// to callers.
+var proxyClient = socks.NewClient(
+	N.SystemDialer,
+	M.ParseSocksaddrHostPort("127.0.0.1", uint16(ProxyPort)),
+	socks.Version5,
+	"", "",
+)
+
+// DialContext uses the local SOCKS5 bypass proxy when it is available.
+// If the proxy itself is down, it falls back to a direct dial.
 func DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
-	dialer := &net.Dialer{
-		Timeout:   dialTimeout,
-		KeepAlive: dialKeepAlive,
-	}
-	proxyConn, err := dialer.DialContext(ctx, "tcp", ProxyAddr)
+	conn, err := proxyClient.DialContext(ctx, network, M.ParseSocksaddr(addr))
 	if err != nil {
+		dialer := &net.Dialer{
+			Timeout:   dialTimeout,
+			KeepAlive: dialKeepAlive,
+		}
 		return dialer.DialContext(ctx, network, addr)
 	}
-	tunnelConn, err := httpConnect(ctx, proxyConn, addr)
-	if err != nil {
-		proxyConn.Close()
-		return nil, err
-	}
-	return tunnelConn, nil
+	return &tunneledConn{conn}, nil
+}
+
+// tunneledConn masks the loopback socket to the bypass proxy so StreamDialer
+// keeps it away from strategies like disorder that manipulate the target
+// socket directly.
+type tunneledConn struct {
+	net.Conn
 }
 
 // Dial is a convenience wrapper without context, suitable for use with
 // amp.WithDialer which expects func(network, addr string) (net.Conn, error).
 func Dial(network, addr string) (net.Conn, error) {
 	return DialContext(context.Background(), network, addr)
-}
-
-// bufferedConn wraps a net.Conn with a bufio.Reader so that any bytes
-// buffered during the HTTP CONNECT response read are not lost.
-type bufferedConn struct {
-	net.Conn
-	br *bufio.Reader
-}
-
-func (c *bufferedConn) Read(b []byte) (int, error) {
-	return c.br.Read(b)
-}
-
-// httpConnect performs an HTTP CONNECT handshake over an already-established
-// connection to the proxy. It returns a wrapped connection that preserves any
-// bytes buffered during the response read. It respects the context deadline;
-// if none is set, a default timeout is applied for the handshake and cleared
-// afterward.
-func httpConnect(ctx context.Context, conn net.Conn, addr string) (net.Conn, error) {
-	deadline, hasDeadline := ctx.Deadline()
-	if !hasDeadline {
-		deadline = time.Now().Add(connectTimeout)
-	}
-	if err := conn.SetDeadline(deadline); err != nil {
-		return nil, fmt.Errorf("bypass: failed to set deadline: %w", err)
-	}
-
-	req := &http.Request{
-		Method: http.MethodConnect,
-		URL:    &url.URL{Opaque: addr},
-		Host:   addr,
-		Header: make(http.Header),
-	}
-	if err := req.Write(conn); err != nil {
-		return nil, fmt.Errorf("bypass: failed to write CONNECT request: %w", err)
-	}
-
-	br := bufio.NewReader(conn)
-	resp, err := http.ReadResponse(br, req)
-	if err != nil {
-		return nil, fmt.Errorf("bypass: failed to read CONNECT response: %w", err)
-	}
-	resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("bypass: CONNECT returned status %d", resp.StatusCode)
-	}
-
-	// Clear deadline so subsequent I/O on the tunneled connection isn't constrained.
-	if err := conn.SetDeadline(time.Time{}); err != nil {
-		return nil, fmt.Errorf("bypass: failed to clear deadline: %w", err)
-	}
-	return &bufferedConn{Conn: conn, br: br}, nil
 }

--- a/bypass/bypass.go
+++ b/bypass/bypass.go
@@ -2,6 +2,7 @@ package bypass
 
 import (
 	"context"
+	"errors"
 	"net"
 	"time"
 
@@ -26,24 +27,47 @@ const (
 // the upstream connection is established, falsely signaling success
 // to callers.
 var proxyClient = socks.NewClient(
-	N.SystemDialer,
+	proxyDialer{N.SystemDialer},
 	M.ParseSocksaddrHostPort("127.0.0.1", uint16(ProxyPort)),
 	socks.Version5,
 	"", "",
 )
 
-// DialContext uses the local SOCKS5 bypass proxy when it is available.
-// If the proxy itself is down, it falls back to a direct dial.
+// proxyDialer tags a failure to reach the local bypass proxy so DialContext can
+// tell a down proxy apart from a SOCKS handshake or upstream dial failure.
+type proxyDialer struct{ N.Dialer }
+
+func (d proxyDialer) DialContext(ctx context.Context, network string, destination M.Socksaddr) (net.Conn, error) {
+	conn, err := d.Dialer.DialContext(ctx, network, destination)
+	if err != nil {
+		return nil, &proxyUnreachable{err}
+	}
+	return conn, nil
+}
+
+type proxyUnreachable struct{ err error }
+
+func (e *proxyUnreachable) Error() string { return e.err.Error() }
+func (e *proxyUnreachable) Unwrap() error { return e.err }
+
+// DialContext dials addr through the local SOCKS5 bypass proxy. It falls back to
+// a direct dial only when the proxy itself is unreachable (VPN not running); a
+// handshake or upstream failure propagates so the smart dialer can fail over
+// rather than silently succeeding via a route that skips the proxy.
 func DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	conn, err := proxyClient.DialContext(ctx, network, M.ParseSocksaddr(addr))
-	if err != nil {
-		dialer := &net.Dialer{
-			Timeout:   dialTimeout,
-			KeepAlive: dialKeepAlive,
-		}
-		return dialer.DialContext(ctx, network, addr)
+	if err == nil {
+		return &tunneledConn{conn}, nil
 	}
-	return &tunneledConn{conn}, nil
+	var unreachable *proxyUnreachable
+	if !errors.As(err, &unreachable) {
+		return nil, err
+	}
+	dialer := &net.Dialer{
+		Timeout:   dialTimeout,
+		KeepAlive: dialKeepAlive,
+	}
+	return dialer.DialContext(ctx, network, addr)
 }
 
 // tunneledConn masks the loopback socket to the bypass proxy so StreamDialer

--- a/bypass/bypass_test.go
+++ b/bypass/bypass_test.go
@@ -2,58 +2,44 @@ package bypass
 
 import (
 	"context"
-	"io"
 	"net"
-	"net/http"
-	"net/http/httptest"
 	"testing"
-	"time"
 
+	box "github.com/sagernet/sing-box"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing/common/json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	lbox "github.com/getlantern/lantern-box"
 )
 
-// newConnectProxy returns an httptest.Server that handles HTTP CONNECT
-// requests by hijacking the connection and tunneling data to the target.
-func newConnectProxy(t *testing.T) *httptest.Server {
+// newSingboxServer starts a sing-box mixed inbound on ProxyPort that routes to
+// the default direct outbound, standing in for the production bypass proxy. It
+// is torn down on test cleanup so the fixed port is free for the next test.
+func newSingboxServer(t *testing.T) *box.Box {
 	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodConnect {
-			http.Error(w, "only CONNECT supported", http.StatusMethodNotAllowed)
-			return
+	opts := `{
+	"inbounds": [
+		{
+			"type": "mixed",
+			"tag": "socks-in",
+			"listen": "127.0.0.1",
+			"listen_port": 14985
 		}
-
-		target, err := net.DialTimeout("tcp", r.Host, 5*time.Second)
-		if err != nil {
-			http.Error(w, "bad gateway", http.StatusBadGateway)
-			return
-		}
-		defer target.Close()
-
-		hijacker, ok := w.(http.Hijacker)
-		if !ok {
-			http.Error(w, "hijacking not supported", http.StatusInternalServerError)
-			return
-		}
-
-		clientConn, _, err := hijacker.Hijack()
-		if err != nil {
-			return
-		}
-		defer clientConn.Close()
-
-		clientConn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
-
-		done := make(chan struct{}, 2)
-		cp := func(dst, src net.Conn) {
-			io.Copy(dst, src)
-			done <- struct{}{}
-		}
-		go cp(target, clientConn)
-		go cp(clientConn, target)
-		<-done
-		<-done
-	}))
+	]
+}`
+	ctx := lbox.BaseContext()
+	options, err := json.UnmarshalExtendedContext[option.Options](ctx, []byte(opts))
+	require.NoError(t, err)
+	server, err := box.New(box.Options{
+		Context: ctx,
+		Options: options,
+	})
+	require.NoError(t, err)
+	require.NoError(t, server.Start())
+	t.Cleanup(func() { server.Close() })
+	return server
 }
 
 // newEchoServer starts a TCP listener that accepts one connection,
@@ -78,34 +64,51 @@ func newEchoServer(t *testing.T) string {
 	return ln.Addr().String()
 }
 
-func TestDialContext_ProxyAvailable(t *testing.T) {
-	proxy := newConnectProxy(t)
-	defer proxy.Close()
+// deadTCPAddr returns a 127.0.0.1 address with no listener, so a dial to it is
+// refused deterministically.
+func deadTCPAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+	return addr
+}
 
+func TestDialContext_ThroughProxy(t *testing.T) {
+	newSingboxServer(t)
 	echoAddr := newEchoServer(t)
 
-	proxyConn, err := net.Dial("tcp", proxy.Listener.Addr().String())
+	conn, err := DialContext(context.Background(), "tcp", echoAddr)
 	require.NoError(t, err)
-	defer proxyConn.Close()
+	defer conn.Close()
 
-	tunnelConn, err := httpConnect(context.Background(), proxyConn, echoAddr)
-	require.NoError(t, err)
+	_, ok := conn.(*tunneledConn)
+	require.True(t, ok, "expected the proxy path (tunneledConn), not the direct fallback")
 
 	msg := []byte("hello bypass")
-	_, err = tunnelConn.Write(msg)
+	_, err = conn.Write(msg)
 	require.NoError(t, err)
 
 	buf := make([]byte, 64)
-	n, err := tunnelConn.Read(buf)
+	n, err := conn.Read(buf)
 	require.NoError(t, err)
 	assert.Equal(t, string(msg), string(buf[:n]))
+}
+
+func TestDialContext_UpstreamUnreachable(t *testing.T) {
+	newSingboxServer(t)
+	deadEnd := deadTCPAddr(t)
+
+	_, err := DialContext(context.Background(), "tcp", deadEnd)
+	require.Error(t, err, "an unreachable upstream must error so Happy Eyeballs can fail over")
 }
 
 func TestDialContext_FallbackWhenProxyDown(t *testing.T) {
 	echoAddr := newEchoServer(t)
 
 	conn, err := DialContext(context.Background(), "tcp", echoAddr)
-	require.NoError(t, err, "DialContext should fall back to direct dial")
+	require.NoError(t, err, "DialContext should fall back to direct dial when the proxy is down")
 	defer conn.Close()
 
 	msg := []byte("direct fallback")
@@ -116,6 +119,18 @@ func TestDialContext_FallbackWhenProxyDown(t *testing.T) {
 	n, err := conn.Read(buf)
 	require.NoError(t, err)
 	assert.Equal(t, string(msg), string(buf[:n]))
+}
+
+func TestStreamDialer_ProxyPathMasksTCPConn(t *testing.T) {
+	newSingboxServer(t)
+	echoAddr := newEchoServer(t)
+
+	conn, err := StreamDialer().DialStream(context.Background(), echoAddr)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, ok := conn.(*net.TCPConn)
+	assert.False(t, ok, "proxy path must not expose the loopback socket as *net.TCPConn, or disorder would poke the wrong socket")
 }
 
 func TestStreamDialer_DirectReturnsTCPConn(t *testing.T) {
@@ -135,19 +150,4 @@ func TestDialContext_ContextCancellation(t *testing.T) {
 
 	_, err := DialContext(ctx, "tcp", "127.0.0.1:1")
 	require.Error(t, err, "expected error with cancelled context")
-}
-
-func TestHttpConnect_BadStatus(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "forbidden", http.StatusForbidden)
-	}))
-	defer srv.Close()
-
-	conn, err := net.Dial("tcp", srv.Listener.Addr().String())
-	require.NoError(t, err)
-	defer conn.Close()
-
-	_, err = httpConnect(context.Background(), conn, "example.com:443")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "403")
 }

--- a/bypass/bypass_test.go
+++ b/bypass/bypass_test.go
@@ -2,6 +2,7 @@ package bypass
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"testing"
 
@@ -19,16 +20,16 @@ import (
 // is torn down on test cleanup so the fixed port is free for the next test.
 func newSingboxServer(t *testing.T) *box.Box {
 	t.Helper()
-	opts := `{
+	opts := fmt.Sprintf(`{
 	"inbounds": [
 		{
 			"type": "mixed",
 			"tag": "socks-in",
 			"listen": "127.0.0.1",
-			"listen_port": 14985
+			"listen_port": %d
 		}
 	]
-}`
+}`, ProxyPort)
 	ctx := lbox.BaseContext()
 	options, err := json.UnmarshalExtendedContext[option.Options](ctx, []byte(opts))
 	require.NoError(t, err)

--- a/bypass/streamdialer.go
+++ b/bypass/streamdialer.go
@@ -20,10 +20,9 @@ func StreamDialer() transport.StreamDialer {
 		if err != nil {
 			return nil, err
 		}
-		// Preserve *net.TCPConn identity so strategies that require it (e.g. disorder,
-		// which sets per-packet TTL via socket options) can type-assert it back.
-		// The proxy path returns a bufferedConn to the local proxy—not the target—so
-		// unwrapping it would expose the wrong socket; fall through to halfCloseConn.
+		// Preserve *net.TCPConn identity so strategies that require it can type-assert
+		// it back. The proxied path returns a wrapped loopback connection, so exposing
+		// *net.TCPConn there would reveal the proxy socket instead of the target.
 		if tcpConn, ok := conn.(*net.TCPConn); ok {
 			return tcpConn, nil
 		}

--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -277,7 +277,11 @@ func baseRoutingRules() []O.Rule {
 		{
 			Type: C.RuleTypeDefault,
 			DefaultOptions: O.DefaultRule{
-				RawDefaultRule: O.RawDefaultRule{},
+				RawDefaultRule: O.RawDefaultRule{
+					// skip sniffing the bypass inbound for vpn builds, it forces an early
+					// read and reply, breaking IPv6 fallback.
+					Inbound: []string{inboundTag},
+				},
 				RuleAction: O.RuleAction{
 					Action: C.RuleActionTypeSniff,
 				},

--- a/vpn/boxoptions_default.go
+++ b/vpn/boxoptions_default.go
@@ -16,11 +16,15 @@ import (
 	"github.com/getlantern/radiance/common"
 )
 
-// minAndroidSystemStackKernel is the minimum Linux kernel version (major.minor)
-// required for the system TUN stack to work reliably on Android only. Devices
-// running a kernel below this version fall back to gvisor. This constant has no
-// effect on other platforms.
-const minAndroidSystemStackKernel = "5.10"
+const (
+	// minAndroidSystemStackKernel is the minimum Linux kernel version (major.minor)
+	// required for the system TUN stack to work reliably on Android only. Devices
+	// running a kernel below this version fall back to gvisor. This constant has no
+	// effect on other platforms.
+	minAndroidSystemStackKernel = "5.10"
+
+	inboundTag = "tun-in"
+)
 
 // baseInbounds returns the tunnel-build inbounds: the TUN device (per-platform
 // stack/routing applied here) plus the loopback bypass proxy that carries
@@ -67,7 +71,7 @@ func baseInbounds() []O.Inbound {
 	return []O.Inbound{
 		{
 			Type:    "tun",
-			Tag:     "tun-in",
+			Tag:     inboundTag,
 			Options: tunOpts,
 		},
 		{

--- a/vpn/boxoptions_novpn.go
+++ b/vpn/boxoptions_novpn.go
@@ -13,9 +13,13 @@ import (
 	"github.com/getlantern/radiance/common/env"
 )
 
-// defaultSocksAddress is the listen address for the novpn build's SOCKS/HTTP
-// inbound when RADIANCE_SOCKS_ADDRESS is unset.
-const defaultSocksAddress = "127.0.0.1:1080"
+const (
+	// defaultSocksAddress is the listen address for the novpn build's SOCKS/HTTP
+	// inbound when RADIANCE_SOCKS_ADDRESS is unset.
+	defaultSocksAddress = "127.0.0.1:1080"
+
+	inboundTag = "http-socks-in"
+)
 
 // baseInbounds returns the SOCKS/HTTP proxy inbound. The novpn build has no TUN
 // device, so this mixed inbound is the only entry point for traffic.
@@ -34,7 +38,7 @@ func baseInbounds() []O.Inbound {
 	return []O.Inbound{
 		{
 			Type: C.TypeMixed,
-			Tag:  "http-socks-in",
+			Tag:  inboundTag,
 			Options: &O.HTTPMixedInboundOptions{
 				ListenOptions: O.ListenOptions{
 					Listen:     &listen,


### PR DESCRIPTION
## Problem

The bypass proxy (used to fetch config outside the VPN tunnel) spoke **HTTP CONNECT** to the local sing-box `mixed` inbound. sing-box returns `200 Connection established` for a CONNECT *before* the routed `direct` outbound has dialed the target. That eager `200` falsely signals success to kindling's smart dialer, so its Happy Eyeballs never sees the real upstream result.

Concretely: on a v4-only network the smart dialer resolves an AAAA, tries the IPv6 address first through the bypass proxy, gets an immediate `200`, and commits to IPv6 — while the `direct` outbound then fails with `ENETUNREACH`. The connection resets and there is no failover to IPv4.

## Fix

Switch the bypass client to **SOCKS5**. sing wraps the SOCKS reply in a `LazyConn` that is withheld until the routed outbound dial actually resolves (`route/conn.go` reports handshake success/failure after the dial). So an unreachable upstream now surfaces as a handshake error, and the smart dialer fails over to the next address.

- `proxyClient` uses `socks.NewClient(...)` (SOCKS5) against the existing `mixed` inbound, which already accepts SOCKS.
- The proxy-success path returns a `tunneledConn` wrapper so the loopback socket is not exposed as `*net.TCPConn`; that keeps the `disorder` strategy from manipulating the wrong (loopback) socket. The direct-fallback path still returns the raw `*net.TCPConn` (the real target socket).
- Fallback to a direct dial when the proxy is down is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated bypass tunneling to use a local SOCKS5 proxy path.
  * Maintains direct-connection fallback when the proxy is unreachable.
  * Improved streaming behavior so proxied connections don’t surface the local proxy socket type.

* **Bug Fixes**
  * Adjusted default routing so VPN builds avoid sniffing the bypass inbound, improving IPv6 fallback reliability.

* **Tests**
  * Updated bypass tests to use a local Sing-box inbound proxy.
  * Added/removed assertions covering proxied dialing, fallback behavior, stream masking, and proxy/unreachable scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->