### PR TITLE
go mod tidy: drop stale lantern-box v0.0.106 hashes

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,6 @@ github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvd
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464 h1:vZtMtKDsGO0ccBr+aQRRDKgcwFTg4psy13HtMttuBVQ=
 github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464/go.mod h1:ZEPFiB6rH6MtMN1O7b5gE+LJpCsRFzAn4u8lbIxHh3w=
-github.com/getlantern/lantern-box v0.0.106 h1:5czWMqdgrhCslLcE+ttt+us+d0dmCutpjxqmCOZnqKw=
-github.com/getlantern/lantern-box v0.0.106/go.mod h1:HHdmZsGwkiaweBycCYv1Jolk3jkrXbb/R5UUXtY2n3o=
 github.com/getlantern/lantern-box v0.0.107 h1:uTRoj5BKijO6Q2a9JZWunFL7Z29WDg8WzEuoliJ+kJg=
 github.com/getlantern/lantern-box v0.0.107/go.mod h1:HHdmZsGwkiaweBycCYv1Jolk3jkrXbb/R5UUXtY2n3o=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=


### PR DESCRIPTION
Follow-up to #586, which I got wrong.

## What happened

#586 bumped `go.mod` to `lantern-box v0.0.107` but left v0.0.106's hashes in `go.sum`, so main currently carries **both** with valid hashes:

```
github.com/getlantern/lantern-box v0.0.106 h1:5czWMqdgrhCslLcE+ttt+us+d0dmCutpjxqmCOZnqKw=
github.com/getlantern/lantern-box v0.0.106/go.mod h1:HHdmZsGwkiaweBycCYv1Jolk3jkrXbb/R5UUXtY2n3o=
github.com/getlantern/lantern-box v0.0.107 h1:uTRoj5BKijO6Q2a9JZWunFL7Z29WDg8WzEuoliJ+kJg=
github.com/getlantern/lantern-box v0.0.107/go.mod h1:HHdmZsGwkiaweBycCYv1Jolk3jkrXbb/R5UUXtY2n3o=
```

## Why it matters

This is the precise condition that lets a build resolve a superseded version even though `go.mod` declares the newer one — the stale entry still verifies, so nothing complains. On 2026-04-13 that shipped a release with `lantern-box v0.0.58` compiled in while `go.mod` said v0.0.65, silently disabling Reflex for every user. `gomobile bind` is the tool that has done this.

Given #586 exists specifically to carry a client-info fix out to clients, a build that quietly resolves v0.0.106 would deliver the release without the fix it was cut for.

## How it got through

My working tree had untracked files (`cmd/meek-probe`, `cmd/meek-fronts-dump`, and a missing `kindling/meek`) that made `go mod tidy` exit early — after writing its `go.mod` change but before pruning `go.sum`. I then "verified" against `git stash`, which does not stash untracked files, so the contamination survived the check and I read the failure as pre-existing.

Worth noting for anyone reading #586's description: my claim there that `go mod tidy` is broken on main was **wrong** — it succeeds on a clean checkout. The `cmd/lantern` breakage I mentioned is real and tracked (`cmd/lantern/lantern.go:170` calls `ipc.NewClient()` against a signature taking `(context.Context, backend.Options)` and returning two values), but it is unrelated to this.

## Verification

Run on a clean `git worktree` of `origin/main` with no untracked files:

- `go mod tidy` — exit 0, removes exactly the two stale lines
- `go mod verify` — all modules verified
- library packages build and **18/18 test packages pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVgb2MDpZ4wpH6fywKC2hE