### PR TITLE
peer: route the peer box's sing-box logger into radiance's slog (replaces #481)

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1057,8 +1057,10 @@ func newPeerBoxContext(ctx context.Context) context.Context {
 }
 
 // peerBoxContext resolves Deadline/Done/Err from the embedded caller
-// context so a Stop-induced cancel propagates into box internals, and
-// every other value from base.
+// context so a Stop-induced cancel propagates into box internals. Values
+// come from the caller first and from base only as a fallback, so anything
+// the caller carries shadows base — which matters because base holds the one
+// captured registry instance libbox both registers into and reads back.
 type peerBoxContext struct {
 	context.Context
 	base context.Context

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -13,8 +13,11 @@ import (
 	"time"
 
 	"github.com/sagernet/sing-box/experimental/libbox"
+	sblog "github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing/service"
 
 	box "github.com/getlantern/lantern-box"
+	lblog "github.com/getlantern/lantern-box/log"
 	"github.com/getlantern/lantern-box/tracker/peerconn"
 	"github.com/getlantern/radiance/common/env"
 	"github.com/getlantern/radiance/common/settings"
@@ -1009,43 +1012,51 @@ func pickInternalPort() uint16 {
 // inbound is just an HTTPS server bound to a TCP port; sing-box's default
 // network stack handles it.
 //
-// box.BaseContext registers the lantern-box protocol fields registries
-// (samizdat, reflex, etc.) into the ctx so libbox can decode the
-// inbounds[0].type="samizdat" stanza coming back from /peer/register.
-// Without it the user's ctx is missing InboundOptionsRegistry and
-// libbox returns "missing inbound fields registry in context" — the
-// failure mode is silent in CI because the integration tests stub
-// BuildBoxService entirely; only TestDefaultBuildBoxService_DecodesSamizdatInbound
-// exercises the real decode path.
-//
-// We wrap so libbox sees the caller's Deadline/Done (so a Stop-induced
-// ctx cancel propagates to box internals) AND can still resolve the
-// registry values from box.BaseContext via Value lookups.
-//
-// Lives in the same process as the user's main VPN tunnel, which has
-// already invoked libbox.Setup at process start. The registries set
-// here are scoped to this peer's box instance via context values, so
-// the two coexist without stomping on each other.
+// The registries newPeerBoxContext supplies are what let libbox decode the
+// inbounds[0].type="samizdat" stanza from /peer/register; without them it
+// fails with "missing inbound fields registry in context". They are scoped
+// to this box instance, so the peer and the main tunnel coexist without
+// stomping on each other.
 func defaultBuildBoxService(ctx context.Context, options string) (boxService, error) {
-	bs, err := libbox.NewServiceWithContext(boxRegistryCtx{ctx}, options, nil)
+	bs, err := libbox.NewServiceWithContext(newPeerBoxContext(ctx), options, nil)
 	if err != nil {
 		return nil, fmt.Errorf("libbox.NewServiceWithContext: %w", err)
 	}
 	return bs, nil
 }
 
-// boxRegistryCtx is a context wrapper that delegates Value() lookups to
-// box.BaseContext() (where lantern-box's protocol registries live) while
-// keeping the caller's Deadline/Done/Err for cancellation. Without this,
-// passing box.BaseContext() directly to libbox would discard the
-// caller's runCtx, leaving libbox internals running past Stop.
-type boxRegistryCtx struct {
-	context.Context
+// newPeerBoxContext assembles the context for one peer box: cancellation
+// from ctx, lantern-box's protocol registries and this box's log factory
+// from a single captured base context.
+//
+// The base must be captured exactly once. box.BaseContext() builds a new
+// service registry on every call, and service.MustRegister mutates
+// whichever registry the context hands back, so registering through a
+// wrapper that rebuilds the base per lookup writes into a registry that
+// is discarded before libbox ever reads it — the registration silently
+// does nothing.
+func newPeerBoxContext(ctx context.Context) context.Context {
+	base := box.BaseContext()
+	// The peer runs a second box beside the main tunnel's. Absent its own
+	// factory it keeps sing-box's stderr-only default, so this box's
+	// router and dial errors never reach lantern.log — the signal that
+	// explains why a peer-share verify failed. Mirrors the main tunnel's
+	// registration.
+	service.MustRegister[sblog.Factory](base, lblog.NewFactory(slog.Default().Handler()))
+	return peerBoxContext{Context: ctx, base: base}
 }
 
-func (c boxRegistryCtx) Value(key any) any {
+// peerBoxContext resolves Deadline/Done/Err from the embedded caller
+// context so a Stop-induced cancel propagates into box internals, and
+// every other value from base.
+type peerBoxContext struct {
+	context.Context
+	base context.Context
+}
+
+func (c peerBoxContext) Value(key any) any {
 	if v := c.Context.Value(key); v != nil {
 		return v
 	}
-	return box.BaseContext().Value(key)
+	return c.base.Value(key)
 }

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -12,6 +12,9 @@ import (
 	"testing"
 	"time"
 
+	sblog "github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing/service"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -1063,4 +1066,64 @@ func TestAPI_ForwardsCommonHeaders(t *testing.T) {
 		assert.NotEmpty(t, c.platform, "%s must carry %s", path, common.PlatformHeader)
 		assert.NotEmpty(t, c.appName, "%s must carry %s", path, common.AppNameHeader)
 	}
+}
+
+// The peer box's log factory has to survive the trip into libbox, and the
+// bug that made it not survive was invisible: box.BaseContext() mints a
+// fresh service registry per call, so a wrapper that rebuilt the base on
+// every Value lookup handed out a different registry each time. Reads kept
+// working (each fresh base carries the same protocol registrations), which
+// is why only a registration could expose it. These four tests pin the
+// properties that make the registration land.
+
+// A registration made against the context libbox receives must be
+// retrievable from that same context.
+func TestPeerBoxContext_LogFactoryIsRetrievable(t *testing.T) {
+	boxCtx := newPeerBoxContext(context.Background())
+
+	got := service.FromContext[sblog.Factory](boxCtx)
+	require.NotNil(t, got, "the registered sing-box log factory must be readable "+
+		"from the context handed to libbox, or this box logs only to stderr")
+}
+
+// Repeated registry lookups must return the same object. This is the
+// invariant the old wrapper broke: two lookups, two registries, so a write
+// through one was never seen through the other.
+func TestPeerBoxContext_RegistryIsStableAcrossLookups(t *testing.T) {
+	boxCtx := newPeerBoxContext(context.Background())
+
+	first := service.RegistryFromContext(boxCtx)
+	second := service.RegistryFromContext(boxCtx)
+	require.NotNil(t, first)
+	assert.True(t, first == second,
+		"every lookup must resolve to one registry; a per-lookup rebuild makes "+
+			"service.MustRegister write into an object that is immediately discarded")
+}
+
+// Cancellation still comes from the caller, so a Stop-induced cancel reaches
+// box internals rather than being swallowed by the base context.
+func TestPeerBoxContext_InheritsCallerCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	boxCtx := newPeerBoxContext(ctx)
+	require.NoError(t, boxCtx.Err())
+
+	cancel()
+
+	select {
+	case <-boxCtx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("peer box context did not observe the caller's cancel")
+	}
+	assert.ErrorIs(t, boxCtx.Err(), context.Canceled)
+}
+
+// The lantern-box protocol registries must still resolve through the
+// wrapper. This is the registry libbox reports as "missing inbound fields
+// registry in context" when it is absent, which is what would break
+// decoding the samizdat inbound from /peer/register.
+func TestPeerBoxContext_StillResolvesInboundRegistry(t *testing.T) {
+	boxCtx := newPeerBoxContext(context.Background())
+
+	assert.NotNil(t, service.FromContext[option.InboundOptionsRegistry](boxCtx),
+		"registering the log factory must not displace the protocol registries")
 }


### PR DESCRIPTION
Delivers the functionality #481 was after — the peer box's sing-box logs going to `lantern.log` instead of stderr — and fixes the reason a direct port of that PR would not have worked.

Closes #481 (that branch was based on the orphaned pre-`-A` `fisk/peer-connection-events`, 97 commits behind, with a failing `build` check).

## Why #481 could not just be rebased

Its diff was a plausible six lines:

```go
ctx := box.BaseContext()
service.MustRegister[sblog.Factory](ctx, lblog.NewFactory(slog.Default().Handler()))
bs, err := libbox.NewServiceWithContext(ctx, options, nil)
```

Ported onto current `main` that compiles, passes CI, and **does nothing**.

`box.BaseContext()` builds a *fresh* `service.Registry` on every call (`libbox.BaseContext` → `box.Context` → `service.ContextWith`, which lazily creates one). The old `boxRegistryCtx.Value` called `box.BaseContext()` on **every** cache miss:

```go
func (c boxRegistryCtx) Value(key any) any {
	if v := c.Context.Value(key); v != nil {
		return v
	}
	return box.BaseContext().Value(key)   // ← new registry, every lookup
}
```

`service.MustRegister` mutates whichever registry the context hands back. So the write landed in an object discarded before libbox ever looked. Reads were unaffected, because each fresh base carries the same protocol registrations — which is exactly why nothing caught this: only a *registration* can expose it, and until now nothing registered.

## The fix

Capture the base once per box, register against it, resolve values from that single instance, and keep taking cancellation from the caller:

```go
func newPeerBoxContext(ctx context.Context) context.Context {
	base := box.BaseContext()
	service.MustRegister[sblog.Factory](base, lblog.NewFactory(slog.Default().Handler()))
	return peerBoxContext{Context: ctx, base: base}
}
```

This is the shape `vpn/tunnel.go` already uses for the main tunnel — capture `box.BaseContext()` into `baseCtx` once (`vpn/tunnel.go:81`), register into a context derived from it (`:149-150`). The peer path was the outlier.

Per-box (rather than process-global) registration is deliberate: the peer's box and the main tunnel's stay independent, and `Registry.Register` overwrites rather than panics, so the credential-rotation path rebuilding its box is safe.

## Tests

Four tests, and I verified which ones are load-bearing by reverting `Value()` to the old rebuild-per-lookup while keeping the registration:

| Test | old behaviour | with fix |
|---|---|---|
| `LogFactoryIsRetrievable` | **FAIL** (nil) | PASS |
| `RegistryIsStableAcrossLookups` | **FAIL** | PASS |
| `InheritsCallerCancellation` | PASS | PASS |
| `StillResolvesInboundRegistry` | PASS | PASS |

The bottom two pass either way by design — cancellation and protocol-registry resolution were never broken, and they guard against the fix regressing them. The top two would have caught the silent no-op.

`TestDefaultBuildBoxService_DecodesSamizdatInbound` (the existing real-libbox decode test) still passes, confirming the registration doesn't displace the protocol registries.

## Verification

- `go build -tags "with_clash_api standalone" ./...` — clean
- `go test -tags "with_clash_api standalone" ./...` — all 20 packages pass
- `gofmt` clean

## Note on the comment

#481's original comment cited a Freshdesk ticket. This repo's `CLAUDE.md` says tickets belong in git history rather than comments, so the rationale is kept and the reference dropped.

## Stacking

Targets `smc/peer-core` (#589) since the change is confined to `peer/`. It does not touch anything in #590, so #589 → #590 and #589 → this can merge in either order once #589 lands.
