### PR TITLE
fix: resolve mobile device ID from caller then persisted settings

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -139,7 +139,17 @@ func NewLocalBackend(ctx context.Context, opts Options) (*LocalBackend, error) {
 	var platformDeviceID string
 	switch common.Platform {
 	case "ios", "android":
-		platformDeviceID = opts.DeviceID
+		// The device ID is owned by the native caller and shared to the extension
+		// through persisted settings so both use the same ID. Unlike the desktop
+		// branch, don't generate one here — log and continue if it's absent.
+		switch {
+		case opts.DeviceID != "":
+			platformDeviceID = opts.DeviceID
+		case settings.Exists(settings.DeviceIDKey):
+			platformDeviceID = settings.GetString(settings.DeviceIDKey)
+		default:
+			slog.Warn("No device ID was found")
+		}
 	default:
 		platformDeviceID = deviceid.Get(settings.GetString(settings.DataPathKey))
 	}

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -146,7 +146,9 @@ func NewLocalBackend(ctx context.Context, opts Options) (*LocalBackend, error) {
 		case opts.DeviceID != "":
 			platformDeviceID = opts.DeviceID
 		case settings.Exists(settings.DeviceIDKey):
-			platformDeviceID = settings.GetString(settings.DeviceIDKey)
+			if platformDeviceID = settings.GetString(settings.DeviceIDKey); platformDeviceID == "" {
+				slog.Warn("No device ID was found")
+			}
 		default:
 			slog.Warn("No device ID was found")
 		}


### PR DESCRIPTION
## Summary

On iOS the main app and network extension run as separate processes that did not share a device ID, so each sent a different ID in config and telemetry requests (getlantern/engineering/issues/3701).

`NewLocalBackend` now resolves the mobile device ID in priority order:

1. the caller-supplied `opts.DeviceID` — the main app, which is authoritative
2. the ID persisted in the shared app-group settings — how the extension inherits the app's ID

Unlike the desktop branch, radiance never generates a device ID on mobile: the ID is owned by the native caller, so both processes use the same one. If neither source has an ID (unexpected once the app has run), it logs and continues rather than fabricating a mismatched one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device identification on iOS and Android by using a saved device ID when one isn’t explicitly provided.
  * Added warnings when a device ID is missing or empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->