### PR TITLE
change the memory monitor dump path to the correct dir

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -501,7 +501,7 @@ func baseIssueAttachments() []string {
 		filepath.Join(dataPath, internal.ServersFileName),
 		filepath.Join(dataPath, internal.DebugBoxOptionsFileName),
 	}
-	memdump := filepath.Join(dataPath, internal.MemoryDumpFileName)
+	memdump := filepath.Join(logPath, internal.MemoryDumpFileName)
 	if _, err := os.Stat(memdump); err == nil {
 		// put memory dump first in the list so it's prioritized.
 		files = append([]string{memdump}, files...)


### PR DESCRIPTION
This pull request includes a small but important change to how the memory dump file is handled in the `baseIssueAttachments` function. The memory dump is now sourced from the `logPath` directory instead of the `dataPath` directory, ensuring that the correct file location is used when attaching logs for issues. 

* Changed the source directory for `internal.MemoryDumpFileName` from `dataPath` to `logPath` in the `baseIssueAttachments` function in `backend/radiance.go`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Issue reports now attach memory dump files from the configured log directory, improving the accuracy of diagnostic attachments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->