### PR TITLE
fronted: race a jsDelivr mirror for the config + tune smart dialer for it

### DIFF
--- a/kindling/fronted/fronted.go
+++ b/kindling/fronted/fronted.go
@@ -23,8 +23,13 @@ const (
 	// old getlantern/fronted copy went stale when the masquerades cron's target
 	// moved during the domainfront fork (last update 2026-06-05).
 	configURL = "https://raw.githubusercontent.com/getlantern/domainfront/refs/heads/main/fronted.yaml.gz"
+	// mirrorConfigURL serves the same fronted.yaml.gz via jsDelivr from a
+	// non-getlantern account, reachable where raw.githubusercontent.com is
+	// blocked (e.g. China) — jsDelivr bans the getlantern org, so the mirror
+	// lives elsewhere. Raced against configURL; first valid response wins.
+	mirrorConfigURL = "https://cdn.jsdelivr.net/gh/firetweet/domainfront@main/fronted.yaml.gz"
 	// configCacheName is where domainfront persists the last successfully fetched
-	// config so the next start can bootstrap when configURL is unreachable.
+	// config so the next start can bootstrap when the config hosts are unreachable.
 	configCacheName = "fronted_config.yaml.gz"
 )
 
@@ -45,18 +50,18 @@ func (bypassDialer) DialContext(ctx context.Context, network, addr string) (net.
 // responsible for calling Close() to shut down its background goroutines.
 //
 // Startup does no blocking network I/O: it seeds domainfront with the embedded
-// config and lets domainfront own the live config lifecycle. configURL lives on
-// raw.githubusercontent.com, which is blocked in some regions (e.g. China);
-// fetching it synchronously here stalled radiance init for the full fetch
-// timeout on every cold start there. domainfront's config updater
-// (WithConfigURL) now fetches it off the critical path, persists it
-// (WithConfigCacheFile), and bootstraps from that persisted copy on the next
-// start in preference to the embedded seed.
+// config and lets domainfront own the live config lifecycle. The primary source
+// (configURL) is on raw.githubusercontent.com, blocked in some regions (e.g.
+// China), so it's raced against a jsDelivr mirror (mirrorConfigURL) — first
+// valid response wins. domainfront's config updater (WithConfigURL) fetches them
+// off the critical path, persists the result (WithConfigCacheFile), and
+// bootstraps from that persisted copy on the next start in preference to the
+// embedded seed. The smart HTTP client is tuned for both hosts.
 func NewFronted(ctx context.Context, cacheFile string, logWriter io.Writer) (*domainfront.Client, error) {
 	_, span := otel.Tracer(tracerName).Start(ctx, "NewFronted")
 	defer span.End()
 
-	smartClient, err := smart.NewHTTPClientWithSmartTransport(logWriter, configURL)
+	smartClient, err := smart.NewHTTPClientWithSmartTransport(logWriter, configURL, mirrorConfigURL)
 	if err != nil {
 		span.RecordError(err)
 		return nil, fmt.Errorf("build smart HTTP client: %w", err)
@@ -73,7 +78,7 @@ func NewFronted(ctx context.Context, cacheFile string, logWriter io.Writer) (*do
 		domainfront.WithConfigCacheFile(filepath.Join(filepath.Dir(cacheFile), configCacheName)),
 		domainfront.WithDialer(bypassDialer{}),
 		domainfront.WithLogger(slog.Default()),
-		domainfront.WithConfigURL(configURL),
+		domainfront.WithConfigURL(configURL, mirrorConfigURL),
 		domainfront.WithHTTPClient(smartClient),
 	}
 	return domainfront.New(ctx, seed, opts...)

--- a/kindling/smart/client.go
+++ b/kindling/smart/client.go
@@ -43,7 +43,14 @@ func NewHTTPClientWithSmartTransport(logWriter io.Writer, addresses ...string) (
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse URL %q: %v", address, err)
 		}
-		domains = append(domains, u.Host)
+		// Hostname() drops any :port; skip entries with no host (e.g. a
+		// scheme-less URL) so the dialer isn't tuned for an empty domain.
+		if host := u.Hostname(); host != "" {
+			domains = append(domains, host)
+		}
+	}
+	if len(domains) == 0 {
+		return nil, fmt.Errorf("no valid config host among %v", addresses)
 	}
 	trans, err := kindling.NewSmartHTTPTransportWithConfig(logWriter, DialerConfig, bypass.StreamDialer(), nil, domains...)
 	if err != nil {
@@ -77,7 +84,13 @@ func (lz *lazyDialingRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 	ctx, span := otel.Tracer(tracerName).Start(
 		req.Context(),
 		"lazy_dialing_round_trip",
-		trace.WithAttributes(attribute.StringSlice("domains", lz.domains)),
+		trace.WithAttributes(
+			// Keep the original "domain" key (first host) for existing tracing
+			// queries; add "domains" for the full raced set. domains is always
+			// non-empty (the constructor errors otherwise).
+			attribute.String("domain", lz.domains[0]),
+			attribute.StringSlice("domains", lz.domains),
+		),
 	)
 	defer span.End()
 

--- a/kindling/smart/client.go
+++ b/kindling/smart/client.go
@@ -32,29 +32,37 @@ const tracerName = "github.com/getlantern/radiance/kindling/smart"
 //go:embed smart_dialer_config.yml
 var DialerConfig []byte
 
+// NewHTTPClientWithSmartTransport returns an HTTP client whose transport uses
+// the Outline smart dialer, tuned for the hosts of the supplied config URLs (the
+// dialer searches for a working strategy against each). At least one URL with a
+// host is required.
 func NewHTTPClientWithSmartTransport(logWriter io.Writer, addresses ...string) (*http.Client, error) {
-	// Extract the host from each URL; the smart dialer searches for a working
-	// strategy against all of them, so a caller that races several config
-	// sources (e.g. the GitHub config URL and a jsDelivr mirror) gets a transport
-	// tuned for every host it may fetch from.
+	// Extract each URL's host; the smart dialer searches for a working strategy
+	// against all of them, so a caller that races several config sources (e.g.
+	// the GitHub config URL and a jsDelivr mirror) gets a transport tuned for
+	// every host it may fetch from.
+	seen := make(map[string]bool, len(addresses))
 	domains := make([]string, 0, len(addresses))
 	for _, address := range addresses {
 		u, err := url.Parse(address)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse URL %q: %v", address, err)
+			return nil, fmt.Errorf("failed to parse URL %q: %w", address, err)
 		}
-		// Hostname() drops any :port; skip entries with no host (e.g. a
-		// scheme-less URL) so the dialer isn't tuned for an empty domain.
-		if host := u.Hostname(); host != "" {
-			domains = append(domains, host)
+		// Hostname() drops any :port; skip empties (e.g. scheme-less URLs) and
+		// dedup so a shared host isn't probed twice.
+		host := u.Hostname()
+		if host == "" || seen[host] {
+			continue
 		}
+		seen[host] = true
+		domains = append(domains, host)
 	}
 	if len(domains) == 0 {
 		return nil, fmt.Errorf("no valid config host among %v", addresses)
 	}
 	trans, err := kindling.NewSmartHTTPTransportWithConfig(logWriter, DialerConfig, bypass.StreamDialer(), nil, domains...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create smart HTTP transport: %v", err)
+		return nil, fmt.Errorf("failed to create smart HTTP transport: %w", err)
 	}
 	lz := &lazyDialingRoundTripper{
 		smartTransportMu: sync.Mutex{},

--- a/kindling/smart/client.go
+++ b/kindling/smart/client.go
@@ -32,23 +32,28 @@ const tracerName = "github.com/getlantern/radiance/kindling/smart"
 //go:embed smart_dialer_config.yml
 var DialerConfig []byte
 
-func NewHTTPClientWithSmartTransport(logWriter io.Writer, address string) (*http.Client, error) {
-	// Parse the domain from the URL.
-	u, err := url.Parse(address)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse URL: %v", err)
+func NewHTTPClientWithSmartTransport(logWriter io.Writer, addresses ...string) (*http.Client, error) {
+	// Extract the host from each URL; the smart dialer searches for a working
+	// strategy against all of them, so a caller that races several config
+	// sources (e.g. the GitHub config URL and a jsDelivr mirror) gets a transport
+	// tuned for every host it may fetch from.
+	domains := make([]string, 0, len(addresses))
+	for _, address := range addresses {
+		u, err := url.Parse(address)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse URL %q: %v", address, err)
+		}
+		domains = append(domains, u.Host)
 	}
-
-	// Extract the domain from the URL.
-	domain := u.Host
-	trans, err := kindling.NewSmartHTTPTransportWithConfig(logWriter, DialerConfig, bypass.StreamDialer(), nil, domain)
+	trans, err := kindling.NewSmartHTTPTransportWithConfig(logWriter, DialerConfig, bypass.StreamDialer(), nil, domains...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create smart HTTP transport: %v", err)
 	}
 	lz := &lazyDialingRoundTripper{
 		smartTransportMu: sync.Mutex{},
 		logWriter:        logWriter,
-		domain:           domain}
+		domains:          domains,
+	}
 	if trans != nil {
 		lz.smartTransport = trans
 	}
@@ -62,7 +67,7 @@ type lazyDialingRoundTripper struct {
 	smartTransportMu sync.Mutex
 
 	logWriter io.Writer
-	domain    string
+	domains   []string
 }
 
 // Make sure lazyDialingRoundTripper implements http.RoundTripper
@@ -72,7 +77,7 @@ func (lz *lazyDialingRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 	ctx, span := otel.Tracer(tracerName).Start(
 		req.Context(),
 		"lazy_dialing_round_trip",
-		trace.WithAttributes(attribute.String("domain", lz.domain)),
+		trace.WithAttributes(attribute.StringSlice("domains", lz.domains)),
 	)
 	defer span.End()
 
@@ -80,7 +85,7 @@ func (lz *lazyDialingRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 
 	if lz.smartTransport == nil {
 		slog.Info("Smart transport is nil")
-		trans, err := kindling.NewSmartHTTPTransportWithConfig(lz.logWriter, DialerConfig, bypass.StreamDialer(), nil, lz.domain)
+		trans, err := kindling.NewSmartHTTPTransportWithConfig(lz.logWriter, DialerConfig, bypass.StreamDialer(), nil, lz.domains...)
 		if err != nil {
 			slog.Info("Error creating smart transport", "error", err)
 			lz.smartTransportMu.Unlock()


### PR DESCRIPTION
## Why

The client fetches `fronted.yaml.gz` from `raw.githubusercontent.com`, **blocked in China**. jsDelivr (the China-reachable CDN) **bans the getlantern org**, so we mirror the file to a non-getlantern account (`firetweet/domainfront`) and serve it via `cdn.jsdelivr.net`. Part of getlantern/engineering#3721; uses the multi-URL config racing added in [domainfront#17](https://github.com/getlantern/domainfront/pull/17).

## Change

- **`NewFronted`** now races two config sources — `configURL` (GitHub) and `mirrorConfigURL` (`cdn.jsdelivr.net/gh/firetweet/domainfront@main/fronted.yaml.gz`) — via `WithConfigURL(configURL, mirrorConfigURL)`. First valid response wins.
- **Smart dialer tuned for both hosts:** `smart.NewHTTPClientWithSmartTransport` is now variadic (`addresses ...string`) and passes every host to kindling's smart transport (which already accepts variadic test domains), so the dialer searches for a working TLS-fragmentation strategy against both `raw.githubusercontent.com` and `cdn.jsdelivr.net`. Without this the transport would only be tuned for the (blocked-in-China) GitHub host. Single-URL callers (`dnstt`, `amp`) are unaffected by the variadic change.

## Status of the mirror

`firetweet/domainfront` is created, **public**, and seeded with the current `fronted.yaml.gz` (jsDelivr serves it — verified 200, byte-identical). Server-side **daily auto-publish** to it is getlantern/lantern-cloud#3020 (gated on a Vault `MIRROR_GITHUB_TOKEN`). Until that's activated the mirror serves the seeded config, which is already fresher-in-China than the embedded fallback.

## Testing

`go build ./kindling/...`, `go vet`, `gofmt -l`, `go test ./kindling/...` all pass. **End-to-end China reachability of the jsDelivr fetch should be confirmed with a real in-region test** (e.g. Patrick's remote testing) — that's the one thing I can't verify from here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability Improvements**
  - Configuration updates can now be retrieved from both the primary source and a mirror, with the first valid response used.
  - Improved resilience helps the application continue bootstrapping and updating configuration when one source is unavailable.
  - Network handling now supports multiple configuration hosts for more dependable connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->