### PR TITLE
smart: fix reversed disorder/split ordering, verify the dialer on Android

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,3 +65,9 @@ proto:
 .PHONY: test
 test:
 	go test -v ./...
+
+# Runs on a connected device or emulator. Set RADIANCE_SMART_NETWORK_TEST=1 to
+# include the tests that need real egress.
+.PHONY: test-android
+test-android:
+	./scripts/android-test.sh

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac
 	github.com/getlantern/domainfront v0.0.0-20260722204513-8c1f8acfa715
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3
-	github.com/getlantern/kindling v0.0.0-20260722205227-8563bcdd9b04
+	github.com/getlantern/kindling v0.0.0-20260727200630-e0ccaa2a6abd
 	github.com/getlantern/lantern-box v0.0.106
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ replace github.com/refraction-networking/water => github.com/getlantern/water v0
 require (
 	github.com/1Password/srp v0.2.0
 	github.com/Jigsaw-Code/outline-sdk v0.0.19
+	github.com/Jigsaw-Code/outline-sdk/x v0.0.2
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/alexflint/go-arg v1.6.1
 	github.com/alitto/pond v1.9.2
@@ -64,7 +65,6 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
-	github.com/Jigsaw-Code/outline-sdk/x v0.0.2 // indirect
 	github.com/RoaringBitmap/roaring v1.2.3 // indirect
 	github.com/STARRY-S/zip v0.2.3 // indirect
 	github.com/akutz/memconn v0.1.0 // indirect
@@ -302,7 +302,7 @@ require (
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260504160031-60b97b32f348 // indirect
 	google.golang.org/grpc v1.80.0
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 	lukechampine.com/blake3 v1.3.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,8 @@ github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 h1:cSrD9ryDfTV2y
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770/go.mod h1:GOQsoDnEHl6ZmNIL+5uVo+JWRFWozMEp18Izcb++H+A=
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvdWv+YvXDqADVwjxM0DyABg2x4UgLVKU9McKI=
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
-github.com/getlantern/kindling v0.0.0-20260722205227-8563bcdd9b04 h1:YaN1rTKlpkREh9GQIJ8sLnZDt2brzzAhpd+nqmr2Iss=
-github.com/getlantern/kindling v0.0.0-20260722205227-8563bcdd9b04/go.mod h1:Mej4MXda67EuL+kM6k4xcgxysWarkYjR5XPcNr8oYUI=
+github.com/getlantern/kindling v0.0.0-20260727200630-e0ccaa2a6abd h1:1454lk6DHVIAVVM4v8oa2gzKbjSgEPWUcHihBcLKQYM=
+github.com/getlantern/kindling v0.0.0-20260727200630-e0ccaa2a6abd/go.mod h1:Mej4MXda67EuL+kM6k4xcgxysWarkYjR5XPcNr8oYUI=
 github.com/getlantern/lantern-box v0.0.106 h1:5czWMqdgrhCslLcE+ttt+us+d0dmCutpjxqmCOZnqKw=
 github.com/getlantern/lantern-box v0.0.106/go.mod h1:HHdmZsGwkiaweBycCYv1Jolk3jkrXbb/R5UUXtY2n3o=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=

--- a/internal/testsocks/testsocks.go
+++ b/internal/testsocks/testsocks.go
@@ -18,28 +18,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type Server struct {
-	ln net.Listener
-}
-
 // Listen starts a SOCKS5 CONNECT proxy on addr and closes it on test cleanup.
-// Pass port 0 for an ephemeral port and read the resolved one from Addr.
-func Listen(t *testing.T, addr string) *Server {
+func Listen(t *testing.T, addr string) {
 	t.Helper()
 	ln, err := net.Listen("tcp", addr)
 	require.NoError(t, err)
 	t.Cleanup(func() { ln.Close() })
-
-	s := &Server{ln: ln}
-	go s.serve()
-	return s
+	go serve(ln)
 }
 
-func (s *Server) Addr() string { return s.ln.Addr().String() }
-
-func (s *Server) serve() {
+func serve(ln net.Listener) {
 	for {
-		conn, err := s.ln.Accept()
+		conn, err := ln.Accept()
 		if err != nil {
 			return
 		}

--- a/internal/testsocks/testsocks.go
+++ b/internal/testsocks/testsocks.go
@@ -1,0 +1,103 @@
+// Package testsocks provides a SOCKS5 CONNECT proxy standing in for radiance's
+// local bypass proxy in tests.
+//
+// Production runs a sing-box mixed inbound, and the bypass package's own tests
+// use one. Callers that only need something on the far end of the proxy port
+// take this instead, to keep the whole sing-box stack out of their test binary
+// — it has to be pushed to a device on every android run.
+package testsocks
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"testing"
+
+	M "github.com/sagernet/sing/common/metadata"
+	"github.com/sagernet/sing/protocol/socks/socks5"
+	"github.com/stretchr/testify/require"
+)
+
+type Server struct {
+	ln net.Listener
+}
+
+// Listen starts a SOCKS5 CONNECT proxy on addr and closes it on test cleanup.
+// Pass port 0 for an ephemeral port and read the resolved one from Addr.
+func Listen(t *testing.T, addr string) *Server {
+	t.Helper()
+	ln, err := net.Listen("tcp", addr)
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	s := &Server{ln: ln}
+	go s.serve()
+	return s
+}
+
+func (s *Server) Addr() string { return s.ln.Addr().String() }
+
+func (s *Server) serve() {
+	for {
+		conn, err := s.ln.Accept()
+		if err != nil {
+			return
+		}
+		go handle(conn)
+	}
+}
+
+func handle(conn net.Conn) {
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+	if _, err := socks5.ReadAuthRequest(reader); err != nil {
+		return
+	}
+	if err := socks5.WriteAuthResponse(conn, socks5.AuthResponse{Method: socks5.AuthTypeNotRequired}); err != nil {
+		return
+	}
+	request, err := socks5.ReadRequest(reader)
+	if err != nil {
+		return
+	}
+	if request.Command != socks5.CommandConnect {
+		socks5.WriteResponse(conn, socks5.Response{ReplyCode: socks5.ReplyCodeUnsupported})
+		return
+	}
+
+	upstream, err := net.Dial("tcp", request.Destination.String())
+	if err != nil {
+		socks5.WriteResponse(conn, socks5.Response{ReplyCode: socks5.ReplyCodeForError(err)})
+		return
+	}
+	defer upstream.Close()
+
+	err = socks5.WriteResponse(conn, socks5.Response{
+		ReplyCode: socks5.ReplyCodeSuccess,
+		Bind:      M.SocksaddrFromNet(upstream.LocalAddr()),
+	})
+	if err != nil {
+		return
+	}
+
+	done := make(chan struct{}, 2)
+	// Copy from reader, not conn: it may hold bytes the client pipelined behind
+	// the CONNECT request.
+	go splice(upstream, reader, done)
+	go splice(conn, upstream, done)
+	<-done
+	<-done
+}
+
+// splice copies src into dst, then half-closes dst when it supports it, so that
+// an upstream waiting on EOF — an echo server, or an HTTP server reading a
+// request body — sees the stream end rather than stalling until the test times
+// out.
+func splice(dst io.Writer, src io.Reader, done chan<- struct{}) {
+	io.Copy(dst, src)
+	if hc, ok := dst.(interface{ CloseWrite() error }); ok {
+		hc.CloseWrite()
+	}
+	done <- struct{}{}
+}

--- a/justfile
+++ b/justfile
@@ -37,3 +37,8 @@ proto:
 
 test:
     go test -v ./...
+
+# Runs on a connected device or emulator. Set RADIANCE_SMART_NETWORK_TEST=1 to
+# include the tests that need real egress.
+test-android *packages:
+    ./scripts/android-test.sh {{packages}}

--- a/kindling/smart/client.go
+++ b/kindling/smart/client.go
@@ -23,18 +23,14 @@ import (
 
 const tracerName = "github.com/getlantern/radiance/kindling/smart"
 
-// DialerConfig is a copy of kindling's smart_dialer_config.yml that diverges
-// from it in two ways, both of which a resync has to carry over.
-//
-// The `system: {}` DNS entry is removed. The outline-sdk smart strategy rejects
-// any base StreamDialer that isn't *transport.TCPDialer when the system
-// resolver is selected, which the bypass dialer can't satisfy. DoH entries
-// route every probe through the supplied StreamDialer instead, which is
-// what we want anyway — system DNS uses OS routing tables and would loop
-// back through the VPN TUN we're trying to bypass.
-//
-// disorder sits leftmost in the tls list rather than rightmost, so configurl
-// hands it the raw socket it requires.
+// DialerConfig is a copy of kindling's smart_dialer_config.yml with the
+// `system: {}` DNS entry removed, which is the one divergence a resync has to
+// carry over. The outline-sdk smart strategy rejects any base StreamDialer that
+// isn't *transport.TCPDialer when the system resolver is selected, which the
+// bypass dialer can't satisfy. DoH entries route every probe through the
+// supplied StreamDialer instead, which is what we want anyway — system DNS uses
+// OS routing tables and would loop back through the VPN TUN we're trying to
+// bypass.
 //
 //go:embed smart_dialer_config.yml
 var DialerConfig []byte

--- a/kindling/smart/client.go
+++ b/kindling/smart/client.go
@@ -23,13 +23,18 @@ import (
 
 const tracerName = "github.com/getlantern/radiance/kindling/smart"
 
-// DialerConfig is a copy of kindling's smart_dialer_config.yml with the
-// `system: {}` DNS entry removed. The outline-sdk smart strategy rejects
+// DialerConfig is a copy of kindling's smart_dialer_config.yml that diverges
+// from it in two ways, both of which a resync has to carry over.
+//
+// The `system: {}` DNS entry is removed. The outline-sdk smart strategy rejects
 // any base StreamDialer that isn't *transport.TCPDialer when the system
 // resolver is selected, which the bypass dialer can't satisfy. DoH entries
 // route every probe through the supplied StreamDialer instead, which is
 // what we want anyway — system DNS uses OS routing tables and would loop
 // back through the VPN TUN we're trying to bypass.
+//
+// disorder sits leftmost in the tls list rather than rightmost, so configurl
+// hands it the raw socket it requires.
 //
 //go:embed smart_dialer_config.yml
 var DialerConfig []byte

--- a/kindling/smart/dialerconfig_test.go
+++ b/kindling/smart/dialerconfig_test.go
@@ -1,0 +1,249 @@
+package smart
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Jigsaw-Code/outline-sdk/transport"
+	"github.com/Jigsaw-Code/outline-sdk/x/configurl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/getlantern/radiance/bypass"
+	"github.com/getlantern/radiance/internal/testsocks"
+)
+
+// dialerConfigYAML mirrors the schema outline-sdk's strategy finder unmarshals
+// DialerConfig into. Its own type is unexported, so a test that wants to assert
+// on what the finder will see has to restate it.
+type dialerConfigYAML struct {
+	DNS      []dnsEntryYAML `yaml:"dns"`
+	TLS      []string       `yaml:"tls"`
+	Fallback []string       `yaml:"fallback"`
+}
+
+type dnsEntryYAML struct {
+	System *struct{}       `yaml:"system"`
+	HTTPS  *dnsServerYAML  `yaml:"https"`
+	TLS    *dnsServerYAML  `yaml:"tls"`
+	UDP    *dnsAddressYAML `yaml:"udp"`
+	TCP    *dnsAddressYAML `yaml:"tcp"`
+}
+
+type dnsServerYAML struct {
+	Name    string `yaml:"name"`
+	Address string `yaml:"address"`
+}
+
+type dnsAddressYAML struct {
+	Address string `yaml:"address"`
+}
+
+const testServerName = "smart-dialer-test"
+
+func parseDialerConfig(t *testing.T) dialerConfigYAML {
+	t.Helper()
+	var cfg dialerConfigYAML
+	dec := yaml.NewDecoder(strings.NewReader(string(DialerConfig)))
+	// Strict: a key outline-sdk doesn't know is silently dropped at runtime, so
+	// a typo would disable a strategy or resolver without any signal.
+	dec.KnownFields(true)
+	require.NoError(t, dec.Decode(&cfg))
+	return cfg
+}
+
+func TestDialerConfigParses(t *testing.T) {
+	cfg := parseDialerConfig(t)
+	assert.NotEmpty(t, cfg.DNS, "a config with no resolver cannot complete a search")
+	assert.NotEmpty(t, cfg.TLS, "a config with no TLS strategy cannot complete a search")
+}
+
+// TestDialerConfigResolversAreEncrypted covers why radiance drops kindling's
+// system DNS entry. A system entry that wins the resolver race makes outline-sdk
+// demand a base dialer of exactly *transport.TCPDialer, which
+// bypass.StreamDialer never is. A udp entry
+// resolves through the packet dialer, which has no bypass path and loops back
+// into the tunnel; a tcp entry keeps the bypass path but resolves in the clear.
+func TestDialerConfigResolversAreEncrypted(t *testing.T) {
+	for i, entry := range parseDialerConfig(t).DNS {
+		assert.Nil(t, entry.System, "dns entry %d: system resolver", i)
+		assert.Nil(t, entry.UDP, "dns entry %d: plaintext UDP resolver", i)
+		assert.Nil(t, entry.TCP, "dns entry %d: plaintext TCP resolver", i)
+		assert.True(t, entry.HTTPS != nil || entry.TLS != nil, "dns entry %d: neither DoH nor DoT", i)
+	}
+}
+
+// TestDisorderPrecedesTheWrappersItFeeds guards the one ordering constraint in
+// the strategy list: disorder requires a raw *net.TCPConn from whatever is to
+// its left, so any wrapper placed before it makes the strategy unusable.
+func TestDisorderPrecedesTheWrappersItFeeds(t *testing.T) {
+	for _, strategy := range parseDialerConfig(t).TLS {
+		for i, part := range strings.Split(strategy, "|") {
+			if strings.HasPrefix(strings.TrimSpace(part), "disorder") {
+				assert.Zero(t, i, "%q: disorder must be the leftmost element", strategy)
+			}
+		}
+	}
+}
+
+// needsRawSocket reports whether a strategy fails outright without a
+// *net.TCPConn from the base dialer. Only disorder does; tlsfrag also
+// type-asserts one but degrades to a buffered write.
+func needsRawSocket(strategy string) bool {
+	return strings.Contains(strategy, "disorder")
+}
+
+// newTLSServer returns the listener's address and a pool trusting its
+// self-signed certificate. tlsfrag cuts on TLS record boundaries, so a bare TCP
+// echo cannot stand in for a real ClientHello.
+func newTLSServer(t *testing.T) (string, *x509.CertPool) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: testServerName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		DNSNames:     []string{testServerName},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	roots := x509.NewCertPool()
+	roots.AddCert(cert)
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{{Certificate: [][]byte{der}, PrivateKey: key}},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				conn.(*tls.Conn).HandshakeContext(context.Background())
+			}()
+		}
+	}()
+	return ln.Addr().String(), roots
+}
+
+func handshakeThrough(t *testing.T, base transport.StreamDialer, strategy, addr string, roots *x509.CertPool, serverName string) error {
+	t.Helper()
+
+	providers := configurl.NewDefaultProviders()
+	providers.StreamDialers.BaseInstance = base
+	dialer, err := providers.NewStreamDialer(context.Background(), strategy)
+	require.NoError(t, err, "strategy %q is not a valid outline-sdk config", strategy)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	conn, err := dialer.DialStream(ctx, addr)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	tlsConn := tls.Client(conn, &tls.Config{ServerName: serverName, RootCAs: roots})
+	defer tlsConn.Close()
+	return tlsConn.HandshakeContext(ctx)
+}
+
+// TestStrategiesHandshakeOverTCPDialer is the platform-independent floor: every
+// strategy has to work against the plain TCP dialer, or it is simply misspelled.
+func TestStrategiesHandshakeOverTCPDialer(t *testing.T) {
+	addr, roots := newTLSServer(t)
+	for _, strategy := range parseDialerConfig(t).TLS {
+		t.Run(strategyName(strategy), func(t *testing.T) {
+			assert.NoError(t, handshakeThrough(t, &transport.TCPDialer{}, strategy, addr, roots, testServerName))
+		})
+	}
+}
+
+// TestStrategiesHandshakeOverDirectBypassDial covers the shape radiance has
+// before its own tunnel is up — bypass.StreamDialer falls through to a direct
+// dial, so every strategy including disorder must work.
+func TestStrategiesHandshakeOverDirectBypassDial(t *testing.T) {
+	requireNoBypassProxy(t)
+	addr, roots := newTLSServer(t)
+	for _, strategy := range parseDialerConfig(t).TLS {
+		t.Run(strategyName(strategy), func(t *testing.T) {
+			assert.NoError(t, handshakeThrough(t, bypass.StreamDialer(), strategy, addr, roots, testServerName))
+		})
+	}
+}
+
+// TestStrategiesHandshakeThroughBypassProxy covers the shape radiance runs in
+// whenever its tunnel is up: the base dialer hands back a masked loopback
+// socket rather than a *net.TCPConn.
+//
+// disorder is expected to fail there and the assertion is deliberate rather
+// than a skip. Unmasking the socket would let it pass while setting TTL on the
+// loopback leg to the bypass proxy — a strategy that wins the search and
+// circumvents nothing.
+func TestStrategiesHandshakeThroughBypassProxy(t *testing.T) {
+	requireNoBypassProxy(t)
+	testsocks.Listen(t, bypassProxyAddr())
+	addr, roots := newTLSServer(t)
+
+	var usable int
+	for _, strategy := range parseDialerConfig(t).TLS {
+		t.Run(strategyName(strategy), func(t *testing.T) {
+			err := handshakeThrough(t, bypass.StreamDialer(), strategy, addr, roots, testServerName)
+			if needsRawSocket(strategy) {
+				assert.ErrorContains(t, err, "TCPConn",
+					"the only accepted reason for a strategy to fail behind the bypass proxy is the masked socket")
+				return
+			}
+			assert.NoError(t, err)
+			usable++
+		})
+	}
+	assert.GreaterOrEqual(t, usable, 2,
+		"a tunnelled search needs more than one survivor, or a single blocked strategy leaves it nothing")
+}
+
+func bypassProxyAddr() string {
+	return net.JoinHostPort("127.0.0.1", strconv.Itoa(bypass.ProxyPort))
+}
+
+// requireNoBypassProxy skips when something already holds the fixed bypass port
+// — a running Lantern on a developer machine — since the test would otherwise
+// dial the real tunnel and assert on the wrong dialer shape.
+func requireNoBypassProxy(t *testing.T) {
+	t.Helper()
+	conn, err := net.DialTimeout("tcp", bypassProxyAddr(), time.Second)
+	if err == nil {
+		conn.Close()
+		t.Skipf("something is already listening on the bypass port %s", bypassProxyAddr())
+	}
+}
+
+// strategyName labels the empty direct strategy, which would otherwise produce
+// an unnamed subtest.
+func strategyName(strategy string) string {
+	if strategy == "" {
+		return "direct"
+	}
+	return strategy
+}

--- a/kindling/smart/network_test.go
+++ b/kindling/smart/network_test.go
@@ -1,0 +1,155 @@
+package smart
+
+import (
+	"context"
+	"crypto/x509"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Jigsaw-Code/outline-sdk/transport"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/getlantern/radiance/internal/testsocks"
+)
+
+// networkTestEnv gates the tests below. They need real egress and they hit the
+// production config hosts, so they stay out of the default suite and out of CI.
+const networkTestEnv = "RADIANCE_SMART_NETWORK_TEST"
+
+// configURLs are two hosts with different blocking profiles, the shape the
+// production fetch races a pair in.
+var configURLs = []string{
+	"https://raw.githubusercontent.com/getlantern/domainfront/refs/heads/main/fronted.yaml.gz",
+	"https://cdn.jsdelivr.net/gh/firetweet/domainfront@main/fronted.yaml.gz",
+}
+
+const (
+	realHostName = "raw.githubusercontent.com"
+	realHostAddr = realHostName + ":443"
+)
+
+// searchTimeout bounds one host's fetch. The strategy search races a resolver
+// list and a strategy list at 250 ms intervals with a 5 s per-test timeout, so
+// a cold search on a slow emulator can legitimately take tens of seconds.
+const searchTimeout = 90 * time.Second
+
+func requireNetworkTests(t *testing.T) {
+	t.Helper()
+	if os.Getenv(networkTestEnv) == "" {
+		t.Skipf("set %s=1 to run tests that need real egress", networkTestEnv)
+	}
+}
+
+// searchLog collects the strategy finder's output, which is the only place the
+// selected strategy and the per-strategy failures are reported.
+type searchLog struct {
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+func (l *searchLog) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.buf.Write(p)
+}
+
+func (l *searchLog) String() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.buf.String()
+}
+
+func (l *searchLog) report(t *testing.T) {
+	t.Helper()
+	for line := range strings.SplitSeq(l.String(), "\n") {
+		if strings.Contains(line, "selected") || strings.Contains(line, "❌") {
+			t.Log(line)
+		}
+	}
+}
+
+// fetchThroughSmartClient returns the number of hosts that turned out to be
+// reachable, since one blocked host is an expected outcome rather than a
+// failure.
+func fetchThroughSmartClient(t *testing.T, log *searchLog) int {
+	t.Helper()
+
+	client, err := NewHTTPClientWithSmartTransport(log, configURLs...)
+	require.NoError(t, err)
+
+	var reached int
+	for _, url := range configURLs {
+		t.Run(url, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), searchTimeout)
+			defer cancel()
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+			require.NoError(t, err)
+
+			res, err := client.Do(req)
+			if err != nil {
+				t.Logf("unreachable: %v", err)
+				return
+			}
+			defer res.Body.Close()
+			assert.Equal(t, http.StatusOK, res.StatusCode)
+
+			body, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			assert.NotEmpty(t, body)
+			reached++
+		})
+	}
+	return reached
+}
+
+// TestStrategiesReachRealHost runs every strategy against a real host rather
+// than letting the search race them, so a strategy that only ever loses the
+// race is still exercised. The loopback tests cannot stand in for this one:
+// disorder relies on a TTL-limited packet being dropped in transit, which no
+// loopback path can reproduce.
+func TestStrategiesReachRealHost(t *testing.T) {
+	requireNetworkTests(t)
+	requireNoBypassProxy(t)
+
+	roots, err := x509.SystemCertPool()
+	require.NoError(t, err)
+	for _, strategy := range parseDialerConfig(t).TLS {
+		t.Run(strategyName(strategy), func(t *testing.T) {
+			assert.NoError(t, handshakeThrough(t, &transport.TCPDialer{}, strategy, realHostAddr, roots, realHostName))
+		})
+	}
+}
+
+// TestSmartClientFetchesConfigDirectly is the pre-tunnel shape: no bypass proxy
+// is listening, so the base dialer falls through to a direct dial.
+func TestSmartClientFetchesConfigDirectly(t *testing.T) {
+	requireNetworkTests(t)
+	requireNoBypassProxy(t)
+
+	log := &searchLog{}
+	reached := fetchThroughSmartClient(t, log)
+	log.report(t)
+	assert.Positive(t, reached, "no config host was reachable through any strategy")
+}
+
+// TestSmartClientFetchesConfigThroughBypassProxy is the connected shape: every
+// probe goes through the local SOCKS proxy, so the strategies that need a raw
+// socket drop out of the search and a working strategy must still be found
+// among the rest.
+func TestSmartClientFetchesConfigThroughBypassProxy(t *testing.T) {
+	requireNetworkTests(t)
+	requireNoBypassProxy(t)
+	testsocks.Listen(t, bypassProxyAddr())
+
+	log := &searchLog{}
+	reached := fetchThroughSmartClient(t, log)
+	log.report(t)
+	assert.Positive(t, reached,
+		"the search must survive losing the strategies that need a raw socket")
+}

