### PR TITLE
fix(vpn): remove deprecated endpoint-independent NAT from tun defaults

### DIFF
--- a/vpn/boxoptions_default.go
+++ b/vpn/boxoptions_default.go
@@ -45,12 +45,11 @@ func baseInbounds() []O.Inbound {
 	}
 
 	tunOpts := &O.TunInboundOptions{
-		InterfaceName:          "utun225",
-		Address:                tunAddress,
-		AutoRoute:              true,
-		StrictRoute:            true,
-		EndpointIndependentNat: true, // needed for QUIC migration and hole-punching
-		Stack:                  "system",
+		InterfaceName: "utun225",
+		Address:       tunAddress,
+		AutoRoute:     true,
+		StrictRoute:   true,
+		Stack:         "system",
 	}
 	switch common.Platform {
 	case "android":

--- a/vpn/boxoptions_default.go
+++ b/vpn/boxoptions_default.go
@@ -59,10 +59,12 @@ func baseInbounds() []O.Inbound {
 			slog.Warn("kernel version unknown, keeping default TUN stack")
 		} else if kernelBelow(kv, minAndroidSystemStackKernel) {
 			tunOpts.Stack = "gvisor"
+			tunOpts.EndpointIndependentNat = true
 			slog.Info("kernel below 5.10, using gvisor TUN stack", "kernel", kv)
 		}
 	case "ios":
 		tunOpts.Stack = ""
+		tunOpts.EndpointIndependentNat = true
 	case "linux":
 		tunOpts.AutoRedirect = true
 	}


### PR DESCRIPTION
This pull request makes a small change to the default inbound configuration in `vpn/boxoptions_default.go`. The `EndpointIndependentNat` option was removed from the returned struct in the `baseInbounds` function. `EndpointIndependentNat` is only supported on gVisor stacks and is deprecated, so drop it from the system stack tun configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated TUN networking configuration while preserving existing interface, routing, and system stack settings.
  * Removed endpoint-independent NAT behavior from the default VPN inbound configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->