### PR TITLE
deps: bump kindling to pick up the strategy-dial regression test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac
 	github.com/getlantern/domainfront v0.0.0-20260722204513-8c1f8acfa715
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3
-	github.com/getlantern/kindling v0.0.0-20260727200630-e0ccaa2a6abd
+	github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464
 	github.com/getlantern/lantern-box v0.0.106
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,8 @@ github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 h1:cSrD9ryDfTV2y
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770/go.mod h1:GOQsoDnEHl6ZmNIL+5uVo+JWRFWozMEp18Izcb++H+A=
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvdWv+YvXDqADVwjxM0DyABg2x4UgLVKU9McKI=
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
-github.com/getlantern/kindling v0.0.0-20260727200630-e0ccaa2a6abd h1:1454lk6DHVIAVVM4v8oa2gzKbjSgEPWUcHihBcLKQYM=
-github.com/getlantern/kindling v0.0.0-20260727200630-e0ccaa2a6abd/go.mod h1:Mej4MXda67EuL+kM6k4xcgxysWarkYjR5XPcNr8oYUI=
+github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464 h1:vZtMtKDsGO0ccBr+aQRRDKgcwFTg4psy13HtMttuBVQ=
+github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464/go.mod h1:ZEPFiB6rH6MtMN1O7b5gE+LJpCsRFzAn4u8lbIxHh3w=
 github.com/getlantern/lantern-box v0.0.106 h1:5czWMqdgrhCslLcE+ttt+us+d0dmCutpjxqmCOZnqKw=
 github.com/getlantern/lantern-box v0.0.106/go.mod h1:HHdmZsGwkiaweBycCYv1Jolk3jkrXbb/R5UUXtY2n3o=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=


### PR DESCRIPTION
Propagates getlantern/kindling#46, which adds the regression test that the ordering fix in kindling#45 shipped without.

## What's in the range

`e0ccaa2..573c1ef` is a single commit:

```
 go.mod                      |   2 +-
 smart_dialer_config_test.go | 118 +++++++++++++++++++++++++++++++++++++++++++
```

**No non-test Go source changed** — the `go.mod` line is `gopkg.in/yaml.v3` moving indirect→direct in kindling (same version, v3.0.1), which the new test needs to parse the embedded config.

## Why bump at all

This is behaviourally inert for radiance: kindling's tests aren't compiled into us, and we override the embedded config anyway (`kindling/smart/DialerConfig`). It's pin hygiene — keeping us near kindling HEAD so the next functional bump is a small diff rather than a pile of unrelated commits. Easy to drop if you'd rather not carry the churn.

## Verification

`go.mod`/`go.sum` diff is confined to the kindling pseudo-version — no transitive version moved. `go mod tidy` run; both files committed together.

- `go build -tags with_clash_api ./...` — clean
- `go test ./kindling/... ./bypass/` with `RADIANCE_SMART_NETWORK_TEST=1` — all pass

Also re-ran on an emulator (API 30, arm64-v8a) rather than assuming, because `main` picked up a sing-box-minimal bump (#581) in the meantime and sing-box's `experimental/libbox` is exactly what drove the `-checklinkname=0` requirement in `scripts/android-test.sh`. Both packages still cross-compile, link, and pass on device, real-egress tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to a newer version, bringing in the latest available improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->