--- a/kindling/smart/network_test.go
+++ b/kindling/smart/network_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -39,9 +40,12 @@ const (
 // a cold search on a slow emulator can legitimately take tens of seconds.
 const searchTimeout = 90 * time.Second
 
+// requireNetworkTests parses rather than checking for non-empty, so that an
+// explicit 0 or false disables the tests instead of enabling them.
 func requireNetworkTests(t *testing.T) {
 	t.Helper()
-	if os.Getenv(networkTestEnv) == "" {
+	on, err := strconv.ParseBool(os.Getenv(networkTestEnv))
+	if err != nil || !on {
 		t.Skipf("set %s=1 to run tests that need real egress", networkTestEnv)
 	}
 }

--- a/kindling/smart/smart_dialer_config.yml
+++ b/kindling/smart/smart_dialer_config.yml
@@ -28,5 +28,8 @@ tls:
   - "" # Direct dialer
   - split:1
   - split:2,20*5
-  - split:200|disorder:1
+  # disorder must precede split: configurl pipes left to right, so the rightmost
+  # entry is outermost, and disorder type-asserts its inner conn to *net.TCPConn.
+  # Spelled the other way round it never dials.
+  - disorder:1|split:200
   - tlsfrag:1

--- a/scripts/android-test.sh
+++ b/scripts/android-test.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Cross-compile Go test binaries for Android and run them on a connected device
+# or emulator.
+#
+#   scripts/android-test.sh [PACKAGE...]
+#
+# Packages default to the smart dialer and its base dialer.
+#
+# Environment:
+#   ANDROID_HOME / ANDROID_SDK_ROOT  SDK location (default ~/Library/Android/sdk
+#                                    on macOS, ~/Android/Sdk elsewhere)
+#   ANDROID_NDK_HOME                 NDK location (default: newest under $SDK/ndk)
+#   ANDROID_API                      minimum API for the toolchain (default 24)
+#   ANDROID_SERIAL                   target device when several are attached
+#   RADIANCE_SMART_NETWORK_TEST      set to 1 to include the real-egress tests
+#   TEST_FLAGS                       extra flags for the test binaries
+#                                    (default: -test.v -test.timeout 10m)
+set -euo pipefail
+
+PACKAGES=("$@")
+if [[ ${#PACKAGES[@]} -eq 0 ]]; then
+    PACKAGES=(./kindling/smart ./bypass)
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- SDK / NDK -------------------------------------------------------------
+
+SDK="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+if [[ -z "$SDK" ]]; then
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        SDK="$HOME/Library/Android/sdk"
+    else
+        SDK="$HOME/Android/Sdk"
+    fi
+fi
+[[ -d "$SDK" ]] || { echo "Android SDK not found at $SDK; set ANDROID_HOME" >&2; exit 1; }
+
+ADB="$SDK/platform-tools/adb"
+[[ -x "$ADB" ]] || { echo "adb not found at $ADB" >&2; exit 1; }
+
+NDK="${ANDROID_NDK_HOME:-}"
+if [[ -z "$NDK" ]]; then
+    NDK="$(find "$SDK/ndk" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort -V | tail -1)"
+fi
+[[ -n "$NDK" && -d "$NDK" ]] || { echo "NDK not found under $SDK/ndk; set ANDROID_NDK_HOME" >&2; exit 1; }
+
+# The NDK's macOS toolchain lives under darwin-x86_64 on Apple Silicon hosts
+# too; the binaries are universal.
+case "$(uname -s)" in
+    Darwin) HOST_TAG="darwin-x86_64" ;;
+    Linux)  HOST_TAG="linux-x86_64" ;;
+    *)      echo "unsupported host $(uname -s)" >&2; exit 1 ;;
+esac
+TOOLCHAIN="$NDK/toolchains/llvm/prebuilt/$HOST_TAG/bin"
+[[ -d "$TOOLCHAIN" ]] || { echo "NDK toolchain not found at $TOOLCHAIN" >&2; exit 1; }
+
+# --- Device ----------------------------------------------------------------
+
+if ! "$ADB" get-state >/dev/null 2>&1; then
+    echo "no device: start an emulator or attach a device" >&2
+    "$ADB" devices >&2
+    exit 1
+fi
+
+DEVICE_ABI="$("$ADB" shell getprop ro.product.cpu.abi | tr -d '\r\n')"
+case "$DEVICE_ABI" in
+    arm64-v8a)   GOARCH=arm64; CC_PREFIX=aarch64-linux-android ;;
+    armeabi-v7a) GOARCH=arm;   CC_PREFIX=armv7a-linux-androideabi ;;
+    x86_64)      GOARCH=amd64; CC_PREFIX=x86_64-linux-android ;;
+    x86)         GOARCH=386;   CC_PREFIX=i686-linux-android ;;
+    *) echo "unsupported device ABI: $DEVICE_ABI" >&2; exit 1 ;;
+esac
+
+API="${ANDROID_API:-24}"
+CC="$TOOLCHAIN/$CC_PREFIX$API-clang"
+[[ -x "$CC" ]] || { echo "no clang for API $API at $CC" >&2; exit 1; }
+# Packages with C++ objects link through CXX, which otherwise defaults to the
+# host g++ and fails on the android objects.
+CXX="$CC++"
+# Those binaries then need the NDK's C++ runtime at load time. An app gets it
+# bundled into the APK; a bare test binary has to carry its own copy.
+LIBCXX="$TOOLCHAIN/../sysroot/usr/lib/$CC_PREFIX/libc++_shared.so"
+
+DEVICE_API="$("$ADB" shell getprop ro.build.version.sdk | tr -d '\r\n')"
+echo "device: $DEVICE_ABI, API $DEVICE_API"
+echo "ndk:    $(basename "$NDK") ($CC_PREFIX$API)"
+
+# --- Build -----------------------------------------------------------------
+
+BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+
+# Without this, sing-box's experimental/libbox fails to link: it pull-linknames
+# os.checkPidfdOnce to disable pidfd on Android, which the linker has rejected by
+# default since Go 1.23. The shipped android library is built with the same flag.
+LDFLAGS="-checklinkname=0"
+
+BINARIES=()
+for pkg in "${PACKAGES[@]}"; do
+    name="$(basename "$pkg")"
+    echo "building $pkg"
+    if ! GOOS=android GOARCH="$GOARCH" CGO_ENABLED=1 CC="$CC" CXX="$CXX" \
+        go test -c -ldflags="$LDFLAGS" -o "$BUILD_DIR/$name.test" "$pkg"; then
+        echo "FAILED to build $pkg for android/$GOARCH" >&2
+        exit 1
+    fi
+    BINARIES+=("$name")
+done
+
+# --- Run -------------------------------------------------------------------
+
+REMOTE_DIR="/data/local/tmp/radiance-tests"
+"$ADB" shell "rm -rf $REMOTE_DIR && mkdir -p $REMOTE_DIR/tmp"
+"$ADB" push "$LIBCXX" "$REMOTE_DIR/" >/dev/null
+
+REMOTE_ENV="TMPDIR=$REMOTE_DIR/tmp LD_LIBRARY_PATH=$REMOTE_DIR"
+if [[ -n "${RADIANCE_SMART_NETWORK_TEST:-}" ]]; then
+    REMOTE_ENV="$REMOTE_ENV RADIANCE_SMART_NETWORK_TEST=$RADIANCE_SMART_NETWORK_TEST"
+fi
+
+FLAGS="${TEST_FLAGS:--test.v -test.timeout 10m}"
+
+status=0
+for name in "${BINARIES[@]}"; do
+    "$ADB" push "$BUILD_DIR/$name.test" "$REMOTE_DIR/" >/dev/null
+    "$ADB" shell "chmod 755 $REMOTE_DIR/$name.test"
+    echo
+    echo "=== $name (android/$GOARCH) ==="
+    # cd into the remote dir so relative paths land under the tree removed below.
+    if ! "$ADB" shell "cd $REMOTE_DIR && $REMOTE_ENV ./$name.test $FLAGS"; then
+        status=1
+    fi
+done
+
+"$ADB" shell "rm -rf $REMOTE_DIR"
+exit $status


