### PR TITLE
deps: bump lantern-box to v0.0.106 (client-info stall fix)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/getlantern/domainfront v0.0.0-20260722204513-8c1f8acfa715
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3
 	github.com/getlantern/kindling v0.0.0-20260722205227-8563bcdd9b04
-	github.com/getlantern/lantern-box v0.0.104
+	github.com/getlantern/lantern-box v0.0.106
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb
@@ -117,7 +117,7 @@ require (
 	github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52 // indirect
 	github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86 // indirect
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 // indirect
-	github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf // indirect
+	github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 // indirect
 	github.com/go-chi/chi/v5 v5.2.2 // indirect
 	github.com/go-json-experiment/json v0.0.0-20250103232110-6a9a0fde9288 // indirect
 	github.com/go-llsqlite/adapter v0.0.0-20230927005056-7f5ce7f0c916 // indirect

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvd
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260722205227-8563bcdd9b04 h1:YaN1rTKlpkREh9GQIJ8sLnZDt2brzzAhpd+nqmr2Iss=
 github.com/getlantern/kindling v0.0.0-20260722205227-8563bcdd9b04/go.mod h1:Mej4MXda67EuL+kM6k4xcgxysWarkYjR5XPcNr8oYUI=
-github.com/getlantern/lantern-box v0.0.104 h1:ASLpYelmYUnY/bgDXH+UKiIex1Pme/Zg9YtDY6qQThk=
-github.com/getlantern/lantern-box v0.0.104/go.mod h1:xrH8ZziXLy1pYN94cfHenczjVwUVcuuUzJWb9lY8duw=
+github.com/getlantern/lantern-box v0.0.106 h1:5czWMqdgrhCslLcE+ttt+us+d0dmCutpjxqmCOZnqKw=
+github.com/getlantern/lantern-box v0.0.106/go.mod h1:HHdmZsGwkiaweBycCYv1Jolk3jkrXbb/R5UUXtY2n3o=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395/go.mod h1:3JpJgwi4KEI6rS9loOAvcBp+F2jP65d0tTg2GQcTPBU=
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 h1:3BwvWj0JZzFEvNNiMhCu4bf60nqcIuQpTYb00Ezm1ag=
@@ -258,8 +258,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf h1:KxiMF+oG0rTtuBi7GiIaHfccYOf69rLJ/VnO5myoYc4=
-github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
+github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 h1:RZd3CELOtQUEzIE5kPdEO9HYg+7JYbR3OTdC+3P/wng=
+github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb/go.mod h1:GkPT5P9JoOTIRXRmFWxYgu1hhXgTFFTNc2hoG7WQc3g=
 github.com/getlantern/sing v0.7.18-lantern h1:QKGgIUA3LwmKYP/7JlQTRkxj9jnP4cX2Q/B+nd8XEjo=


### PR DESCRIPTION
Bumps `github.com/getlantern/lantern-box` `v0.0.104` → `v0.0.106`, pulling in the client-info-stall fix and its transitive samizdat half.

## What this pulls in

- **[getlantern/lantern-box#291](https://github.com/getlantern/lantern-box/pull/291)** — bounds the post-handshake client-info `OK` exchange with a read deadline and fixes the TCP short-read / UDP short-buffer teardowns.
- **[getlantern/samizdat#14](https://github.com/getlantern/samizdat/pull/14)** (transitive, `samizdat` bumped in #291) — makes `streamConn`'s read deadline actually interrupt a blocked HTTP/2 stream read. Without it the lantern-box deadline is a silent no-op for the samizdat transport.

## Why it matters

A proxy that completes the handshake and then goes silent (the Rostelecom / DPI-throttling failure mode in Russia — Freshdesk #180563, engineering#3726) previously held the flow and its slot in the client's healthy-outbound pool for 10+ minutes. Now it fails in ~10s, so `MutableAutoSelect` moves to the next candidate an order of magnitude faster.

## Verification

- `go.mod`/`go.sum` only; `go mod tidy` clean (sing-box-minimal `replace` unchanged — #291 didn't move it).
- All packages build except `cmd/lantern`, which fails to build on `main` independently of this change (`ipc.NewClient` signature mismatch, pre-existing).
- `go test ./vpn/` (wires up the ClientContextInjector) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)