### PR TITLE
fix(vpn): guard split-tunnel saves, outbound RMW, and tunnel close

### DIFF
--- a/vpn/split_tunnel.go
+++ b/vpn/split_tunnel.go
@@ -75,6 +75,8 @@ func newSplitTunnel(path string, logger *slog.Logger) *SplitTunnel {
 	return s
 }
 
+// SetEnabled enables or disables split tunneling, persisting the change to
+// disk. It is a no-op when already in the requested state.
 func (s *SplitTunnel) SetEnabled(enabled bool) error {
 	s.access.Lock()
 	defer s.access.Unlock()
@@ -163,6 +165,8 @@ func (s *SplitTunnel) RemoveItems(items SplitTunnelFilter) error {
 
 type actionFn func(slice []string, items []string) []string
 
+// updateFilterLocked applies fn to the filter of the given type. The caller
+// must hold s.access.
 func (s *SplitTunnel) updateFilterLocked(filterType string, item string, fn actionFn) error {
 	rule, exist := s.ruleMap[filterType]
 	if !exist {
@@ -191,6 +195,8 @@ func (s *SplitTunnel) updateFilterLocked(filterType string, item string, fn acti
 	return nil
 }
 
+// updateFiltersLocked applies fn to every filter category present in diff. The
+// caller must hold s.access.
 func (s *SplitTunnel) updateFiltersLocked(diff SplitTunnelFilter, fn actionFn) {
 	s.ruleMap[TypeDomain].Domain = fn(s.ruleMap[TypeDomain].Domain, diff.Domain)
 	s.ruleMap[TypeDomainSuffix].DomainSuffix = fn(s.ruleMap[TypeDomainSuffix].DomainSuffix, diff.DomainSuffix)
@@ -225,6 +231,10 @@ func remove(s []string, items []string) []string {
 	return s[:i]
 }
 
+// saveLocked serializes the current rule set to disk. The caller must hold
+// s.access: it reads activeFilter.Rules and rule.Mode, which the mutators
+// modify under the same lock, so an unsynchronized save can marshal a
+// half-updated rule set.
 func (s *SplitTunnel) saveLocked() error {
 	// Build a serialization-only copy of the rules, filtering out empty entries
 	// without mutating the live activeFilter/ruleMap state.

--- a/vpn/split_tunnel.go
+++ b/vpn/split_tunnel.go
@@ -66,12 +66,18 @@ func newSplitTunnel(path string, logger *slog.Logger) *SplitTunnel {
 	s.initRuleMap()
 	if _, err := os.Stat(s.ruleFile); errors.Is(err, fs.ErrNotExist) {
 		logger.Debug("Creating initial split tunnel rule file", "file", s.ruleFile)
-		s.saveToFile()
+		s.access.Lock()
+		if err := s.saveLocked(); err != nil {
+			logger.Error("Writing initial split tunnel rule file", "file", s.ruleFile, "error", err)
+		}
+		s.access.Unlock()
 	}
 	return s
 }
 
 func (s *SplitTunnel) SetEnabled(enabled bool) error {
+	s.access.Lock()
+	defer s.access.Unlock()
 	if s.enabled.Load() == enabled {
 		return nil
 	}
@@ -81,7 +87,7 @@ func (s *SplitTunnel) SetEnabled(enabled bool) error {
 	}
 	prev := s.rule.Mode
 	s.rule.Mode = mode
-	if err := s.saveToFile(); err != nil {
+	if err := s.saveLocked(); err != nil {
 		s.rule.Mode = prev
 		return fmt.Errorf("writing rule to %s: %w", s.ruleFile, err)
 	}
@@ -111,11 +117,13 @@ func (s *SplitTunnel) Filters() SplitTunnelFilter {
 
 // AddItem adds a new item to the filter of the given type.
 func (s *SplitTunnel) AddItem(filterType, item string) error {
-	if err := s.updateFilter(filterType, item, merge); err != nil {
+	s.access.Lock()
+	defer s.access.Unlock()
+	if err := s.updateFilterLocked(filterType, item, merge); err != nil {
 		return err
 	}
 	s.logger.Debug("added item to filter", "filterType", filterType, "item", item)
-	if err := s.saveToFile(); err != nil {
+	if err := s.saveLocked(); err != nil {
 		return fmt.Errorf("writing rule to %s: %w", s.ruleFile, err)
 	}
 	return nil
@@ -123,11 +131,13 @@ func (s *SplitTunnel) AddItem(filterType, item string) error {
 
 // RemoveItem removes an item from the filter of the given type.
 func (s *SplitTunnel) RemoveItem(filterType, item string) error {
-	if err := s.updateFilter(filterType, item, remove); err != nil {
+	s.access.Lock()
+	defer s.access.Unlock()
+	if err := s.updateFilterLocked(filterType, item, remove); err != nil {
 		return err
 	}
 	s.logger.Debug("removed item from filter", "filterType", filterType, "item", item)
-	if err := s.saveToFile(); err != nil {
+	if err := s.saveLocked(); err != nil {
 		return fmt.Errorf("writing rule to %s: %w", s.ruleFile, err)
 	}
 	return nil
@@ -135,23 +145,25 @@ func (s *SplitTunnel) RemoveItem(filterType, item string) error {
 
 // AddItems adds multiple items to the filter.
 func (s *SplitTunnel) AddItems(items SplitTunnelFilter) error {
-	s.updateFilters(items, merge)
+	s.access.Lock()
+	defer s.access.Unlock()
+	s.updateFiltersLocked(items, merge)
 	s.logger.Debug("added items to filter", "items", items.String())
-	return s.saveToFile()
+	return s.saveLocked()
 }
 
 // RemoveItems removes multiple items from the filter.
 func (s *SplitTunnel) RemoveItems(items SplitTunnelFilter) error {
-	s.updateFilters(items, remove)
+	s.access.Lock()
+	defer s.access.Unlock()
+	s.updateFiltersLocked(items, remove)
 	s.logger.Debug("removed items from filter", "items", items.String())
-	return s.saveToFile()
+	return s.saveLocked()
 }
 
 type actionFn func(slice []string, items []string) []string
 
-func (s *SplitTunnel) updateFilter(filterType string, item string, fn actionFn) error {
-	s.access.Lock()
-	defer s.access.Unlock()
+func (s *SplitTunnel) updateFilterLocked(filterType string, item string, fn actionFn) error {
 	rule, exist := s.ruleMap[filterType]
 	if !exist {
 		return fmt.Errorf("unsupported filter type: %s", filterType)
@@ -179,10 +191,7 @@ func (s *SplitTunnel) updateFilter(filterType string, item string, fn actionFn) 
 	return nil
 }
 
-func (s *SplitTunnel) updateFilters(diff SplitTunnelFilter, fn actionFn) {
-	s.access.Lock()
-	defer s.access.Unlock()
-
+func (s *SplitTunnel) updateFiltersLocked(diff SplitTunnelFilter, fn actionFn) {
 	s.ruleMap[TypeDomain].Domain = fn(s.ruleMap[TypeDomain].Domain, diff.Domain)
 	s.ruleMap[TypeDomainSuffix].DomainSuffix = fn(s.ruleMap[TypeDomainSuffix].DomainSuffix, diff.DomainSuffix)
 	s.ruleMap[TypeDomainKeyword].DomainKeyword = fn(s.ruleMap[TypeDomainKeyword].DomainKeyword, diff.DomainKeyword)
@@ -216,7 +225,7 @@ func remove(s []string, items []string) []string {
 	return s[:i]
 }
 
-func (s *SplitTunnel) saveToFile() error {
+func (s *SplitTunnel) saveLocked() error {
 	// Build a serialization-only copy of the rules, filtering out empty entries
 	// without mutating the live activeFilter/ruleMap state.
 	filterRules := make([]O.HeadlessRule, 0, len(s.activeFilter.Rules))

--- a/vpn/split_tunnel_test.go
+++ b/vpn/split_tunnel_test.go
@@ -123,7 +123,8 @@ func TestAddRemoveItems(t *testing.T) {
 	assert.Empty(t, f.ProcessName)
 }
 
-// Concurrent mutators share activeFilter.Rules and rule.Mode. Without holding
+// TestConcurrentMutationPersistsParseableRuleSet drives the mutators
+// concurrently: they share activeFilter.Rules and rule.Mode, so without holding
 // s.access across the mutate and the subsequent save, saveLocked reads those
 // fields while another goroutine modifies them — flagged by -race and capable
 // of serializing a torn rule set.
@@ -132,16 +133,29 @@ func TestConcurrentMutationPersistsParseableRuleSet(t *testing.T) {
 	st, err := NewSplitTunnelHandler(tmpDir, rlog.NoOpLogger())
 	require.NoError(t, err)
 
-	var wg sync.WaitGroup
+	var (
+		wg   sync.WaitGroup
+		mu   sync.Mutex
+		errs []error
+	)
+	record := func(err error) {
+		if err == nil {
+			return
+		}
+		mu.Lock()
+		errs = append(errs, err)
+		mu.Unlock()
+	}
 	for i := range 20 {
 		wg.Go(func() {
 			domain := fmt.Sprintf("d%d.example.com", i)
-			_ = st.AddItems(SplitTunnelFilter{Domain: []string{domain}, ProcessName: []string{fmt.Sprintf("p%d", i)}})
-			_ = st.SetEnabled(i%2 == 0)
-			_ = st.RemoveItems(SplitTunnelFilter{Domain: []string{domain}})
+			record(st.AddItems(SplitTunnelFilter{Domain: []string{domain}, ProcessName: []string{fmt.Sprintf("p%d", i)}}))
+			record(st.SetEnabled(i%2 == 0))
+			record(st.RemoveItems(SplitTunnelFilter{Domain: []string{domain}}))
 		})
 	}
 	wg.Wait()
+	assert.Empty(t, errs, "concurrent mutations must all succeed")
 
 	_, err = NewSplitTunnelHandler(tmpDir, rlog.NoOpLogger())
 	require.NoError(t, err, "rule set persisted under concurrent mutation must still parse")

--- a/vpn/split_tunnel_test.go
+++ b/vpn/split_tunnel_test.go
@@ -4,7 +4,9 @@ package vpn
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -119,6 +121,30 @@ func TestAddRemoveItems(t *testing.T) {
 	f = st.Filters()
 	assert.Equal(t, []string{"b.com"}, f.Domain)
 	assert.Empty(t, f.ProcessName)
+}
+
+// Concurrent mutators share activeFilter.Rules and rule.Mode. Without holding
+// s.access across the mutate and the subsequent save, saveLocked reads those
+// fields while another goroutine modifies them — flagged by -race and capable
+// of serializing a torn rule set.
+func TestConcurrentMutationPersistsParseableRuleSet(t *testing.T) {
+	tmpDir := t.TempDir()
+	st, err := NewSplitTunnelHandler(tmpDir, rlog.NoOpLogger())
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for i := range 20 {
+		wg.Go(func() {
+			domain := fmt.Sprintf("d%d.example.com", i)
+			_ = st.AddItems(SplitTunnelFilter{Domain: []string{domain}, ProcessName: []string{fmt.Sprintf("p%d", i)}})
+			_ = st.SetEnabled(i%2 == 0)
+			_ = st.RemoveItems(SplitTunnelFilter{Domain: []string{domain}})
+		})
+	}
+	wg.Wait()
+
+	_, err = NewSplitTunnelHandler(tmpDir, rlog.NoOpLogger())
+	require.NoError(t, err, "rule set persisted under concurrent mutation must still parse")
 }
 
 func TestFilterPersistence(t *testing.T) {

--- a/vpn/throughput_tracker_test.go
+++ b/vpn/throughput_tracker_test.go
@@ -223,8 +223,6 @@ func TestThroughputTracker_ConcurrentSampleAndClose(t *testing.T) {
 	assert.Equal(t, int64(producers*perProducer*5), down)
 }
 
-
-
 func TestThroughputTracker_NonPositiveIntervalUsesDefault(t *testing.T) {
 	ct := newConnTracker()
 	for _, interval := range []time.Duration{0, -time.Second} {

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -425,6 +425,8 @@ func (t *tunnel) addOutbounds(list servers.ServerList) error {
 	return t.addOutboundsLocked(list)
 }
 
+// addOutboundsLocked adds the servers in list to the tunnel. The caller must
+// hold t.outboundMu.
 func (t *tunnel) addOutboundsLocked(list servers.ServerList) (err error) {
 	outbounds := list.Outbounds()
 	endpoints := list.Endpoints()
@@ -558,6 +560,8 @@ func (t *tunnel) removeOutbounds(tags []string) error {
 	return t.removeOutboundsLocked(tags)
 }
 
+// removeOutboundsLocked removes the outbounds with the given tags from the
+// tunnel. The caller must hold t.outboundMu.
 func (t *tunnel) removeOutboundsLocked(tags []string) error {
 	var (
 		mutGrpMgr = t.mutGrpMgr

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	runtimeDebug "runtime/debug"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/sagernet/sing-box/adapter"
@@ -62,9 +63,20 @@ type tunnel struct {
 	// connection-close pushes for telemetry.
 	connObserver ConnObserver
 
+	// outboundMu serializes the outbound mutators. Each does a read-modify-write
+	// over clientContextTracker.MatchBounds(), which clones on read, so
+	// concurrent mutators would silently drop each other's tag updates.
+	outboundMu sync.Mutex
+
+	// closeTimeout bounds how long close() waits for closers to finish; a zero
+	// value uses defaultCloseTimeout.
+	closeTimeout time.Duration
+
 	cancel  context.CancelFunc
 	closers []io.Closer
 }
+
+const defaultCloseTimeout = 10 * time.Second
 
 func (t *tunnel) start(ctx context.Context, options string, platformIfce libbox.PlatformInterface, isRestart bool) error {
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "tunnel.start",
@@ -293,7 +305,6 @@ func (t *tunnel) connect(ctx context.Context) (err error) {
 		)
 		return err
 	}); err != nil {
-		t.close()
 		return fmt.Errorf("creating mutable group manager: %w", err)
 	}
 	t.mutGrpMgr = mutGrpMgr
@@ -377,30 +388,44 @@ func (t *tunnel) close() error {
 		t.cancel()
 	}
 
+	closers := t.closers
+	t.closers = nil
+	t.lbService = nil
+
 	done := make(chan error, 1)
 	go func() {
 		var errs []error
-		for _, closer := range t.closers {
+		for _, closer := range closers {
 			slog.Log(nil, rlog.LevelTrace, "Closing tunnel resource", "type", fmt.Sprintf("%T", closer))
 			errs = append(errs, closer.Close())
 		}
-		done <- errors.Join(errs...)
+		err := errors.Join(errs...)
+		done <- err
+		slog.Log(nil, rlog.LevelTrace, "Tunnel closers finished", "error", err)
 	}()
-	var err error
-	select {
-	case <-time.After(10 * time.Second):
-		err = errors.New("timeout waiting for tunnel to close")
-	case err = <-done:
-	}
 
-	t.closers = nil
-	t.lbService = nil
-	return err
+	timeout := t.closeTimeout
+	if timeout == 0 {
+		timeout = defaultCloseTimeout
+	}
+	select {
+	case <-time.After(timeout):
+		slog.Warn("Timed out waiting for tunnel to close; closers still running")
+		return errors.New("timeout waiting for tunnel to close")
+	case err := <-done:
+		return err
+	}
 }
 
 var errLibboxClosed = errors.New("libbox closed")
 
-func (t *tunnel) addOutbounds(list servers.ServerList) (err error) {
+func (t *tunnel) addOutbounds(list servers.ServerList) error {
+	t.outboundMu.Lock()
+	defer t.outboundMu.Unlock()
+	return t.addOutboundsLocked(list)
+}
+
+func (t *tunnel) addOutboundsLocked(list servers.ServerList) (err error) {
 	outbounds := list.Outbounds()
 	endpoints := list.Endpoints()
 	if len(outbounds) == 0 && len(endpoints) == 0 {
@@ -528,6 +553,12 @@ func (t *tunnel) addOutbounds(list servers.ServerList) (err error) {
 }
 
 func (t *tunnel) removeOutbounds(tags []string) error {
+	t.outboundMu.Lock()
+	defer t.outboundMu.Unlock()
+	return t.removeOutboundsLocked(tags)
+}
+
+func (t *tunnel) removeOutboundsLocked(tags []string) error {
 	var (
 		mutGrpMgr = t.mutGrpMgr
 		removed   []string
@@ -565,6 +596,9 @@ func (t *tunnel) removeOutbounds(tags []string) error {
 }
 
 func (t *tunnel) updateOutbounds(list servers.ServerList) error {
+	t.outboundMu.Lock()
+	defer t.outboundMu.Unlock()
+
 	var errs []error
 	outbounds := list.Outbounds()
 	endpoints := list.Endpoints()
@@ -608,7 +642,7 @@ func (t *tunnel) updateOutbounds(list servers.ServerList) error {
 	// Add new outbounds first, before removing old ones. If all new
 	// outbounds fail to load (e.g. invalid config), we keep the old
 	// working outbounds to maintain connectivity.
-	addErr := t.addOutbounds(list)
+	addErr := t.addOutboundsLocked(list)
 	if errors.Is(addErr, errLibboxClosed) {
 		return addErr
 	}
@@ -626,7 +660,7 @@ func (t *tunnel) updateOutbounds(list servers.ServerList) error {
 	}
 
 	if hasNewOutbound {
-		if err := t.removeOutbounds(toRemove); errors.Is(err, errLibboxClosed) {
+		if err := t.removeOutboundsLocked(toRemove); errors.Is(err, errLibboxClosed) {
 			return err
 		} else if err != nil {
 			errs = append(errs, err)

--- a/vpn/tunnel_test.go
+++ b/vpn/tunnel_test.go
@@ -3,6 +3,7 @@ package vpn
 import (
 	"context"
 	"testing"
+	"time"
 
 	lsync "github.com/getlantern/common/sync"
 	box "github.com/getlantern/lantern-box"
@@ -43,6 +44,34 @@ func TestTunnelClose(t *testing.T) {
 
 		err := tun.close()
 		assert.ErrorIs(t, err, assert.AnError)
+	})
+
+	// On the timeout branch close() returns while the closer goroutine is still
+	// running; a follow-up close() (as on a restart) must not race or panic on
+	// the abandoned goroutine's slice, and the slow closer must still finish.
+	t.Run("timeout abandons slow closer without corrupting a restart", func(t *testing.T) {
+		release := make(chan struct{})
+		finished := make(chan struct{})
+		tun := &tunnel{closeTimeout: 50 * time.Millisecond}
+		tun.closers = append(tun.closers, closerFunc(func() error {
+			<-release
+			close(finished)
+			return nil
+		}))
+
+		err := tun.close()
+		require.Error(t, err, "close must report the timeout")
+		assert.Nil(t, tun.closers, "shared closers must be cleared before returning")
+		assert.Nil(t, tun.lbService)
+
+		assert.NoError(t, tun.close(), "a second close must find no closers")
+
+		close(release)
+		select {
+		case <-finished:
+		case <-time.After(time.Second):
+			t.Fatal("abandoned closer never finished")
+		}
 	})
 }
 


### PR DESCRIPTION
This pull request introduces important concurrency safety improvements to the VPN split tunnel and tunnel management code. It ensures that rule and outbound modifications are properly synchronized, preventing race conditions and potential data corruption during concurrent access. Additionally, it enhances the robustness of resource cleanup during tunnel closure, especially in timeout scenarios. The changes are covered by new and updated tests to verify thread safety and correct behavior under concurrent operations.

**Split Tunnel concurrency and thread safety:**

* All mutating methods in `SplitTunnel` (such as `SetEnabled`, `AddItem`, `RemoveItem`, `AddItems`, `RemoveItems`) now acquire a mutex (`s.access`) to serialize access, preventing races between rule/filter updates and file saves. The internal update and save methods have been renamed to reflect their locked usage (e.g., `saveLocked`, `updateFilterLocked`). 
* A new test `TestConcurrentMutationPersistsParseableRuleSet` was added to ensure that concurrent mutations do not corrupt the persisted rule set and that it remains parseable.

**Tunnel outbound and close synchronization:**

* Introduced a new mutex (`outboundMu`) in the `tunnel` struct to serialize all outbound modifications (`addOutbounds`, `removeOutbounds`, `updateOutbounds`), preventing silent loss of updates when multiple goroutines modify outbounds concurrently. 
* The `close` method now clears the `closers` and `lbService` fields before waiting for resource cleanup, and uses a configurable timeout (`closeTimeout`) with a default value. This prevents races and panics if `close` is called multiple times, especially after a timeout.

**Testing improvements:**

* Added a test to verify that a second call to `close` after a timeout does not panic or race, and that resources are properly cleaned up even if the first close times out.

These changes significantly improve the reliability and correctness of split tunnel rule management and tunnel lifecycle handling in concurrent environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved split-tunnel reliability during simultaneous rule changes and persistence.
  * Prevented inconsistent VPN routing state during concurrent updates.
  * Enhanced tunnel shutdown to clear state reliably and report timeout or closing errors.
  * Allowed shutdown to be retried safely after a timeout.

* **Tests**
  * Added coverage for concurrent split-tunnel mutations and timeout-based tunnel shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->