### PR TITLE
deps: bump lantern-box to v0.0.103 (unbounded leak/retry fixes)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3
 	github.com/getlantern/kindling v0.0.0-20260625002640-7cdf7184420c
-	github.com/getlantern/lantern-box v0.0.101
+	github.com/getlantern/lantern-box v0.0.103
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb
@@ -115,7 +115,7 @@ require (
 	github.com/gaissmai/bart v0.11.1 // indirect
 	github.com/gaukas/wazerofs v0.1.0 // indirect
 	github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52 // indirect
-	github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc // indirect
+	github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86 // indirect
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 // indirect
 	github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf // indirect
 	github.com/go-chi/chi/v5 v5.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,8 @@ github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52 h1:w2/RqYPw7Pb
 github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52/go.mod h1:PrNR8tMXO26YNs8K9653XCUH7u2Kv4OdfFC3Ke1GsX0=
 github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c h1:ZzxuhIWO295y4eE6wPYUq8Smntlgg+y39L5OOyMJY+k=
 github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c/go.mod h1:b5teAOFT+vpBqc2CHoz74QTEM15iOv1PLdQogwXcfrM=
-github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc h1:AVY56mzJHM4CBTrW9oBgpShB5S68gGunvk9GMvJrkzM=
-github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc/go.mod h1:bIxM6xon/ADgprn6tZXYdXGrUIMCzq6u8zO9rET50IE=
+github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86 h1:r7j54Ol1wak59OY0SK2Fw5lOI3YvrAEDW3QAQEj12mA=
+github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86/go.mod h1:bIxM6xon/ADgprn6tZXYdXGrUIMCzq6u8zO9rET50IE=
 github.com/getlantern/common v1.2.1-0.20260708083946-cc657b08792c h1:Hpxu12ORnAcyYuIqV2yAqrmDAnTaY1Cd3yL7TvFB6ME=
 github.com/getlantern/common v1.2.1-0.20260708083946-cc657b08792c/go.mod h1:eSSuV4bMPgQJnczBw+KWWqWNo1itzmVxC++qUBPRTt0=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
@@ -246,8 +246,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvd
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260625002640-7cdf7184420c h1:F4/LE+5zehr6AUfuJBab3iubscOOTdFZxwYldIpLgg8=
 github.com/getlantern/kindling v0.0.0-20260625002640-7cdf7184420c/go.mod h1:rN6O8pIQ9nc7Gyvtf2GGSjiWEFIApGsRCHkgYz0h3Ak=
-github.com/getlantern/lantern-box v0.0.101 h1:HXJWgpv48B5lo9d9p4Q0crYi3X3YIn+tJMh/F3sbyH0=
-github.com/getlantern/lantern-box v0.0.101/go.mod h1:yQhnLpnDY17+c/s+4WiiUhun3HtoHNj5NFb355ThKQk=
+github.com/getlantern/lantern-box v0.0.103 h1:2Oqq1Ucaa3Va73XYpXCecU+7vkTxfWD0NSHETbrSrTw=
+github.com/getlantern/lantern-box v0.0.103/go.mod h1:qMpxONKk4Gd/9Zd9vOY4q+uHCAfXG/xUF87/K4bO6AA=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395/go.mod h1:3JpJgwi4KEI6rS9loOAvcBp+F2jP65d0tTg2GQcTPBU=
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 h1:3BwvWj0JZzFEvNNiMhCu4bf60nqcIuQpTYb00Ezm1ag=


### PR DESCRIPTION
## Why

The consumer-side unbounded memory-leak fixes (getlantern/engineering#3698) live in broflake, which radiance pulls in **transitively** through `lantern-box/protocol/unbounded`. The right way to advance it is to bump **lantern-box** (the direct importer of `broflake/clientcore`), not to override the transitive broflake version in radiance's own go.mod — the latter is the fragile pattern that shipped stale code via gomobile on 2026-04-13.

## What

Bumps `github.com/getlantern/lantern-box` `v0.0.101` → `v0.0.103`. lantern-box v0.0.103 (getlantern/lantern-box#288) bumped broflake to `f2cacf69`, so this pulls in:

- **broflake#371** — engine teardown no longer leaks bus observer, routers, UI ticker, or a live `PeerConnection` per connect/disconnect cycle.
- **broflake#372** — context-aware signaling backoff (`sleepOrDone`); a torn-down outbound exits its retry backoff immediately instead of lingering a full `ErrorBackoff`.
- **broflake#373** — `QUICLayer` initializes `ctx`/`cancel` in its constructor, fixing the `Close()` data race + lost-cancel leak.

After `go mod tidy`, broflake's `// indirect` entry updates to `f2cacf69` **as a consequence of lantern-box v0.0.103's own requirement** — so gomobile resolves it consistently, no manual override.

## Verification

- `go build ./vpn/...` (the tunnel path that compiles the unbounded outbound) passes.
- `go list -m broflake` → `f2cacf69`; confirmed `sleepOrDone` (#372) and the `QUICLayer` guard/constructor init (#373) are in the resolved module.
- `cmd/lantern` has a **pre-existing** break on `main` unrelated to this bump (`ipc.NewClient` signature mismatch at `cmd/lantern/lantern.go:170`, reproduced on pristine `origin/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying networking components to newer versions.
  * Includes maintenance updates for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->