### PR TITLE
bump lantern-box to v0.0.107

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/getlantern/domainfront v0.0.0-20260722204513-8c1f8acfa715
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3
 	github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464
-	github.com/getlantern/lantern-box v0.0.106
+	github.com/getlantern/lantern-box v0.0.107
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb

--- a/go.sum
+++ b/go.sum
@@ -248,6 +248,8 @@ github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464 h1:vZtMtKDsGO0
 github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464/go.mod h1:ZEPFiB6rH6MtMN1O7b5gE+LJpCsRFzAn4u8lbIxHh3w=
 github.com/getlantern/lantern-box v0.0.106 h1:5czWMqdgrhCslLcE+ttt+us+d0dmCutpjxqmCOZnqKw=
 github.com/getlantern/lantern-box v0.0.106/go.mod h1:HHdmZsGwkiaweBycCYv1Jolk3jkrXbb/R5UUXtY2n3o=
+github.com/getlantern/lantern-box v0.0.107 h1:uTRoj5BKijO6Q2a9JZWunFL7Z29WDg8WzEuoliJ+kJg=
+github.com/getlantern/lantern-box v0.0.107/go.mod h1:HHdmZsGwkiaweBycCYv1Jolk3jkrXbb/R5UUXtY2n3o=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395/go.mod h1:3JpJgwi4KEI6rS9loOAvcBp+F2jP65d0tTg2GQcTPBU=
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 h1:3BwvWj0JZzFEvNNiMhCu4bf60nqcIuQpTYb00Ezm1ag=


### PR DESCRIPTION
Step 1 of the chain carrying getlantern/lantern-box#294 to clients. Step 2 is the radiance bump in `getlantern/lantern`.

## What this picks up

**lantern-box#294** — `readInfo` decided whether a flow carried client info from a **single** `Conn.Read`, then prefix-matched whatever that one read returned. TCP is a stream, so an 11-byte `CLIENTINFO ` prefix split across reads — routine under DPI throttling, where segments are small and fragmented — was classified as ordinary traffic. Two consequences:

- the server never wrote `"OK"`, so the client blocked on its 2-byte response read
- the fall-through replayed the prefix bytes upstream, so the destination received `CLIENTINFO {…}` instead of a TLS ClientHello and reset

Measured from RU Android logs ([ticket #180956](https://lantern.freshdesk.com/a/tickets/180956), 438 occurrences over Aug 1–5): **954s median**, 1964s max, 312 of 438 over two minutes. Tracked as getlantern/engineering#3773; shared root cause behind #3718 and #3772.

Also carries **lantern-box#291**'s client-side deadline — already pinned here at v0.0.106 — onward to clients, which converts that stall into a 10s failure rather than one bounded only by the kernel's TCP timeout.

## Verification

- library packages (everything the client imports) build, vet and test clean — **18/18 packages pass**
- `go mod tidy` run; `go.mod` and `go.sum` committed together
- `go mod verify` — all modules verified
- confirmed the resolved module actually contains the fix:
  ```
  github.com/getlantern/lantern-box v0.0.107
  tracker/clientcontext/manager.go:161: n, err := io.ReadAtLeast(c.Conn, buf[:], len(packetPrefix))
  ```

## Pre-existing breakage, unrelated to this change

Two things in `cmd/` are already broken on clean `main`, verified by stashing:

- `cmd/meek-fronts-dump` and `cmd/meek-probe` import `github.com/getlantern/radiance/kindling/meek`, which is **not in the tree** — this makes `go mod tidy` unable to complete (it exits non-zero after writing its changes)
- `cmd/lantern/lantern.go:170` calls `ipc.NewClient()` with no arguments against a signature that now takes `(context.Context, backend.Options)` and returns two values

Neither is touched here and neither affects the library packages, but the first means `go mod tidy` cannot run cleanly in this repo until the missing package is restored or those commands are removed. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVgb2MDpZ4wpH6fywKC2hE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to a newer version for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->