### PR TITLE
fronted: let domainfront own config fetch/persist/bootstrap (no blocking startup fetch)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c
 	github.com/getlantern/common v1.2.1-0.20260708083946-cc657b08792c
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac
-	github.com/getlantern/domainfront v0.0.0-20260721025733-db7c158ccac8
+	github.com/getlantern/domainfront v0.0.0-20260722154128-2862f7ad2558
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3
 	github.com/getlantern/kindling v0.0.0-20260721030225-ef87ee261cad
 	github.com/getlantern/lantern-box v0.0.104

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wd
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac/go.mod h1:0+wlia2hljruM7rhjzBMFhve011lGRO0OxjVSOcXBoQ=
-github.com/getlantern/domainfront v0.0.0-20260721025733-db7c158ccac8 h1:/XB/H1/nRXANtAybB5NjRDjYMfZwR9X0Qs7eGSUGTK4=
-github.com/getlantern/domainfront v0.0.0-20260721025733-db7c158ccac8/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
+github.com/getlantern/domainfront v0.0.0-20260722154128-2862f7ad2558 h1:2Fiu74ER24v0JeSVA32A5NriP8xQ8RyaNrUpE5AV84s=
+github.com/getlantern/domainfront v0.0.0-20260722154128-2862f7ad2558/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
 github.com/getlantern/errors v1.0.4 h1:i2iR1M9GKj4WuingpNqJ+XQEw6i6dnAgKAmLj6ZB3X0=
 github.com/getlantern/errors v1.0.4/go.mod h1:/Foq8jtSDGP8GOXzAjeslsC4Ar/3kB+UiQH+WyV4pzY=
 github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65 h1:NlQedYmPI3pRAXJb+hLVVDGqfvvXGRPV8vp7XOjKAZ0=

