### PR TITLE
fix: disabling dnstt

### DIFF
--- a/kindling/client.go
+++ b/kindling/client.go
@@ -45,7 +45,7 @@ var (
 	// EnabledTransports gates which transports NewKindling wires up. Toggle it
 	// through EnableTransport, then rebuild via Close+Init to apply the change.
 	EnabledTransports = map[kindling.TransportName]bool{
-		kindling.TransportDNSTunnel:   true,
+		kindling.TransportDNSTunnel:   false,
 		kindling.TransportAMP:         true,
 		kindling.TransportSmart:       true,
 		kindling.TransportDomainfront: true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * DNS tunneling is now disabled by default.
  * Other transport settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->