### PR TITLE
smart: one dialer per config host so a blocked host can't take the rest down

### DIFF
--- a/kindling/smart/client.go
+++ b/kindling/smart/client.go
@@ -136,7 +136,7 @@ func (lz *lazyDialingRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
 		}
-		return nil, traces.RecordError(ctx, fmt.Errorf("could not create smart transport for %q -- offline? %w", ht.host, err))
+		return nil, traces.RecordError(ctx, fmt.Errorf("could not create smart transport for %q: %w", ht.host, err))
 	}
 	res, err := trans.RoundTrip(req.WithContext(ctx))
 	if err != nil {
@@ -220,22 +220,28 @@ func (ht *hostTransport) beginSearch() (http.RoundTripper, *pendingSearch) {
 
 // runSearch clears inFlight before releasing anyone waiting on search, so a
 // caller arriving in that window starts a fresh search rather than joining a
-// finished one. Releasing is deferred because recover cannot stop a
-// runtime.Goexit — a test helper's t.Fatal, say — from unwinding this goroutine.
+// finished one. The entire release path is deferred because recover cannot stop
+// a runtime.Goexit — a test helper's t.Fatal, say — from unwinding this
+// goroutine: even then the search must report an error rather than (nil, nil),
+// clear inFlight so the next caller starts fresh, and only then release.
 func (ht *hostTransport) runSearch(search *pendingSearch) {
-	defer close(search.done)
+	defer func() {
+		if search.trans == nil && search.err == nil {
+			search.err = fmt.Errorf("strategy search for %q exited without a result", ht.host)
+		}
+		ht.mu.Lock()
+		if search.err == nil {
+			ht.trans = search.trans
+		}
+		ht.inFlight = nil
+		ht.mu.Unlock()
+		close(search.done)
+	}()
 
 	search.trans, search.err = ht.buildTransport()
 	if search.err != nil {
 		slog.Warn("smart dialer found no working strategy", "host", ht.host, "error", search.err)
 	}
-
-	ht.mu.Lock()
-	if search.err == nil {
-		ht.trans = search.trans
-	}
-	ht.inFlight = nil
-	ht.mu.Unlock()
 }
 
 // buildTransport turns a panic into an error: the search runs on a goroutine of

--- a/kindling/smart/client.go
+++ b/kindling/smart/client.go
@@ -10,6 +10,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"runtime/debug"
+	"sync"
 
 	"github.com/getlantern/kindling"
 	"github.com/getlantern/radiance/bypass"
@@ -64,15 +66,14 @@ func NewHTTPClientWithSmartTransport(logWriter io.Writer, addresses ...string) (
 			host:         host,
 			logWriter:    logWriter,
 			newTransport: newSmartTransport,
-			searching:    make(chan struct{}, 1),
 		}
 		byHost[host] = ht
-		// Searching in the background keeps the client constructible while
-		// offline yet still spends the search before anything waits on it.
-		// Callers bound a whole config fetch at a timeout of the same order as
-		// the search itself, so one that pays for the search inside that budget
-		// has little of it left for the request.
-		go func() { _, _ = ht.roundTripper(context.Background()) }()
+		// Searching now keeps the client constructible while offline yet still
+		// spends the search before anything waits on it. Callers bound a whole
+		// config fetch at a timeout of the same order as the search itself, so
+		// one that pays for the search inside that budget has little of it left
+		// for the request.
+		ht.beginSearch()
 	}
 	lz := &lazyDialingRoundTripper{hosts: hosts, byHost: byHost}
 	return &http.Client{Transport: traces.NewRoundTripper(lz)}, nil
@@ -115,12 +116,14 @@ type lazyDialingRoundTripper struct {
 var _ http.RoundTripper = (*lazyDialingRoundTripper)(nil)
 
 func (lz *lazyDialingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	ht := lz.transportFor(req.URL.Hostname())
+	host := req.URL.Hostname()
+	ht := lz.transportFor(host)
 	ctx, span := otel.Tracer(tracerName).Start(
 		req.Context(),
 		"lazy_dialing_round_trip",
 		trace.WithAttributes(
-			attribute.String("domain", ht.host),
+			attribute.String("domain", host),
+			attribute.String("transport_host", ht.host),
 			attribute.StringSlice("domains", lz.hosts),
 		),
 	)
@@ -128,6 +131,11 @@ func (lz *lazyDialingRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 
 	trans, err := ht.roundTripper(ctx)
 	if err != nil {
+		// A caller that gave up learned nothing about the host, so don't report
+		// its own cancellation as this host being unreachable.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		return nil, traces.RecordError(ctx, fmt.Errorf("could not create smart transport for %q -- offline? %w", ht.host, err))
 	}
 	res, err := trans.RoundTrip(req.WithContext(ctx))
@@ -147,6 +155,9 @@ func (lz *lazyDialingRoundTripper) transportFor(host string) *hostTransport {
 	return lz.byHost[lz.hosts[0]]
 }
 
+// hostTransport holds one host's smart transport, built by a strategy search and
+// reused once it lands. Searches are single-flight: concurrent callers join the
+// one already running rather than starting their own.
 type hostTransport struct {
 	host      string
 	logWriter io.Writer
@@ -156,34 +167,88 @@ type hostTransport struct {
 	// a test restoring the seam.
 	newTransport func(logWriter io.Writer, host string) (http.RoundTripper, error)
 
-	// searching admits one strategy search at a time, and is a channel rather
-	// than a mutex so that a caller can abandon its wait when its own context
-	// ends while the search runs on for whoever comes next.
-	searching chan struct{}
-	trans     http.RoundTripper
+	mu       sync.Mutex
+	trans    http.RoundTripper
+	inFlight *pendingSearch
 }
 
-// roundTripper returns the transport for this host, running the strategy search
-// on first use — so it blocks for however long that search takes, or until ctx
-// ends. A failed search is deliberately not remembered: this requires callers
-// to retry on their own schedule, in exchange for letting a host blocked at
-// first contact recover without a restart.
+// pendingSearch is one attempt at building a host's transport. trans and err are
+// written before done is closed, so a caller that has received from done may
+// read them without the lock.
+type pendingSearch struct {
+	done  chan struct{}
+	trans http.RoundTripper
+	err   error
+}
+
+// roundTripper returns the transport for this host, starting a strategy search
+// on first use and joining one already under way otherwise. ctx bounds only the
+// wait — the search itself takes no context and runs to completion on its own
+// goroutine, so work a caller gave up on still serves whoever comes next.
+//
+// A failed search is deliberately not remembered: this requires callers to
+// retry on their own schedule, in exchange for letting a host blocked at first
+// contact recover without a restart.
 func (ht *hostTransport) roundTripper(ctx context.Context) (http.RoundTripper, error) {
+	trans, search := ht.beginSearch()
+	if trans != nil {
+		return trans, nil
+	}
 	select {
-	case ht.searching <- struct{}{}:
+	case <-search.done:
+		return search.trans, search.err
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
-	defer func() { <-ht.searching }()
+}
 
+// beginSearch hands the search back rather than waiting on it, so that the
+// caller who starts one can abandon it on its own context just as a caller who
+// joins one can.
+func (ht *hostTransport) beginSearch() (http.RoundTripper, *pendingSearch) {
+	ht.mu.Lock()
+	defer ht.mu.Unlock()
 	if ht.trans != nil {
 		return ht.trans, nil
 	}
-	trans, err := ht.newTransport(ht.logWriter, ht.host)
-	if err != nil {
-		slog.Warn("smart dialer found no working strategy", "host", ht.host, "error", err)
-		return nil, err
+	if ht.inFlight == nil {
+		ht.inFlight = &pendingSearch{done: make(chan struct{})}
+		go ht.runSearch(ht.inFlight)
 	}
-	ht.trans = trans
-	return trans, nil
+	return nil, ht.inFlight
+}
+
+// runSearch clears inFlight before releasing anyone waiting on search, so a
+// caller arriving in that window starts a fresh search rather than joining a
+// finished one. Releasing is deferred because recover cannot stop a
+// runtime.Goexit — a test helper's t.Fatal, say — from unwinding this goroutine.
+func (ht *hostTransport) runSearch(search *pendingSearch) {
+	defer close(search.done)
+
+	search.trans, search.err = ht.buildTransport()
+	if search.err != nil {
+		slog.Warn("smart dialer found no working strategy", "host", ht.host, "error", search.err)
+	}
+
+	ht.mu.Lock()
+	if search.err == nil {
+		ht.trans = search.trans
+	}
+	ht.inFlight = nil
+	ht.mu.Unlock()
+}
+
+// buildTransport turns a panic into an error: the search runs on a goroutine of
+// its own, where a panic would take the process down with no caller in a
+// position to intercept it, and a host whose search blows up should cost only
+// that host.
+func (ht *hostTransport) buildTransport() (trans http.RoundTripper, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("smart dialer strategy search panicked",
+				"host", ht.host, "panic", r, "stack", string(debug.Stack()))
+			err = fmt.Errorf("strategy search panicked: %v", r)
+		}
+	}()
+	return ht.newTransport(ht.logWriter, ht.host)
 }

--- a/kindling/smart/client.go
+++ b/kindling/smart/client.go
@@ -3,13 +3,13 @@
 package smart
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
-	"sync"
 
 	"github.com/getlantern/kindling"
 	"github.com/getlantern/radiance/bypass"
@@ -32,93 +32,158 @@ const tracerName = "github.com/getlantern/radiance/kindling/smart"
 //go:embed smart_dialer_config.yml
 var DialerConfig []byte
 
-// NewHTTPClientWithSmartTransport returns an HTTP client whose transport uses
-// the Outline smart dialer, tuned for the hosts of the supplied config URLs (the
-// dialer searches for a working strategy against each). At least one URL with a
-// host is required.
+// newSmartTransport is a test seam: a real strategy search needs network
+// reachability that tests don't have.
+var newSmartTransport = func(logWriter io.Writer, host string) (http.RoundTripper, error) {
+	trans, err := kindling.NewSmartHTTPTransportWithConfig(logWriter, DialerConfig, bypass.StreamDialer(), nil, host)
+	if err != nil {
+		return nil, err
+	}
+	if trans == nil {
+		return nil, fmt.Errorf("no smart transport for %q", host)
+	}
+	return trans, nil
+}
+
+// NewHTTPClientWithSmartTransport returns an HTTP client that reaches each
+// config URL's host through its own Outline smart dialer. At least one URL with
+// a host is required.
+//
+// One dialer per host rather than one dialer covering all of them: the strategy
+// search is conjunctive, so a single dialer given several hosts succeeds only if
+// one strategy unblocks every one of them, and a host that is blocked outright
+// then takes the reachable ones down with it.
 func NewHTTPClientWithSmartTransport(logWriter io.Writer, addresses ...string) (*http.Client, error) {
-	// Extract each URL's host; the smart dialer searches for a working strategy
-	// against all of them, so a caller that races several config sources (e.g.
-	// the GitHub config URL and a jsDelivr mirror) gets a transport tuned for
-	// every host it may fetch from.
+	hosts, err := configHosts(addresses)
+	if err != nil {
+		return nil, err
+	}
+	byHost := make(map[string]*hostTransport, len(hosts))
+	for _, host := range hosts {
+		ht := &hostTransport{
+			host:         host,
+			logWriter:    logWriter,
+			newTransport: newSmartTransport,
+			searching:    make(chan struct{}, 1),
+		}
+		byHost[host] = ht
+		// Searching in the background keeps the client constructible while
+		// offline yet still spends the search before anything waits on it.
+		// Callers bound a whole config fetch at a timeout of the same order as
+		// the search itself, so one that pays for the search inside that budget
+		// has little of it left for the request.
+		go func() { _, _ = ht.roundTripper(context.Background()) }()
+	}
+	lz := &lazyDialingRoundTripper{hosts: hosts, byHost: byHost}
+	return &http.Client{Transport: traces.NewRoundTripper(lz)}, nil
+}
+
+// configHosts returns each address's host, in order and deduplicated.
+func configHosts(addresses []string) ([]string, error) {
 	seen := make(map[string]bool, len(addresses))
-	domains := make([]string, 0, len(addresses))
+	hosts := make([]string, 0, len(addresses))
 	for _, address := range addresses {
 		u, err := url.Parse(address)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse URL %q: %w", address, err)
 		}
 		// Hostname() drops any :port; skip empties (e.g. scheme-less URLs) and
-		// dedup so a shared host isn't probed twice.
+		// dedup so a shared host isn't dialed through two dialers.
 		host := u.Hostname()
 		if host == "" || seen[host] {
 			continue
 		}
 		seen[host] = true
-		domains = append(domains, host)
+		hosts = append(hosts, host)
 	}
-	if len(domains) == 0 {
+	if len(hosts) == 0 {
 		return nil, fmt.Errorf("no valid config host among %v", addresses)
 	}
-	trans, err := kindling.NewSmartHTTPTransportWithConfig(logWriter, DialerConfig, bypass.StreamDialer(), nil, domains...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create smart HTTP transport: %w", err)
-	}
-	lz := &lazyDialingRoundTripper{
-		smartTransportMu: sync.Mutex{},
-		logWriter:        logWriter,
-		domains:          domains,
-	}
-	if trans != nil {
-		lz.smartTransport = trans
-	}
-	return &http.Client{Transport: traces.NewRoundTripper(lz)}, nil
+	return hosts, nil
 }
 
-// This is a lazy RoundTripper that allows radiance to start without an error
-// when it's offline.
+// lazyDialingRoundTripper routes each request to its own host's transport, so a
+// host that never becomes reachable costs only the requests aimed at it.
+//
+// byHost is written only during construction, so reads need no lock; each entry
+// guards its own transport.
 type lazyDialingRoundTripper struct {
-	smartTransport   http.RoundTripper
-	smartTransportMu sync.Mutex
-
-	logWriter io.Writer
-	domains   []string
+	hosts  []string
+	byHost map[string]*hostTransport
 }
 
-// Make sure lazyDialingRoundTripper implements http.RoundTripper
 var _ http.RoundTripper = (*lazyDialingRoundTripper)(nil)
 
 func (lz *lazyDialingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	ht := lz.transportFor(req.URL.Hostname())
 	ctx, span := otel.Tracer(tracerName).Start(
 		req.Context(),
 		"lazy_dialing_round_trip",
 		trace.WithAttributes(
-			// Keep the original "domain" key (first host) for existing tracing
-			// queries; add "domains" for the full raced set. domains is always
-			// non-empty (the constructor errors otherwise).
-			attribute.String("domain", lz.domains[0]),
-			attribute.StringSlice("domains", lz.domains),
+			attribute.String("domain", ht.host),
+			attribute.StringSlice("domains", lz.hosts),
 		),
 	)
 	defer span.End()
 
-	lz.smartTransportMu.Lock()
-
-	if lz.smartTransport == nil {
-		slog.Info("Smart transport is nil")
-		trans, err := kindling.NewSmartHTTPTransportWithConfig(lz.logWriter, DialerConfig, bypass.StreamDialer(), nil, lz.domains...)
-		if err != nil {
-			slog.Info("Error creating smart transport", "error", err)
-			lz.smartTransportMu.Unlock()
-			return nil, traces.RecordError(ctx, fmt.Errorf("could not create smart transport -- offline? %v", err))
-		}
-		lz.smartTransport = trans
+	trans, err := ht.roundTripper(ctx)
+	if err != nil {
+		return nil, traces.RecordError(ctx, fmt.Errorf("could not create smart transport for %q -- offline? %w", ht.host, err))
 	}
-
-	lz.smartTransportMu.Unlock()
-	res, err := lz.smartTransport.RoundTrip(req.WithContext(ctx))
+	res, err := trans.RoundTrip(req.WithContext(ctx))
 	if err != nil {
 		traces.RecordError(ctx, err, trace.WithStackTrace(true))
 	}
 	return res, err
+}
+
+// transportFor returns host's transport, falling back to the first configured
+// host's: one tuned for a sibling config source is a better guess than failing
+// the request outright.
+func (lz *lazyDialingRoundTripper) transportFor(host string) *hostTransport {
+	if ht, ok := lz.byHost[host]; ok {
+		return ht
+	}
+	return lz.byHost[lz.hosts[0]]
+}
+
+type hostTransport struct {
+	host      string
+	logWriter io.Writer
+
+	// newTransport is captured at construction rather than read from the
+	// package var, so that a search still running in the background can't race
+	// a test restoring the seam.
+	newTransport func(logWriter io.Writer, host string) (http.RoundTripper, error)
+
+	// searching admits one strategy search at a time, and is a channel rather
+	// than a mutex so that a caller can abandon its wait when its own context
+	// ends while the search runs on for whoever comes next.
+	searching chan struct{}
+	trans     http.RoundTripper
+}
+
+// roundTripper returns the transport for this host, running the strategy search
+// on first use — so it blocks for however long that search takes, or until ctx
+// ends. A failed search is deliberately not remembered: this requires callers
+// to retry on their own schedule, in exchange for letting a host blocked at
+// first contact recover without a restart.
+func (ht *hostTransport) roundTripper(ctx context.Context) (http.RoundTripper, error) {
+	select {
+	case ht.searching <- struct{}{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	defer func() { <-ht.searching }()
+
+	if ht.trans != nil {
+		return ht.trans, nil
+	}
+	trans, err := ht.newTransport(ht.logWriter, ht.host)
+	if err != nil {
+		slog.Warn("smart dialer found no working strategy", "host", ht.host, "error", err)
+		return nil, err
+	}
+	ht.trans = trans
+	return trans, nil
 }

--- a/kindling/smart/client_test.go
+++ b/kindling/smart/client_test.go
@@ -1,0 +1,247 @@
+package smart
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubSmartTransport replaces the strategy search for the duration of a test.
+// fn decides, per host, whether that host turned out to be reachable.
+func stubSmartTransport(t *testing.T, fn func(host string) (http.RoundTripper, error)) {
+	t.Helper()
+	original := newSmartTransport
+	newSmartTransport = func(_ io.Writer, host string) (http.RoundTripper, error) {
+		return fn(host)
+	}
+	t.Cleanup(func() { newSmartTransport = original })
+}
+
+// echoHostRoundTripper answers with the host whose transport served the
+// request, so a test can tell which dialer a request went through.
+type echoHostRoundTripper struct {
+	host string
+}
+
+func (e echoHostRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(e.host)),
+		Request:    req,
+	}, nil
+}
+
+func getBody(t *testing.T, client *http.Client, url string) string {
+	t.Helper()
+	res, err := client.Get(url)
+	require.NoError(t, err)
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	return string(body)
+}
+
+func TestBlockedHostDoesNotBlockOthers(t *testing.T) {
+	stubSmartTransport(t, func(host string) (http.RoundTripper, error) {
+		if host == "blocked.example" {
+			return nil, errors.New("could not find a working strategy")
+		}
+		return echoHostRoundTripper{host: host}, nil
+	})
+
+	client, err := NewHTTPClientWithSmartTransport(io.Discard, "https://good.example/config", "https://blocked.example/config.gz")
+	require.NoError(t, err)
+
+	assert.Equal(t, "good.example", getBody(t, client, "https://good.example/config"))
+
+	_, err = client.Get("https://blocked.example/config.gz")
+	require.Error(t, err)
+
+	assert.Equal(t, "good.example", getBody(t, client, "https://good.example/config"),
+		"a host with no working strategy must not disturb a reachable one")
+}
+
+func TestSlowSearchDoesNotDelayOtherHosts(t *testing.T) {
+	const slowSearch = time.Second
+	stubSmartTransport(t, func(host string) (http.RoundTripper, error) {
+		if host == "slow.example" {
+			time.Sleep(slowSearch)
+		}
+		return echoHostRoundTripper{host: host}, nil
+	})
+
+	client, err := NewHTTPClientWithSmartTransport(io.Discard, "https://slow.example/config", "https://fast.example/config")
+	require.NoError(t, err)
+
+	start := time.Now()
+	assert.Equal(t, "fast.example", getBody(t, client, "https://fast.example/config"))
+	assert.Less(t, time.Since(start), slowSearch/2,
+		"a search for one host must stay off another host's request path")
+}
+
+func TestFailedSearchIsRetried(t *testing.T) {
+	var blocked atomic.Bool
+	blocked.Store(true)
+	stubSmartTransport(t, func(host string) (http.RoundTripper, error) {
+		if blocked.Load() {
+			return nil, errors.New("offline")
+		}
+		return echoHostRoundTripper{host: host}, nil
+	})
+
+	client, err := NewHTTPClientWithSmartTransport(io.Discard, "https://config.example/config")
+	require.NoError(t, err)
+
+	_, err = client.Get("https://config.example/config")
+	require.Error(t, err)
+
+	blocked.Store(false)
+	assert.Equal(t, "config.example", getBody(t, client, "https://config.example/config"),
+		"a host must be able to recover without a restart")
+}
+
+func TestConcurrentRequestsShareOneSearch(t *testing.T) {
+	var searches atomic.Int32
+	stubSmartTransport(t, func(host string) (http.RoundTripper, error) {
+		searches.Add(1)
+		time.Sleep(50 * time.Millisecond)
+		return echoHostRoundTripper{host: host}, nil
+	})
+
+	client, err := NewHTTPClientWithSmartTransport(io.Discard, "https://config.example/config")
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			res, err := client.Get("https://config.example/config")
+			if assert.NoError(t, err) {
+				res.Body.Close()
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.EqualValues(t, 1, searches.Load(), "a host searches once, however many requests are waiting on it")
+}
+
+func TestConstructionStartsTheSearchWithoutBlocking(t *testing.T) {
+	searched := make(chan string, 1)
+	stubSmartTransport(t, func(host string) (http.RoundTripper, error) {
+		searched <- host
+		time.Sleep(time.Second)
+		return echoHostRoundTripper{host: host}, nil
+	})
+
+	start := time.Now()
+	_, err := NewHTTPClientWithSmartTransport(io.Discard, "https://config.example/config")
+	require.NoError(t, err)
+	assert.Less(t, time.Since(start), 250*time.Millisecond, "radiance has to start while offline")
+
+	select {
+	case host := <-searched:
+		assert.Equal(t, "config.example", host)
+	case <-time.After(5 * time.Second):
+		t.Fatal("the search has to be under way before a caller waits on it")
+	}
+}
+
+func TestRequestGivesUpOnSearchWhenItsContextEnds(t *testing.T) {
+	neverFinishes := make(chan struct{})
+	t.Cleanup(func() { close(neverFinishes) })
+	stubSmartTransport(t, func(host string) (http.RoundTripper, error) {
+		<-neverFinishes
+		return echoHostRoundTripper{host: host}, nil
+	})
+
+	client, err := NewHTTPClientWithSmartTransport(io.Discard, "https://config.example/config")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://config.example/config", nil)
+	require.NoError(t, err)
+
+	start := time.Now()
+	_, err = client.Do(req)
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), time.Second, "a request must be able to abandon a search it is waiting on")
+}
+
+func TestUnknownHostUsesFirstConfiguredTransport(t *testing.T) {
+	stubSmartTransport(t, func(host string) (http.RoundTripper, error) {
+		return echoHostRoundTripper{host: host}, nil
+	})
+
+	client, err := NewHTTPClientWithSmartTransport(io.Discard, "https://first.example/config", "https://second.example/config")
+	require.NoError(t, err)
+
+	assert.Equal(t, "first.example", getBody(t, client, "https://elsewhere.example/config"))
+}
+
+func TestConfigHosts(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		addresses []string
+		hosts     []string
+		wantErr   bool
+	}{
+		{
+			name:      "single URL",
+			addresses: []string{"https://config.example/config"},
+			hosts:     []string{"config.example"},
+		},
+		{
+			name:      "port is not part of the host",
+			addresses: []string{"https://config.example:8443/config"},
+			hosts:     []string{"config.example"},
+		},
+		{
+			name:      "repeated host is dialed by one transport",
+			addresses: []string{"https://config.example/a", "https://config.example/b"},
+			hosts:     []string{"config.example"},
+		},
+		{
+			name:      "hostless address is skipped",
+			addresses: []string{"config.example/a", "https://config.example/b"},
+			hosts:     []string{"config.example"},
+		},
+		{
+			name:      "no host at all",
+			addresses: []string{"config.example/a"},
+			wantErr:   true,
+		},
+		{
+			name:      "no addresses",
+			addresses: nil,
+			wantErr:   true,
+		},
+		{
+			name:      "unparseable URL",
+			addresses: []string{"https://config.example/\x7f"},
+			wantErr:   true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			hosts, err := configHosts(test.addresses)
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.hosts, hosts)
+		})
+	}
+}

--- a/kindling/smart/client_test.go
+++ b/kindling/smart/client_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -123,27 +124,35 @@ func TestFailedSearchIsRetried(t *testing.T) {
 }
 
 func TestConcurrentRequestsShareOneSearch(t *testing.T) {
+	// The search is held open on a channel until every request goroutine is
+	// running, so the requests demonstrably overlap the one in-flight search
+	// rather than relying on a sleep to line them up.
 	var searches atomic.Int32
+	searching := make(chan struct{})
 	stubSmartTransport(t, func(host string) (http.RoundTripper, error) {
 		searches.Add(1)
-		time.Sleep(50 * time.Millisecond)
+		<-searching
 		return echoHostRoundTripper{host: host}, nil
 	})
 
 	client, err := NewHTTPClientWithSmartTransport(io.Discard, "https://config.example/config")
 	require.NoError(t, err)
 
-	var wg sync.WaitGroup
+	var running, wg sync.WaitGroup
 	for i := 0; i < 20; i++ {
+		running.Add(1)
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			running.Done()
 			res, err := client.Get("https://config.example/config")
 			if assert.NoError(t, err) {
 				res.Body.Close()
 			}
 		}()
 	}
+	running.Wait()
+	close(searching)
 	wg.Wait()
 
 	assert.EqualValues(t, 1, searches.Load(), "a host searches once, however many requests are waiting on it")
@@ -173,8 +182,8 @@ func TestSuccessfulSearchIsRemembered(t *testing.T) {
 func TestConstructionStartsTheSearchWithoutBlocking(t *testing.T) {
 	// The search blocks until cleanup rather than sleeping: it cannot finish
 	// while the test runs, so construction returning at all proves it does not
-	// wait on the search (radiance has to start while offline). A regression
-	// deadlocks construction and fails via the test timeout.
+	// wait on the search (radiance has to start while offline). Construction
+	// runs under a watchdog so a regression fails fast instead of hanging.
 	searched := make(chan string, 1)
 	searching := make(chan struct{})
 	t.Cleanup(func() { close(searching) })
@@ -184,8 +193,17 @@ func TestConstructionStartsTheSearchWithoutBlocking(t *testing.T) {
 		return echoHostRoundTripper{host: host}, nil
 	})
 
-	_, err := NewHTTPClientWithSmartTransport(io.Discard, "https://config.example/config")
-	require.NoError(t, err)
+	built := make(chan error, 1)
+	go func() {
+		_, err := NewHTTPClientWithSmartTransport(io.Discard, "https://config.example/config")
+		built <- err
+	}()
+	select {
+	case err := <-built:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("radiance has to start while offline — construction must not wait on the search")
+	}
 
 	select {
 	case host := <-searched:
@@ -236,10 +254,55 @@ func TestSearchStarterGivesUpWhenItsContextEnds(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	start := time.Now()
-	_, err := ht.roundTripper(ctx)
-	require.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Less(t, time.Since(start), time.Second)
+	// A watchdog so that a roundTripper that regresses to ignoring ctx fails
+	// the test fast instead of deadlocking it until the package timeout.
+	gaveUp := make(chan error, 1)
+	go func() {
+		_, err := ht.roundTripper(ctx)
+		gaveUp <- err
+	}()
+	select {
+	case err := <-gaveUp:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(5 * time.Second):
+		t.Fatal("the caller who starts a search must be able to abandon it with its context")
+	}
+}
+
+// TestGoexitingSearchStillReleasesWaiters covers the unwind recover cannot
+// intercept: the search goroutine must still hand waiters an error rather than
+// (nil, nil), and must clear the in-flight slot so the host can search again.
+// It drives a hostTransport directly — a client's construction-time search
+// would absorb the Goexit before a request could join it.
+func TestGoexitingSearchStillReleasesWaiters(t *testing.T) {
+	var exited atomic.Bool
+	ht := &hostTransport{
+		host:      "config.example",
+		logWriter: io.Discard,
+		newTransport: func(io.Writer, string) (http.RoundTripper, error) {
+			if exited.CompareAndSwap(false, true) {
+				runtime.Goexit()
+			}
+			return echoHostRoundTripper{host: "config.example"}, nil
+		},
+	}
+
+	got := make(chan error, 1)
+	go func() {
+		_, err := ht.roundTripper(context.Background())
+		got <- err
+	}()
+	select {
+	case err := <-got:
+		require.ErrorContains(t, err, "without a result",
+			"a search that unwound must not hand waiters (nil, nil)")
+	case <-time.After(5 * time.Second):
+		t.Fatal("a search that unwound must still release its waiters")
+	}
+
+	trans, err := ht.roundTripper(context.Background())
+	require.NoError(t, err, "a host whose search unwound must be able to search again")
+	require.NotNil(t, trans)
 }
 
 func TestPanickingSearchBecomesAnError(t *testing.T) {

--- a/kindling/smart/client_test.go
+++ b/kindling/smart/client_test.go
@@ -137,6 +137,27 @@ func TestConcurrentRequestsShareOneSearch(t *testing.T) {
 	assert.EqualValues(t, 1, searches.Load(), "a host searches once, however many requests are waiting on it")
 }
 
+// TestSuccessfulSearchIsRemembered issues its requests one after another, so
+// that each has already settled when the next arrives: concurrent requests
+// would collapse into one search whether or not the result is ever kept.
+func TestSuccessfulSearchIsRemembered(t *testing.T) {
+	var searches atomic.Int32
+	stubSmartTransport(t, func(host string) (http.RoundTripper, error) {
+		searches.Add(1)
+		return echoHostRoundTripper{host: host}, nil
+	})
+
+	client, err := NewHTTPClientWithSmartTransport(io.Discard, "https://config.example/config")
+	require.NoError(t, err)
+
+	for range 5 {
+		assert.Equal(t, "config.example", getBody(t, client, "https://config.example/config"))
+	}
+
+	assert.EqualValues(t, 1, searches.Load(),
+		"a host with a working transport must not search again")
+}
+
 func TestConstructionStartsTheSearchWithoutBlocking(t *testing.T) {
 	searched := make(chan string, 1)
 	stubSmartTransport(t, func(host string) (http.RoundTripper, error) {
@@ -178,6 +199,44 @@ func TestRequestGivesUpOnSearchWhenItsContextEnds(t *testing.T) {
 	_, err = client.Do(req)
 	require.Error(t, err)
 	assert.Less(t, time.Since(start), time.Second, "a request must be able to abandon a search it is waiting on")
+}
+
+// TestSearchStarterGivesUpWhenItsContextEnds covers the caller that starts the
+// search rather than joining one, which has no other way out of a search that
+// never returns.
+func TestSearchStarterGivesUpWhenItsContextEnds(t *testing.T) {
+	neverFinishes := make(chan struct{})
+	t.Cleanup(func() { close(neverFinishes) })
+
+	ht := &hostTransport{
+		host:      "config.example",
+		logWriter: io.Discard,
+		newTransport: func(io.Writer, string) (http.RoundTripper, error) {
+			<-neverFinishes
+			return nil, nil
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := ht.roundTripper(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(start), time.Second)
+}
+
+func TestPanickingSearchBecomesAnError(t *testing.T) {
+	stubSmartTransport(t, func(string) (http.RoundTripper, error) {
+		panic("strategy search exploded")
+	})
+
+	client, err := NewHTTPClientWithSmartTransport(io.Discard, "https://config.example/config")
+	require.NoError(t, err)
+
+	_, err = client.Get("https://config.example/config")
+	require.ErrorContains(t, err, "panicked",
+		"a panicking search must not take the process down with it")
 }
 
 func TestUnknownHostUsesFirstConfiguredTransport(t *testing.T) {

--- a/kindling/smart/client_test.go
+++ b/kindling/smart/client_test.go
@@ -72,10 +72,15 @@ func TestBlockedHostDoesNotBlockOthers(t *testing.T) {
 }
 
 func TestSlowSearchDoesNotDelayOtherHosts(t *testing.T) {
-	const slowSearch = time.Second
+	// The slow host's search blocks until cleanup rather than sleeping: it
+	// cannot finish while the test runs, so the fast host answering at all
+	// proves its request never waited on it — no wall-clock race on a loaded
+	// CI runner.
+	slowSearching := make(chan struct{})
+	t.Cleanup(func() { close(slowSearching) })
 	stubSmartTransport(t, func(host string) (http.RoundTripper, error) {
 		if host == "slow.example" {
-			time.Sleep(slowSearch)
+			<-slowSearching
 		}
 		return echoHostRoundTripper{host: host}, nil
 	})
@@ -83,10 +88,17 @@ func TestSlowSearchDoesNotDelayOtherHosts(t *testing.T) {
 	client, err := NewHTTPClientWithSmartTransport(io.Discard, "https://slow.example/config", "https://fast.example/config")
 	require.NoError(t, err)
 
-	start := time.Now()
-	assert.Equal(t, "fast.example", getBody(t, client, "https://fast.example/config"))
-	assert.Less(t, time.Since(start), slowSearch/2,
-		"a search for one host must stay off another host's request path")
+	// Bounded so a regression fails the test instead of hanging the suite.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://fast.example/config", nil)
+	require.NoError(t, err)
+	res, err := client.Do(req)
+	require.NoError(t, err, "a search for one host must stay off another host's request path")
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "fast.example", string(body))
 }
 
 func TestFailedSearchIsRetried(t *testing.T) {
@@ -159,17 +171,21 @@ func TestSuccessfulSearchIsRemembered(t *testing.T) {
 }
 
 func TestConstructionStartsTheSearchWithoutBlocking(t *testing.T) {
+	// The search blocks until cleanup rather than sleeping: it cannot finish
+	// while the test runs, so construction returning at all proves it does not
+	// wait on the search (radiance has to start while offline). A regression
+	// deadlocks construction and fails via the test timeout.
 	searched := make(chan string, 1)
+	searching := make(chan struct{})
+	t.Cleanup(func() { close(searching) })
 	stubSmartTransport(t, func(host string) (http.RoundTripper, error) {
 		searched <- host
-		time.Sleep(time.Second)
+		<-searching
 		return echoHostRoundTripper{host: host}, nil
 	})
 
-	start := time.Now()
 	_, err := NewHTTPClientWithSmartTransport(io.Discard, "https://config.example/config")
 	require.NoError(t, err)
-	assert.Less(t, time.Since(start), 250*time.Millisecond, "radiance has to start while offline")
 
 	select {
 	case host := <-searched:


### PR DESCRIPTION
Fixes #575.

## The bug

`smart.NewHTTPClientWithSmartTransport` built **one** Outline smart dialer and handed it **both** config hosts at once (`client.go:63` on `main`, `domains...`).

The Outline strategy search is **conjunctive**. `StrategyFinder.NewDialer` looks for a single strategy that unblocks DNS *and* TLS for *every* test domain, and `testDialer` returns on the first domain that fails. There is no `fallback:` entry in `smart_dialer_config.yml`, and `findFallback` is conjunctive too — so that escape hatch doesn't exist either.

So the mirror's reachability became a **precondition** for the primary's. Adding the jsDelivr mirror in #575 didn't add redundancy; it added a second way for the primary to fail.

And the failure isn't scoped to the mirror — it takes domain fronting out entirely:

```mermaid
sequenceDiagram
    autonumber
    participant KC as radiance<br/>kindling/client.go
    participant FR as fronted<br/>kindling/fronted/fronted.go
    participant SM as smart<br/>kindling/smart/client.go
    participant OL as outline-sdk<br/>StrategyFinder

    KC->>FR: client.go:198<br/>NewFronted(ctx, cacheFile, logger)
    FR->>SM: fronted.go:64<br/>NewHTTPClientWithSmartTransport(<br/>configURL, mirrorConfigURL)
    SM->>OL: client.go:63<br/>NewSmartHTTPTransportWithConfig(…, domains...)
    rect rgba(255, 200, 200, 0.3)
        Note over OL: conjunctive search 🐛<br/>needs ONE strategy that unblocks<br/>raw.githubusercontent.com AND cdn.jsdelivr.net<br/>testDialer returns on first failing domain
    end
    OL-->>SM: error: no working strategy
    SM-->>FR: error
    FR-->>KC: client.go:199<br/>err != nil, f == nil ⚠️
    Note over KC: client.go:203<br/>`if f != nil` is false —<br/>WithDomainFronting never appended
    Note over KC: domain fronting silently lost<br/>for the whole process
```

One blocked host cost us domain fronting **altogether**, rather than costing us that one host.

## The fix

One dialer per host, built on first use, warmed in the background at construction.

- `configHosts()` (`client.go:83`) extracts hosts in order, deduplicated — extracted as a pure function so it's directly testable.
- Each host gets a `hostTransport` with its own strategy search. A host that never becomes reachable now costs only the requests aimed at it.
- `lazyDialingRoundTripper.transportFor()` (`client.go:151`) routes each request to its own host's transport, falling back to the first configured host's rather than failing outright.

`NewHTTPClientWithSmartTransport` can now only fail when *no* address has a host — unreachable for the constant URLs in `fronted.go`, `amp.go`, and `dnstt/parser.go`. So `NewFronted` no longer errors and the `if f != nil` guard holds.

### Why background warm-up, not purely lazy

Purely lazy would have traded a hard blocker for a subtler one. domainfront bounds a whole config fetch at `defaultConfigFetchTimeout = 20s`, and a strategy search is itself ~14s. Paying for the search *inside* that budget leaves ~6s for the actual GET — and a miss costs **12 hours**, since refresh is on a `time.NewTicker(12 * time.Hour)`.

Pre-#575 the (blocking) search happened *before* that budget started. The background warm-up at `client.go:76` preserves that property while keeping the client constructible offline.

### Deviation from the sketched approach

The issue discussion floated `sync.Once` per host. This uses a **`pendingSearch` handle** (`client.go:178`) instead, for two reasons:

1. **A failed search must not be cached forever.** `sync.Once` would latch the first failure permanently, so a host blocked at first contact could never recover without a restart. Here a failed search is deliberately not remembered — callers retry on their own schedule.
2. **Every caller must be able to walk away.** The search always runs on a goroutine of its own, and *every* caller — including the one that started it — selects on the handle's `done` channel or its own `ctx.Done()`. The abandoned search runs on for whoever comes next. `sync.Once.Do` has no cancelable wait.

Point 2 was originally a per-host channel semaphore, which got this half-right and CI caught it: see [Testing](#testing).

`trans`/`err` are written before `close(done)` and read only after a receive from it, so the read path needs no lock.

### Containment: panics and `runtime.Goexit`

`buildTransport` (`client.go:251`) converts a panic into an error. The search is fire-and-forget, so a panic there would take the whole process down with no caller in a position to recover — and a host whose search blows up should cost only that host. It sits in `buildTransport` rather than in the goroutine so that **both** call paths are covered.

`recover` cannot stop a `runtime.Goexit`, however, so `runSearch` (`client.go:227`) defers its **entire** release path: synthesize an error if the search produced neither a transport nor an error, write the cache, clear `inFlight`, and only then `close(done)`. Deferring just `close(search.done)` left `ht.inFlight` pointing at a closed, *resultless* search permanently — so every subsequent caller received `(nil, nil)` from `roundTripper` and `RoundTrip` nil-dereferenced on it. One wedged search wedged the host forever.

## Incidental fixes

- `fronted.go:52`'s doc claim "Startup does no blocking network I/O" is **true again** — all network I/O is off the construction path.
- `dnstt/parser.go:150` guards `httpClient == nil`, which silently disabled dnstt config updates for the whole process lifetime whenever the old eager search failed. Now unreachable.

**Residual, not fixable here:** `kindling.NewSmartHTTPTransportWithConfig` takes no context at all and hardcodes `context.Background()` at `kindling.go:427`, so an in-flight search isn't cancellable by anything. The *wait* now is.

Two consequences follow, both needing a kindling change to close properly:

- A search outlives `kindling.Close()`. Mobile constructs a new `LocalBackend` after the extension stops, so repeated Init/Close cycles can leave several searches probing on. Each self-terminates within tens of seconds and none holds a lock, so they don't compound without bound — but they aren't free either. Threading a `ctx` into `NewHTTPClientWithSmartTransport` would *not* fix this, since the searches that stack are all started by fresh contexts on the next `Init()`.
- The startup config fetch now shares its 20s budget with the search rather than following it. Strictly better than pre-#575 when the search *fails* (that was the bug), but a new failure mode when it merely runs long: the fetch times out and domainfront waits 12h to retry. A shorter retry cadence after a failed *startup* fetch belongs upstream in domainfront.

## ⚠️ Observability change

On `lazy_dialing_round_trip`:

- `domain` now carries **the host requested**, not `domains[0]`. SigNoz queries filtering `domain = "raw.githubusercontent.com"` will stop matching mirror spans.
- **new** `transport_host` carries the host whose dialer served it. The two differ only on the `transportFor` fallback, which is exactly the case worth being able to see.
- `domains` still carries the full configured set.

A caller that cancels its own request now gets `ctx.Err()` back rather than a `could not create smart transport for …` error, and no span error is recorded for it — otherwise every 20s config-fetch timeout and every shutdown would look like a host outage in traces.

## Testing

New `kindling/smart/client_test.go` — the package had no tests. 12 tests; `gofmt`/`vet` clean; `go test -count=10 -race` clean. Timing-sensitive cases gate on channels with watchdogs rather than wall-clock bounds, so they assert ordering instead of duration.

Every pinned behavior was **mutation-tested** to confirm the test actually bites. Each mutation was reverted from a pristine copy and the restore verified with `cmp`:

| mutation | test that catches it | result |
|---|---|---|
| remove per-host routing | `TestBlockedHostDoesNotBlockOthers` | FAIL ✓ |
| cache the failed search | `TestFailedSearchIsRetried` | FAIL ✓ |
| ignore ctx while *joining* a search | `TestRequestGivesUpOnSearchWhenItsContextEnds` | FAIL ✓ (hangs to timeout) |
| drop the background warm-up | `TestConstructionStartsTheSearchWithoutBlocking` | FAIL ✓ |
| ignore ctx in the search **starter** | `TestSearchStarterGivesUpWhenItsContextEnds` | FAIL ✓ (hangs to timeout) |
| remove the `recover()` | `TestPanickingSearchBecomesAnError` | FAIL ✓ (panic kills the binary) |
| defer only `close(done)`, not the whole release path | `TestGoexitingSearchStillReleasesWaiters` | FAIL ✓ (waiters get `(nil, nil)`) |
| drop the successful-transport cache write | `TestSuccessfulSearchIsRemembered` | FAIL ✓ (1 search → 6) |

Three of these earned their keep for real:

**The starter/joiner distinction was found by CI, not by me.** The first version of this PR guarded only *acquiring* the semaphore with `ctx`, so the caller that won it had no escape. My machine's scheduling let the warm-up goroutine win every time; CI's didn't, and the job died at `600.007s` with a goroutine parked in `newTransport`. That is not merely a test flake — after a failed search (deliberately not cached) the *next* production request starts the search itself and blocks for its full ~14s regardless of its own deadline. Hence the redesign.

**The `runtime.Goexit` path was a live bug in the first merged-ready revision.** A test helper calling `t.Fatal` on the search goroutine was enough to trigger it, but the production consequence was worse than a broken test: the host stayed wedged for the process lifetime, returning `(nil, nil)` to every caller.

**A mutation once survived a restore.** `gofmt`, `go build` and `go vet` all passed it clean, because an unused *parameter* is legal Go — only the test caught it, in a run I had already moved on from. Every mutation after that restored from a pristine copy and confirmed with `cmp` rather than trusting the script's own "restored" message.

> [!NOTE]
> `cmd/lantern` currently fails to build on `main` (`ipc.NewClient` arity), so I verified `./kindling/...` rather than the full tree. Confirmed pre-existing by stashing and rebuilding clean `main` — unrelated to this change.

## Not addressed here

The config race still has **no freshness tiebreak** — the winner is whichever source responds first, and it gets `persistConfig`'d and preferred on next start. A client cannot order the two: neither source sends `Last-Modified`, their ETags are opaque per-origin validators in different formats (raw.githubusercontent.com sends a 64-hex content digest, jsDelivr a weak `W/"108fd-…"` length+digest pair), and the config itself carries no timestamp (`Config` is just `TrustedCAs` + `Providers`).

Today the two sources agree — `getlantern/domainfront` and `firetweet/domainfront` both hold the same 67837-byte `fronted.yaml.gz`, blob `cfef63f` — so nothing is being served stale right now. The exposure is that **nothing would tell us if that stopped being true.** The authoritative repo is regenerated daily by the masquerades cron, the mirror is written only when `MIRROR_GITHUB_TOKEN` is set, and jsDelivr adds up to 12h of branch-pinned caching (`s-maxage=43200`) on top.

Two follow-ups, in order of urgency:

- **Detection** — a drift monitor in lantern-cloud's `update_masquerades`, comparing the two repos' **git blob SHAs** ahead of each publish and alerting on disagreement. A blob SHA is `sha1("blob <len>\0" + content)`, so it's a function of content alone: two repos sharing no history are directly comparable, and no cache sits in front of the API that reports it. That matters — a URL-only comparison would false-alarm on any run within 12h of a publish. Written, not yet merged.
- **Resolution** — a `generated_at`/version field in the published config, so the client can prefer the *fresher* source rather than the *faster* one. Belongs in **domainfront**; backward-compatible since `goccy/go-yaml`'s `Unmarshal` ignores unknown keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