### PR DESCRIPTION
Android logs showed the smart dialer's `disorder` strategy failing with `expected base dialer to return TCPConn`. Investigating turned up **two independent problems**, only one of which is Android-specific.

## 1. The strategy string is spelled backwards (all platforms)

`configurl` parses a pipeline left to right, so the **rightmost element is outermost**. `split:200|disorder:1` builds `disorder` on top of `split` — but `split.DialStream` returns a `transport.WrapConn`, and `disorder.DialStream` type-asserts its inner conn to `*net.TCPConn`. It can never succeed.

```mermaid
sequenceDiagram
    autonumber
    participant F as strategy finder<br/>outline-sdk smart
    participant D as disorder:1<br/>x/disorder/stream_dialer.go
    participant S as split:200<br/>transport/split/stream_dialer.go
    participant B as base dialer<br/>bypass/streamdialer.go

    Note over F: smart_dialer_config.yml<br/>entry spelled split:200 → disorder:1 ⚠️
    F->>D: DialStream — disorder is outermost<br/>configurl pipes left to right
    D->>S: DialStream on its inner dialer
    S->>B: DialStream
    B-->>S: *net.TCPConn
    Note over S: split wraps it in transport.WrapConn
    S-->>D: transport.StreamConn, no longer a *net.TCPConn
    rect rgba(255, 200, 200, 0.3)
        Note over D: innerConn.(*net.TCPConn) fails 🐛<br/>expected base dialer to return TCPConn
    end
    D-->>F: error — strategy silently dropped from the race
```

