### PR TITLE
remove name from tun options to avoid possible conflicts

### DIFF
--- a/vpn/boxoptions_default.go
+++ b/vpn/boxoptions_default.go
@@ -45,11 +45,10 @@ func baseInbounds() []O.Inbound {
 	}
 
 	tunOpts := &O.TunInboundOptions{
-		InterfaceName: "utun225",
-		Address:       tunAddress,
-		AutoRoute:     true,
-		StrictRoute:   true,
-		Stack:         "system",
+		Address:     tunAddress,
+		AutoRoute:   true,
+		StrictRoute: true,
+		Stack:       "system",
 	}
 	switch common.Platform {
 	case "android":


### PR DESCRIPTION
This pull request makes a small change to the `vpn/boxoptions_default.go` file by removing the explicit setting of the `InterfaceName` field in the `TunInboundOptions` struct. This allows the OS to assign one, avoiding possible conflicts.

closes getlantern/engineering/issues/3707.