### PR TITLE
Bump kindling + domainfront for multi-URL config racing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,9 +33,9 @@ require (
 	github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c
 	github.com/getlantern/common v1.2.1-0.20260708083946-cc657b08792c
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac
-	github.com/getlantern/domainfront v0.0.0-20260722154128-2862f7ad2558
+	github.com/getlantern/domainfront v0.0.0-20260722204513-8c1f8acfa715
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3
-	github.com/getlantern/kindling v0.0.0-20260721030225-ef87ee261cad
+	github.com/getlantern/kindling v0.0.0-20260722205227-8563bcdd9b04
 	github.com/getlantern/lantern-box v0.0.104
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wd
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac/go.mod h1:0+wlia2hljruM7rhjzBMFhve011lGRO0OxjVSOcXBoQ=
-github.com/getlantern/domainfront v0.0.0-20260722154128-2862f7ad2558 h1:2Fiu74ER24v0JeSVA32A5NriP8xQ8RyaNrUpE5AV84s=
-github.com/getlantern/domainfront v0.0.0-20260722154128-2862f7ad2558/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
+github.com/getlantern/domainfront v0.0.0-20260722204513-8c1f8acfa715 h1:7+eqGoiyszEQC0j5LasInlf3XIZIwgjQTturyLzclwg=
+github.com/getlantern/domainfront v0.0.0-20260722204513-8c1f8acfa715/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
 github.com/getlantern/errors v1.0.4 h1:i2iR1M9GKj4WuingpNqJ+XQEw6i6dnAgKAmLj6ZB3X0=
 github.com/getlantern/errors v1.0.4/go.mod h1:/Foq8jtSDGP8GOXzAjeslsC4Ar/3kB+UiQH+WyV4pzY=
 github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65 h1:NlQedYmPI3pRAXJb+hLVVDGqfvvXGRPV8vp7XOjKAZ0=
@@ -244,8 +244,8 @@ github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 h1:cSrD9ryDfTV2y
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770/go.mod h1:GOQsoDnEHl6ZmNIL+5uVo+JWRFWozMEp18Izcb++H+A=
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvdWv+YvXDqADVwjxM0DyABg2x4UgLVKU9McKI=
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
-github.com/getlantern/kindling v0.0.0-20260721030225-ef87ee261cad h1:FIWHYn9KnKVkgXGw3hXZ9tNzf0EzN3sY0FAbijIMNHo=
-github.com/getlantern/kindling v0.0.0-20260721030225-ef87ee261cad/go.mod h1:ECYSHrCeB9dVMhTHFnyoRAT/WDuEOgqy3suMVqPN4Ag=
+github.com/getlantern/kindling v0.0.0-20260722205227-8563bcdd9b04 h1:YaN1rTKlpkREh9GQIJ8sLnZDt2brzzAhpd+nqmr2Iss=
+github.com/getlantern/kindling v0.0.0-20260722205227-8563bcdd9b04/go.mod h1:Mej4MXda67EuL+kM6k4xcgxysWarkYjR5XPcNr8oYUI=
 github.com/getlantern/lantern-box v0.0.104 h1:ASLpYelmYUnY/bgDXH+UKiIex1Pme/Zg9YtDY6qQThk=
 github.com/getlantern/lantern-box v0.0.104/go.mod h1:xrH8ZziXLy1pYN94cfHenczjVwUVcuuUzJWb9lY8duw=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=


### PR DESCRIPTION
Bumps `kindling` → `8563bcd` and `domainfront` → `8c1f8ac`, picking up [domainfront#17](https://github.com/getlantern/domainfront/pull/17): `WithConfigURL` is now variadic and races multiple config sources (first valid wins) — the client-side primitive for a China-reachable config mirror (getlantern/engineering#3721).

**No radiance code change yet.** This carries the capability to `main`; the mirror URL gets added to `NewFronted`'s `WithConfigURL` once the mirror is publishing. go.mod / go.sum only; `go build ./...` (excl. the pre-existing `cmd/lantern` breakage) and the fronted tests pass.