This failed with a plain `*transport.TCPDialer` too — nothing to do with the bypass dialer, and nothing to do with Android. Because `raceTests` just drops a losing strategy, we have been quietly running **four** of our five TLS strategies. outline-sdk's own docs use the other order (`disorder:0|split:123`).

Fixed by reordering to `disorder:1|split:200`.

## 2. `disorder` genuinely cannot run while the tunnel is up

`bypass.StreamDialer()` deliberately masks the loopback socket (`bypass/streamdialer.go`) whenever the SOCKS bypass proxy is listening. That masking is **correct** — setting TTL=1 on a `127.0.0.1` socket circumvents nothing, and unmasking it would let disorder win the search while doing no work. But it does mean disorder is unavailable on any connected session, on every platform (`vpn/boxoptions_default.go` adds the bypass inbound unconditionally). Android is just where it got noticed.

This is left as-is and asserted in a test, so removing the mask breaks the build.

## Tests

`kindling/smart/dialerconfig_test.go` — hermetic, runs on every platform:

- strict YAML parse against outline-sdk's schema (an unknown key is silently dropped at runtime today)
- no `system:` / `udp:` / `tcp:` resolver entries — the reason we fork kindling's config
- the disorder-ordering invariant, as a static check
- every strategy completing a real TLS handshake across **all three dialer shapes**: plain TCP, bypass-direct (pre-tunnel), bypass-proxied (connected). The proxied case asserts disorder fails *specifically* on the masked socket.