--- a/kindling/fronted/fronted.go
+++ b/kindling/fronted/fronted.go
@@ -24,9 +24,9 @@ import (
 
 const (
 	tracerName = "github.com/getlantern/radiance/kindling/fronted"
-	// The masquerades cron pushes daily regenerated configs to domainfront;
-	// the old getlantern/fronted copy went stale when the cron's target moved
-	// during the domainfront fork (last update 2026-06-05).
+	// configURL is the domainfront repo's daily-regenerated fronted.yaml.gz. The
+	// old getlantern/fronted copy went stale when the masquerades cron's target
+	// moved during the domainfront fork (last update 2026-06-05).
 	configURL = "https://raw.githubusercontent.com/getlantern/domainfront/refs/heads/main/fronted.yaml.gz"
 	// initialFetchTime bounds the background cache-warming fetch of configURL.
 	// It no longer gates startup — startup boots on the cached/embedded config —

--- a/kindling/fronted/fronted.go
+++ b/kindling/fronted/fronted.go
@@ -8,17 +8,12 @@ import (
 	"io"
 	"log/slog"
 	"net"
-	"net/http"
-	"os"
 	"path/filepath"
-	"time"
 
 	"go.opentelemetry.io/otel"
 
 	"github.com/getlantern/domainfront"
 	"github.com/getlantern/radiance/bypass"
-	"github.com/getlantern/radiance/common/atomicfile"
-	"github.com/getlantern/radiance/common/fileperm"
 	"github.com/getlantern/radiance/kindling/smart"
 )
 
@@ -28,23 +23,13 @@ const (
 	// old getlantern/fronted copy went stale when the masquerades cron's target
 	// moved during the domainfront fork (last update 2026-06-05).
 	configURL = "https://raw.githubusercontent.com/getlantern/domainfront/refs/heads/main/fronted.yaml.gz"
-	// initialFetchTime bounds the background cache-warming fetch of configURL.
-	// It no longer gates startup — startup boots on the cached/embedded config —
-	// so a long timeout here is harmless where configURL is blocked.
-	initialFetchTime = 30 * time.Second
-	// configCacheName holds the last successfully fetched config so the next
-	// startup can bootstrap when configURL is unreachable.
+	// configCacheName is where domainfront persists the last successfully fetched
+	// config so the next start can bootstrap when configURL is unreachable.
 	configCacheName = "fronted_config.yaml.gz"
-	// maxConfigBytes caps the size of the gzipped fronted config we'll accept
-	// from the network. The real file is ~500 KB; this leaves room for growth
-	// while bounding memory if a misconfigured or compromised endpoint serves
-	// an unbounded body.
-	maxConfigBytes = 10 << 20 // 10 MiB
 )
 
-// embeddedConfig is the last-resort bootstrap when the on-disk config cache is
-// absent or unparseable — typical case is a fresh install with
-// raw.githubusercontent.com blocked from the very first boot.
+// embeddedConfig seeds domainfront on a fresh install (no persisted cache yet),
+// e.g. with raw.githubusercontent.com blocked from the very first boot.
 //
 //go:embed fronted.yaml.gz
 var embeddedConfig []byte
@@ -57,20 +42,16 @@ func (bypassDialer) DialContext(ctx context.Context, network, addr string) (net.
 
 // NewFronted builds a domainfront.Client for use with kindling's
 // WithDomainFronting option. The caller owns the returned *Client and is
-// responsible for calling Close() to shut down the client's own background
-// goroutines (crawler, config updater). The one-shot cache-warming goroutine
-// started here is not tied to Close(): it is bounded by ctx and the fetch
-// timeout, so cancel ctx to abort an in-flight refresh.
+// responsible for calling Close() to shut down its background goroutines.
 //
-// Startup never blocks on network I/O: it bootstraps synchronously on the
-// on-disk config cache (from a prior run) and then the embedded copy, and the
-// live fetch from configURL happens only off the critical path. configURL lives
-// on raw.githubusercontent.com, which is blocked in some regions (e.g. China),
-// and fetching it synchronously here stalled radiance init for the full
-// initialFetchTime on every cold start there. That refresh now runs in the
-// background instead — domainfront's own config updater (WithConfigURL) applies
-// it to the in-memory front pool, and a background goroutine warms the on-disk
-// cache for the next cold start.
+// Startup does no blocking network I/O: it seeds domainfront with the embedded
+// config and lets domainfront own the live config lifecycle. configURL lives on
+// raw.githubusercontent.com, which is blocked in some regions (e.g. China);
+// fetching it synchronously here stalled radiance init for the full fetch
+// timeout on every cold start there. domainfront's config updater
+// (WithConfigURL) now fetches it off the critical path, persists it
+// (WithConfigCacheFile), and bootstraps from that persisted copy on the next
+// start in preference to the embedded seed.
 func NewFronted(ctx context.Context, cacheFile string, logWriter io.Writer) (*domainfront.Client, error) {
 	_, span := otel.Tracer(tracerName).Start(ctx, "NewFronted")
 	defer span.End()
@@ -81,126 +62,19 @@ func NewFronted(ctx context.Context, cacheFile string, logWriter io.Writer) (*do
 		return nil, fmt.Errorf("build smart HTTP client: %w", err)
 	}
 
-	configCache := filepath.Join(filepath.Dir(cacheFile), configCacheName)
-	cfg, err := loadBootstrapConfig(configCache)
+	seed, err := domainfront.ParseConfigFromReader(bytes.NewReader(embeddedConfig))
 	if err != nil {
 		span.RecordError(err)
-		return nil, fmt.Errorf("load bootstrap fronted config: %w", err)
+		return nil, fmt.Errorf("parse embedded fronted config: %w", err)
 	}
 
 	opts := []domainfront.Option{
 		domainfront.WithCacheFile(cacheFile),
+		domainfront.WithConfigCacheFile(filepath.Join(filepath.Dir(cacheFile), configCacheName)),
 		domainfront.WithDialer(bypassDialer{}),
 		domainfront.WithLogger(slog.Default()),
 		domainfront.WithConfigURL(configURL),
 		domainfront.WithHTTPClient(smartClient),
 	}
-	client, err := domainfront.New(ctx, cfg, opts...)
-	if err != nil {
-		span.RecordError(err)
-		return nil, err
-	}
-
-	// Warm the on-disk cache so the next cold start bootstraps on a fresh
-	// config even if configURL is unreachable then. Best-effort and off the
-	// critical path: boot already succeeded on the cached copy, and the
-	// in-memory pool is kept current by domainfront's own updater.
-	go func() {
-		if err := fetchAndCacheConfig(ctx, smartClient, configURL, configCache); err != nil {
-			slog.Debug("background fronted-config cache refresh failed", "err", err)
-		}
-	}()
-
-	return client, nil
-}
-
-// loadBootstrapConfig returns the startup config with no network I/O,
-// preferring the on-disk cache over the embedded copy. It errors only when the
-// embedded copy is itself unparseable.
-func loadBootstrapConfig(path string) (*domainfront.Config, error) {
-	if cfg := parseCachedConfig(path); cfg != nil {
-		return cfg, nil
-	}
-	cfg, err := domainfront.ParseConfigFromReader(bytes.NewReader(embeddedConfig))
-	if err != nil {
-		return nil, fmt.Errorf("embedded fronted config parse failed: %w", err)
-	}
-	slog.Debug("bootstrapped fronted config from embedded copy")
-	return cfg, nil
-}
-
-// parseCachedConfig returns the on-disk cached config, or nil when it is absent,
-// unreadable, larger than maxConfigBytes, or unparseable — in every failure
-// case the caller falls back to the embedded copy. The size check mirrors the
-// network path (fetchAndCacheConfig): read one byte past the cap and reject if
-// present, since gzip's tolerance of trailing bytes means a bare io.LimitReader
-// would accept an oversized file whose config prefix happens to parse.
-func parseCachedConfig(path string) *domainfront.Config {
-	if path == "" {
-		return nil
-	}
-	f, err := os.Open(path)
-	if err != nil {
-		return nil
-	}
-	defer f.Close()
-
-	data, err := io.ReadAll(io.LimitReader(f, maxConfigBytes+1))
-	if err != nil {
-		slog.Warn("failed to read on-disk fronted config, using embedded", "path", path, "err", err)
-		return nil
-	}
-	if len(data) > maxConfigBytes {
-		slog.Warn("on-disk fronted config exceeds size cap, using embedded", "path", path)
-		return nil
-	}
-	cfg, err := domainfront.ParseConfigFromReader(bytes.NewReader(data))
-	if err != nil {
-		slog.Warn("failed to parse on-disk fronted config, using embedded", "path", path, "err", err)
-		return nil
-	}
-	slog.Debug("bootstrapped fronted config from on-disk cache", "path", path)
-	return cfg
-}
-
-// fetchAndCacheConfig fetches the live config and, when it parses cleanly,
-// persists it to configCache for the next cold start. It does no fallback:
-// callers run it off the critical path and ignore failures, since startup has
-// already succeeded on the bootstrap config.
-func fetchAndCacheConfig(ctx context.Context, httpClient *http.Client, url, configCache string) error {
-	fetchCtx, cancel := context.WithTimeout(ctx, initialFetchTime)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, url, nil)
-	if err != nil {
-		return fmt.Errorf("new request: %w", err)
-	}
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("fetch %s: %w", url, err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status %d fetching %s", resp.StatusCode, url)
-	}
-
-	// Cap reads to maxConfigBytes + 1 so we can detect when the body exceeds
-	// the limit (vs. a body that happens to be exactly maxConfigBytes long).
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxConfigBytes+1))
-	if err != nil {
-		return fmt.Errorf("read response: %w", err)
-	}
-	if len(body) > maxConfigBytes {
-		return fmt.Errorf("response body exceeds %d bytes", maxConfigBytes)
-	}
-	// Validate before persisting so a corrupt body never poisons the cache.
-	if _, err := domainfront.ParseConfigFromReader(bytes.NewReader(body)); err != nil {
-		return fmt.Errorf("parse response: %w", err)
-	}
-	if configCache != "" {
-		if err := atomicfile.WriteFile(configCache, body, fileperm.File); err != nil {
-			return fmt.Errorf("persist config cache %s: %w", configCache, err)
-		}
-	}
-	return nil
+	return domainfront.New(ctx, seed, opts...)
 }