`kindling/smart/network_test.go` — opt-in via `RADIANCE_SMART_NETWORK_TEST=1`:

- each strategy against a real host individually, so one that always loses the race is still exercised — loopback can't test disorder, which needs a TTL-limited packet actually dropped in transit
- real config fetches in both dialer shapes, logging which strategy the search picked

I confirmed the tests catch the original bug by reverting the config: both the static ordering check and the TCP-dialer handshake fail.

## Running on Android

```
make test-android                                  # hermetic only
RADIANCE_SMART_NETWORK_TEST=1 make test-android    # + real egress
```

`scripts/android-test.sh` detects the device ABI, cross-compiles with the NDK, pushes, and runs. Three things it has to do that `gomobile bind` handles for an AAR but a bare test binary doesn't:

- `-ldflags=-checklinkname=0` — sing-box's `experimental/libbox` pull-linknames `os.checkPidfdOnce` to disable pidfd on Android, which the linker has rejected by default since Go 1.23. This is not a Go 1.26 regression: I reproduced the identical failure on 1.23, 1.24, 1.25 and 1.26, and sing-box's `go.mod` requires `go >= 1.23.1`, so no supported Go avoids it. `lantern-client`'s `gomobile bind` already passes the same flag.
- `CXX` pointed at the NDK — Go derives the default from the *target* GOOS and picks `g++`, which chokes on the Android objects (the C++ comes from `go-libutp`)
- pushing `libc++_shared.so` with `LD_LIBRARY_PATH`

`internal/testsocks` is a minimal SOCKS5 CONNECT fixture used by the smart-dialer tests, to keep the whole sing-box stack out of that test binary — 16 MB vs 67 MB, pushed to the device on every run. `bypass`'s own tests are unchanged and still use the real sing-box mixed inbound, including on Android.

## Verification

All tests pass locally and on an emulator (API 30, arm64-v8a), in both packages, including the real-network ones. `disorder:1|split:200` now completes a real TLS handshake from Android — its ~0.3 s vs ~0.04 s for the other strategies is the retransmit wait from the TTL-limited packet actually being dropped.

## Follow-up (not in this PR)

`getlantern/kindling`'s own `smart_dialer_config.yml` has the same reversed ordering. radiance overrides it so we're unaffected, but any other `NewSmartHTTPTransport` caller is running a dead strategy. Separate one-line PR to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Android test support for connected devices and emulators.
  * Added automated smart-network integration tests for direct and bypass-proxy connections.
  * Added SOCKS5 proxy support for testing network flows.

* **Bug Fixes**
  * Updated smart dialing strategy ordering to improve connection reliability.

* **Documentation**
  * Clarified smart dialer configuration requirements and strategy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->