--- a/kindling/fronted/fronted.go
+++ b/kindling/fronted/fronted.go
@@ -23,11 +23,14 @@ import (
 )
 
 const (
-	tracerName       = "github.com/getlantern/radiance/kindling/fronted"
+	tracerName = "github.com/getlantern/radiance/kindling/fronted"
 	// The masquerades cron pushes daily regenerated configs to domainfront;
 	// the old getlantern/fronted copy went stale when the cron's target moved
 	// during the domainfront fork (last update 2026-06-05).
-	configURL        = "https://raw.githubusercontent.com/getlantern/domainfront/refs/heads/main/fronted.yaml.gz"
+	configURL = "https://raw.githubusercontent.com/getlantern/domainfront/refs/heads/main/fronted.yaml.gz"
+	// initialFetchTime bounds the background cache-warming fetch of configURL.
+	// It no longer gates startup — startup boots on the cached/embedded config —
+	// so a long timeout here is harmless where configURL is blocked.
 	initialFetchTime = 30 * time.Second
 	// configCacheName holds the last successfully fetched config so the next
 	// startup can bootstrap when configURL is unreachable.
@@ -39,8 +42,8 @@ const (
 	maxConfigBytes = 10 << 20 // 10 MiB
 )
 
-// embeddedConfig is the last-resort fallback when both the live fetch and
-// the local config cache fail — typical case is a fresh install with
+// embeddedConfig is the last-resort bootstrap when the on-disk config cache is
+// absent or unparseable — typical case is a fresh install with
 // raw.githubusercontent.com blocked from the very first boot.
 //
 //go:embed fronted.yaml.gz
@@ -56,9 +59,14 @@ func (bypassDialer) DialContext(ctx context.Context, network, addr string) (net.
 // WithDomainFronting option. The caller owns the returned *Client and is
 // responsible for calling Close() to shut down background goroutines.
 //
-// The initial config is fetched synchronously; on failure NewFronted falls
-// back to a previously cached config and then to an embedded copy, so it
-// does not block first boot when the config host is unreachable.
+// Startup does no network I/O: it bootstraps on the on-disk config cache (from
+// a prior run) and then the embedded copy. configURL lives on
+// raw.githubusercontent.com, which is blocked in some regions (e.g. China), and
+// fetching it synchronously here stalled radiance init for the full
+// initialFetchTime on every cold start there. The live config is refreshed off
+// the critical path instead — domainfront's own config updater (WithConfigURL)
+// applies it to the in-memory front pool, and a background goroutine warms the
+// on-disk cache for the next cold start.
 func NewFronted(ctx context.Context, cacheFile string, logWriter io.Writer) (*domainfront.Client, error) {
 	_, span := otel.Tracer(tracerName).Start(ctx, "NewFronted")
 	defer span.End()
@@ -70,10 +78,10 @@ func NewFronted(ctx context.Context, cacheFile string, logWriter io.Writer) (*do
 	}
 
 	configCache := filepath.Join(filepath.Dir(cacheFile), configCacheName)
-	cfg, err := fetchInitialConfig(ctx, smartClient, configCache)
+	cfg, err := loadBootstrapConfig(configCache)
 	if err != nil {
 		span.RecordError(err)
-		return nil, fmt.Errorf("fetch initial fronted config: %w", err)
+		return nil, fmt.Errorf("load bootstrap fronted config: %w", err)
 	}
 
 	opts := []domainfront.Option{
@@ -83,70 +91,86 @@ func NewFronted(ctx context.Context, cacheFile string, logWriter io.Writer) (*do
 		domainfront.WithConfigURL(configURL),
 		domainfront.WithHTTPClient(smartClient),
 	}
+	client, err := domainfront.New(ctx, cfg, opts...)
+	if err != nil {
+		span.RecordError(err)
+		return nil, err
+	}
 
-	return domainfront.New(ctx, cfg, opts...)
+	// Warm the on-disk cache so the next cold start bootstraps on a fresh
+	// config even if configURL is unreachable then. Best-effort and off the
+	// critical path: boot already succeeded on the cached copy, and the
+	// in-memory pool is kept current by domainfront's own updater.
+	go func() {
+		if err := fetchAndCacheConfig(ctx, smartClient, configURL, configCache); err != nil {
+			slog.Debug("background fronted-config cache refresh failed", "err", err)
+		}
+	}()
+
+	return client, nil
 }
 
-// fetchInitialConfig persists only parsed-OK bytes to configCache; on any
-// failure it falls through to loadCachedConfig.
-func fetchInitialConfig(ctx context.Context, httpClient *http.Client, configCache string) (*domainfront.Config, error) {
+// loadBootstrapConfig returns the startup config with no network I/O,
+// preferring the on-disk cache over the embedded copy. It errors only when the
+// embedded copy is itself unparseable.
+func loadBootstrapConfig(path string) (*domainfront.Config, error) {
+	if path != "" {
+		if f, err := os.Open(path); err == nil {
+			defer f.Close()
+			if cfg, err := domainfront.ParseConfigFromReader(f); err == nil {
+				slog.Debug("bootstrapped fronted config from on-disk cache", "path", path)
+				return cfg, nil
+			} else {
+				slog.Warn("failed to parse on-disk fronted config, using embedded", "path", path, "err", err)
+			}
+		}
+	}
+	cfg, err := domainfront.ParseConfigFromReader(bytes.NewReader(embeddedConfig))
+	if err != nil {
+		return nil, fmt.Errorf("embedded fronted config parse failed: %w", err)
+	}
+	slog.Debug("bootstrapped fronted config from embedded copy")
+	return cfg, nil
+}
+
+// fetchAndCacheConfig fetches the live config and, when it parses cleanly,
+// persists it to configCache for the next cold start. It does no fallback:
+// callers run it off the critical path and ignore failures, since startup has
+// already succeeded on the bootstrap config.
+func fetchAndCacheConfig(ctx context.Context, httpClient *http.Client, url, configCache string) error {
 	fetchCtx, cancel := context.WithTimeout(ctx, initialFetchTime)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, configURL, nil)
+	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("new request: %w", err)
+		return fmt.Errorf("new request: %w", err)
 	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return loadCachedConfig(configCache, fmt.Errorf("fetch %s: %w", configURL, err))
+		return fmt.Errorf("fetch %s: %w", url, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return loadCachedConfig(configCache, fmt.Errorf("unexpected status %d fetching %s", resp.StatusCode, configURL))
+		return fmt.Errorf("unexpected status %d fetching %s", resp.StatusCode, url)
 	}
 
 	// Cap reads to maxConfigBytes + 1 so we can detect when the body exceeds
 	// the limit (vs. a body that happens to be exactly maxConfigBytes long).
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxConfigBytes+1))
 	if err != nil {
-		return loadCachedConfig(configCache, fmt.Errorf("read response: %w", err))
+		return fmt.Errorf("read response: %w", err)
 	}
 	if len(body) > maxConfigBytes {
-		return loadCachedConfig(configCache, fmt.Errorf("response body exceeds %d bytes", maxConfigBytes))
+		return fmt.Errorf("response body exceeds %d bytes", maxConfigBytes)
 	}
-	cfg, err := domainfront.ParseConfigFromReader(bytes.NewReader(body))
-	if err != nil {
-		return loadCachedConfig(configCache, fmt.Errorf("parse response: %w", err))
+	// Validate before persisting so a corrupt body never poisons the cache.
+	if _, err := domainfront.ParseConfigFromReader(bytes.NewReader(body)); err != nil {
+		return fmt.Errorf("parse response: %w", err)
 	}
 	if configCache != "" {
 		if err := atomicfile.WriteFile(configCache, body, fileperm.File); err != nil {
-			slog.Warn("failed to persist fronted config cache", "path", configCache, "err", err)
+			return fmt.Errorf("persist config cache %s: %w", configCache, err)
 		}
 	}
-	return cfg, nil
-}
-
-// loadCachedConfig tries, in order: the on-disk config cache (from a prior
-// successful fetch) and then the embedded config. Returns fetchErr only if
-// both fallbacks fail to parse — so a clean install with the live fetch
-// blocked still boots on the embedded copy.
-func loadCachedConfig(path string, fetchErr error) (*domainfront.Config, error) {
-	if path != "" {
-		if f, err := os.Open(path); err == nil {
-			defer f.Close()
-			if cfg, err := domainfront.ParseConfigFromReader(f); err == nil {
-				slog.Warn("using cached fronted config", "path", path, "fetch_err", fetchErr)
-				return cfg, nil
-			} else {
-				slog.Warn("failed to parse on-disk fronted config, trying embedded", "path", path, "err", err)
-			}
-		}
-	}
-	cfg, err := domainfront.ParseConfigFromReader(bytes.NewReader(embeddedConfig))
-	if err != nil {
-		return nil, fmt.Errorf("embedded fronted config parse failed: %w (original fetch error: %v)", err, fetchErr)
-	}
-	slog.Warn("using embedded fronted config", "fetch_err", fetchErr)
-	return cfg, nil
+	return nil
 }

--- a/kindling/fronted/fronted.go
+++ b/kindling/fronted/fronted.go
@@ -59,14 +59,15 @@ func (bypassDialer) DialContext(ctx context.Context, network, addr string) (net.
 // WithDomainFronting option. The caller owns the returned *Client and is
 // responsible for calling Close() to shut down background goroutines.
 //
-// Startup does no network I/O: it bootstraps on the on-disk config cache (from
-// a prior run) and then the embedded copy. configURL lives on
-// raw.githubusercontent.com, which is blocked in some regions (e.g. China), and
-// fetching it synchronously here stalled radiance init for the full
-// initialFetchTime on every cold start there. The live config is refreshed off
-// the critical path instead — domainfront's own config updater (WithConfigURL)
-// applies it to the in-memory front pool, and a background goroutine warms the
-// on-disk cache for the next cold start.
+// Startup never blocks on network I/O: it bootstraps synchronously on the
+// on-disk config cache (from a prior run) and then the embedded copy, and the
+// live fetch from configURL happens only off the critical path. configURL lives
+// on raw.githubusercontent.com, which is blocked in some regions (e.g. China),
+// and fetching it synchronously here stalled radiance init for the full
+// initialFetchTime on every cold start there. That refresh now runs in the
+// background instead — domainfront's own config updater (WithConfigURL) applies
+// it to the in-memory front pool, and a background goroutine warms the on-disk
+// cache for the next cold start.
 func NewFronted(ctx context.Context, cacheFile string, logWriter io.Writer) (*domainfront.Client, error) {
 	_, span := otel.Tracer(tracerName).Start(ctx, "NewFronted")
 	defer span.End()
@@ -117,7 +118,9 @@ func loadBootstrapConfig(path string) (*domainfront.Config, error) {
 	if path != "" {
 		if f, err := os.Open(path); err == nil {
 			defer f.Close()
-			if cfg, err := domainfront.ParseConfigFromReader(f); err == nil {
+			// Bound the local parse to the same size cap as network fetches; a
+			// larger cache file is treated as unusable and falls through to embedded.
+			if cfg, err := domainfront.ParseConfigFromReader(io.LimitReader(f, maxConfigBytes+1)); err == nil {
 				slog.Debug("bootstrapped fronted config from on-disk cache", "path", path)
 				return cfg, nil
 			} else {

--- a/kindling/fronted/fronted.go
+++ b/kindling/fronted/fronted.go
@@ -115,18 +115,8 @@ func NewFronted(ctx context.Context, cacheFile string, logWriter io.Writer) (*do
 // preferring the on-disk cache over the embedded copy. It errors only when the
 // embedded copy is itself unparseable.
 func loadBootstrapConfig(path string) (*domainfront.Config, error) {
-	if path != "" {
-		if f, err := os.Open(path); err == nil {
-			defer f.Close()
-			// Bound the local parse to the same size cap as network fetches; a
-			// larger cache file is treated as unusable and falls through to embedded.
-			if cfg, err := domainfront.ParseConfigFromReader(io.LimitReader(f, maxConfigBytes+1)); err == nil {
-				slog.Debug("bootstrapped fronted config from on-disk cache", "path", path)
-				return cfg, nil
-			} else {
-				slog.Warn("failed to parse on-disk fronted config, using embedded", "path", path, "err", err)
-			}
-		}
+	if cfg := parseCachedConfig(path); cfg != nil {
+		return cfg, nil
 	}
 	cfg, err := domainfront.ParseConfigFromReader(bytes.NewReader(embeddedConfig))
 	if err != nil {
@@ -134,6 +124,40 @@ func loadBootstrapConfig(path string) (*domainfront.Config, error) {
 	}
 	slog.Debug("bootstrapped fronted config from embedded copy")
 	return cfg, nil
+}
+
+// parseCachedConfig returns the on-disk cached config, or nil when it is absent,
+// unreadable, larger than maxConfigBytes, or unparseable — in every failure
+// case the caller falls back to the embedded copy. The size check mirrors the
+// network path (fetchAndCacheConfig): read one byte past the cap and reject if
+// present, since gzip's tolerance of trailing bytes means a bare io.LimitReader
+// would accept an oversized file whose config prefix happens to parse.
+func parseCachedConfig(path string) *domainfront.Config {
+	if path == "" {
+		return nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(io.LimitReader(f, maxConfigBytes+1))
+	if err != nil {
+		slog.Warn("failed to read on-disk fronted config, using embedded", "path", path, "err", err)
+		return nil
+	}
+	if len(data) > maxConfigBytes {
+		slog.Warn("on-disk fronted config exceeds size cap, using embedded", "path", path)
+		return nil
+	}
+	cfg, err := domainfront.ParseConfigFromReader(bytes.NewReader(data))
+	if err != nil {
+		slog.Warn("failed to parse on-disk fronted config, using embedded", "path", path, "err", err)
+		return nil
+	}
+	slog.Debug("bootstrapped fronted config from on-disk cache", "path", path)
+	return cfg
 }
 
 // fetchAndCacheConfig fetches the live config and, when it parses cleanly,

--- a/kindling/fronted/fronted.go
+++ b/kindling/fronted/fronted.go
@@ -57,7 +57,10 @@ func (bypassDialer) DialContext(ctx context.Context, network, addr string) (net.
 
 // NewFronted builds a domainfront.Client for use with kindling's
 // WithDomainFronting option. The caller owns the returned *Client and is
-// responsible for calling Close() to shut down background goroutines.
+// responsible for calling Close() to shut down the client's own background
+// goroutines (crawler, config updater). The one-shot cache-warming goroutine
+// started here is not tied to Close(): it is bounded by ctx and the fetch
+// timeout, so cancel ctx to abort an in-flight refresh.
 //
 // Startup never blocks on network I/O: it bootstraps synchronously on the
 // on-disk config cache (from a prior run) and then the embedded copy, and the

--- a/kindling/fronted/fronted_test.go
+++ b/kindling/fronted/fronted_test.go
@@ -1,110 +1,21 @@
 package fronted
 
 import (
-	"context"
-	"net/http"
-	"net/http/httptest"
-	"os"
-	"path/filepath"
+	"bytes"
 	"testing"
 
+	"github.com/getlantern/domainfront"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TestLoadBootstrapConfig_EmbeddedIsValid guards the offline-boot guarantee: a
-// fresh install with no on-disk cache (and configURL blocked) must still boot,
-// which means the embedded fallback has to parse.
-func TestLoadBootstrapConfig_EmbeddedIsValid(t *testing.T) {
-	cfg, err := loadBootstrapConfig(filepath.Join(t.TempDir(), "does-not-exist.yaml.gz"))
+// TestEmbeddedConfigValid guards the offline-boot guarantee: NewFronted seeds
+// domainfront with the embedded config, so a fresh install with configURL
+// blocked still boots — which requires the embedded copy to parse and carry
+// providers. (Persistence and bootstrap-preference are tested in domainfront.)
+func TestEmbeddedConfigValid(t *testing.T) {
+	cfg, err := domainfront.ParseConfigFromReader(bytes.NewReader(embeddedConfig))
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 	assert.NotEmpty(t, cfg.Providers, "embedded fronted config must contain providers")
-}
-
-// TestLoadBootstrapConfig_FallsBackOnCorruptCache verifies a corrupt on-disk
-// cache doesn't strand startup — it falls through to the embedded copy.
-func TestLoadBootstrapConfig_FallsBackOnCorruptCache(t *testing.T) {
-	cache := filepath.Join(t.TempDir(), configCacheName)
-	require.NoError(t, os.WriteFile(cache, []byte("not a gzip config"), 0o600))
-
-	cfg, err := loadBootstrapConfig(cache)
-	require.NoError(t, err)
-	require.NotNil(t, cfg)
-	assert.NotEmpty(t, cfg.Providers)
-}
-
-// TestLoadBootstrapConfig_PrefersOnDiskCache verifies the on-disk cache is read
-// in preference to the embedded copy. The embedded fallback is corrupted for
-// the duration of the test so a successful parse can only have come from disk.
-func TestLoadBootstrapConfig_PrefersOnDiskCache(t *testing.T) {
-	cache := filepath.Join(t.TempDir(), configCacheName)
-	// Seed the cache with the (valid) embedded bytes before corrupting the
-	// in-memory fallback, so disk holds a good config and embedded does not.
-	require.NoError(t, os.WriteFile(cache, embeddedConfig, 0o600))
-
-	orig := embeddedConfig
-	t.Cleanup(func() { embeddedConfig = orig })
-	embeddedConfig = []byte("corrupt")
-
-	cfg, err := loadBootstrapConfig(cache)
-	require.NoError(t, err, "must succeed from the on-disk cache with the embedded fallback broken")
-	require.NotNil(t, cfg)
-	assert.NotEmpty(t, cfg.Providers)
-}
-
-// TestLoadBootstrapConfig_RejectsOversizedCache verifies a cache file over the
-// size cap is rejected even when its gzip prefix would parse (gzip ignores
-// trailing bytes). With the embedded fallback broken, acceptance of the disk
-// file would surface as success; rejection surfaces as the embedded error.
-func TestLoadBootstrapConfig_RejectsOversizedCache(t *testing.T) {
-	cache := filepath.Join(t.TempDir(), configCacheName)
-	oversized := make([]byte, maxConfigBytes+1)
-	copy(oversized, embeddedConfig) // valid gzip config prefix, then zero padding
-	require.NoError(t, os.WriteFile(cache, oversized, 0o600))
-
-	orig := embeddedConfig
-	t.Cleanup(func() { embeddedConfig = orig })
-	embeddedConfig = []byte("corrupt")
-
-	_, err := loadBootstrapConfig(cache)
-	require.Error(t, err, "oversized cache must be rejected; the broken embedded fallback then errors")
-}
-
-// TestFetchAndCacheConfig_PersistsValidConfig verifies a good response is
-// validated and written to the cache path for the next cold start.
-func TestFetchAndCacheConfig_PersistsValidConfig(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(embeddedConfig)
-	}))
-	defer srv.Close()
-
-	cache := filepath.Join(t.TempDir(), configCacheName)
-	err := fetchAndCacheConfig(context.Background(), srv.Client(), srv.URL, cache)
-	require.NoError(t, err)
-
-	written, err := os.ReadFile(cache)
-	require.NoError(t, err, "config should be persisted to the cache path")
-	assert.Equal(t, embeddedConfig, written)
-}
-
-// TestFetchAndCacheConfig_NoWriteOnError verifies a failed fetch neither errors
-// silently nor clobbers an existing cache — a previously good config survives.
-func TestFetchAndCacheConfig_NoWriteOnError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer srv.Close()
-
-	cache := filepath.Join(t.TempDir(), configCacheName)
-	seed := []byte("previous-good-config")
-	require.NoError(t, os.WriteFile(cache, seed, 0o600))
-
-	err := fetchAndCacheConfig(context.Background(), srv.Client(), srv.URL, cache)
-	require.Error(t, err)
-
-	got, readErr := os.ReadFile(cache)
-	require.NoError(t, readErr)
-	assert.Equal(t, seed, got, "a failed fetch must leave the existing cache untouched")
 }

--- a/kindling/fronted/fronted_test.go
+++ b/kindling/fronted/fronted_test.go
@@ -34,16 +34,21 @@ func TestLoadBootstrapConfig_FallsBackOnCorruptCache(t *testing.T) {
 	assert.NotEmpty(t, cfg.Providers)
 }
 
-// TestLoadBootstrapConfig_PrefersOnDiskCache verifies a valid on-disk cache is
-// read (the disk branch executes) rather than always using the embedded copy.
+// TestLoadBootstrapConfig_PrefersOnDiskCache verifies the on-disk cache is read
+// in preference to the embedded copy. The embedded fallback is corrupted for
+// the duration of the test so a successful parse can only have come from disk.
 func TestLoadBootstrapConfig_PrefersOnDiskCache(t *testing.T) {
 	cache := filepath.Join(t.TempDir(), configCacheName)
-	// The embedded bytes are a known-valid gzipped config; reuse them as a
-	// stand-in for a previously cached fetch.
+	// Seed the cache with the (valid) embedded bytes before corrupting the
+	// in-memory fallback, so disk holds a good config and embedded does not.
 	require.NoError(t, os.WriteFile(cache, embeddedConfig, 0o600))
 
+	orig := embeddedConfig
+	t.Cleanup(func() { embeddedConfig = orig })
+	embeddedConfig = []byte("corrupt")
+
 	cfg, err := loadBootstrapConfig(cache)
-	require.NoError(t, err)
+	require.NoError(t, err, "must succeed from the on-disk cache with the embedded fallback broken")
 	require.NotNil(t, cfg)
 	assert.NotEmpty(t, cfg.Providers)
 }
@@ -67,7 +72,7 @@ func TestFetchAndCacheConfig_PersistsValidConfig(t *testing.T) {
 }
 
 // TestFetchAndCacheConfig_NoWriteOnError verifies a failed fetch neither errors
-// silently nor poisons the cache — the cache file is left untouched.
+// silently nor clobbers an existing cache — a previously good config survives.
 func TestFetchAndCacheConfig_NoWriteOnError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -75,9 +80,13 @@ func TestFetchAndCacheConfig_NoWriteOnError(t *testing.T) {
 	defer srv.Close()
 
 	cache := filepath.Join(t.TempDir(), configCacheName)
+	seed := []byte("previous-good-config")
+	require.NoError(t, os.WriteFile(cache, seed, 0o600))
+
 	err := fetchAndCacheConfig(context.Background(), srv.Client(), srv.URL, cache)
 	require.Error(t, err)
 
-	_, statErr := os.Stat(cache)
-	assert.True(t, os.IsNotExist(statErr), "cache must not be written on a failed fetch")
+	got, readErr := os.ReadFile(cache)
+	require.NoError(t, readErr)
+	assert.Equal(t, seed, got, "a failed fetch must leave the existing cache untouched")
 }

--- a/kindling/fronted/fronted_test.go
+++ b/kindling/fronted/fronted_test.go
@@ -53,6 +53,24 @@ func TestLoadBootstrapConfig_PrefersOnDiskCache(t *testing.T) {
 	assert.NotEmpty(t, cfg.Providers)
 }
 
+// TestLoadBootstrapConfig_RejectsOversizedCache verifies a cache file over the
+// size cap is rejected even when its gzip prefix would parse (gzip ignores
+// trailing bytes). With the embedded fallback broken, acceptance of the disk
+// file would surface as success; rejection surfaces as the embedded error.
+func TestLoadBootstrapConfig_RejectsOversizedCache(t *testing.T) {
+	cache := filepath.Join(t.TempDir(), configCacheName)
+	oversized := make([]byte, maxConfigBytes+1)
+	copy(oversized, embeddedConfig) // valid gzip config prefix, then zero padding
+	require.NoError(t, os.WriteFile(cache, oversized, 0o600))
+
+	orig := embeddedConfig
+	t.Cleanup(func() { embeddedConfig = orig })
+	embeddedConfig = []byte("corrupt")
+
+	_, err := loadBootstrapConfig(cache)
+	require.Error(t, err, "oversized cache must be rejected; the broken embedded fallback then errors")
+}
+
 // TestFetchAndCacheConfig_PersistsValidConfig verifies a good response is
 // validated and written to the cache path for the next cold start.
 func TestFetchAndCacheConfig_PersistsValidConfig(t *testing.T) {

--- a/kindling/fronted/fronted_test.go
+++ b/kindling/fronted/fronted_test.go
@@ -1,0 +1,83 @@
+package fronted
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoadBootstrapConfig_EmbeddedIsValid guards the offline-boot guarantee: a
+// fresh install with no on-disk cache (and configURL blocked) must still boot,
+// which means the embedded fallback has to parse.
+func TestLoadBootstrapConfig_EmbeddedIsValid(t *testing.T) {
+	cfg, err := loadBootstrapConfig(filepath.Join(t.TempDir(), "does-not-exist.yaml.gz"))
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.NotEmpty(t, cfg.Providers, "embedded fronted config must contain providers")
+}
+
+// TestLoadBootstrapConfig_FallsBackOnCorruptCache verifies a corrupt on-disk
+// cache doesn't strand startup — it falls through to the embedded copy.
+func TestLoadBootstrapConfig_FallsBackOnCorruptCache(t *testing.T) {
+	cache := filepath.Join(t.TempDir(), configCacheName)
+	require.NoError(t, os.WriteFile(cache, []byte("not a gzip config"), 0o600))
+
+	cfg, err := loadBootstrapConfig(cache)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.NotEmpty(t, cfg.Providers)
+}
+
+// TestLoadBootstrapConfig_PrefersOnDiskCache verifies a valid on-disk cache is
+// read (the disk branch executes) rather than always using the embedded copy.
+func TestLoadBootstrapConfig_PrefersOnDiskCache(t *testing.T) {
+	cache := filepath.Join(t.TempDir(), configCacheName)
+	// The embedded bytes are a known-valid gzipped config; reuse them as a
+	// stand-in for a previously cached fetch.
+	require.NoError(t, os.WriteFile(cache, embeddedConfig, 0o600))
+
+	cfg, err := loadBootstrapConfig(cache)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.NotEmpty(t, cfg.Providers)
+}
+
+// TestFetchAndCacheConfig_PersistsValidConfig verifies a good response is
+// validated and written to the cache path for the next cold start.
+func TestFetchAndCacheConfig_PersistsValidConfig(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(embeddedConfig)
+	}))
+	defer srv.Close()
+
+	cache := filepath.Join(t.TempDir(), configCacheName)
+	err := fetchAndCacheConfig(context.Background(), srv.Client(), srv.URL, cache)
+	require.NoError(t, err)
+
+	written, err := os.ReadFile(cache)
+	require.NoError(t, err, "config should be persisted to the cache path")
+	assert.Equal(t, embeddedConfig, written)
+}
+
+// TestFetchAndCacheConfig_NoWriteOnError verifies a failed fetch neither errors
+// silently nor poisons the cache — the cache file is left untouched.
+func TestFetchAndCacheConfig_NoWriteOnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cache := filepath.Join(t.TempDir(), configCacheName)
+	err := fetchAndCacheConfig(context.Background(), srv.Client(), srv.URL, cache)
+	require.Error(t, err)
+
+	_, statErr := os.Stat(cache)
+	assert.True(t, os.IsNotExist(statErr), "cache must not be written on a failed fetch")
+}


### PR DESCRIPTION
## Problem

`NewFronted` fetched `fronted.yaml.gz` from `raw.githubusercontent.com` **synchronously on the radiance init critical path** with a 30s timeout. That host is blocked in China, so every cold start there burned the full 30s before falling back to cached/embedded config — stalling radiance init, which (with the Android startup race, getlantern/lantern#8915 / getlantern/engineering#3716) left Pro users shown as logged-out.

## Change

domainfront now owns the full config lifecycle (getlantern/domainfront#16): **fetch → apply → persist → bootstrap**. So `NewFronted` no longer fetches or persists the config itself (which duplicated domainfront's own background config fetch). It now:

- seeds `domainfront.New` with the **embedded** config (no network on the critical path),
- sets **`WithConfigCacheFile(...)`** so domainfront persists each fetched config and, on the next start, bootstraps from that persisted copy in preference to the embedded seed,
- keeps `WithConfigURL` so domainfront refreshes the in-memory pool in the background.

Startup still does **no blocking network I/O** (the original fix), but the radiance-side `loadBootstrapConfig` / `parseCachedConfig` / `fetchAndCacheConfig` + cache-warming goroutine are **deleted** — `fronted.go` drops 207 → 80 lines. Bumps `domainfront` to the merged version.

## Note on China config freshness

This makes startup resilient and preserves the last-good config across restarts, but it does **not** make the fetch *succeed* in China (raw.githubusercontent.com is still blocked, and jsDelivr bans the getlantern org — see getlantern/engineering#3721 for the durable China-reachable-mirror fix). In China the client boots on the persisted-or-embedded config; elsewhere domainfront refreshes it in the background.

## Testing

`go mod tidy`; `go build ./...`, `go vet`, `gofmt -l`, `go test ./kindling/fronted/` all pass (the only build failure, `cmd/lantern` `ipc.NewClient`, is pre-existing on `main`). Config persistence/bootstrap behavior is covered by tests in getlantern/domainfront#16; radiance keeps a test that the embedded seed parses (offline-boot guarantee).