### PR TITLE
fronted: don't retry origin 403/5xx across fronts

### DIFF
--- a/common/headers.go
+++ b/common/headers.go
@@ -44,6 +44,12 @@ const (
 	ClientIPHeader          = "X-Lantern-Config-Client-IP"
 	ContentTypeHeader       = "content-type"
 	AcceptHeader            = "accept"
+
+	// OriginHeader is set by Lantern origins on every response (see
+	// lantern-cloud's router.OriginMarker). Unlike the headers above it is a
+	// response header: fronted requests use its presence to tell an origin-issued
+	// status from a CDN edge's, since a CDN relays the origin's response verbatim.
+	OriginHeader = "X-Lantern-Origin"
 )
 
 // NewRequestWithHeaders creates a new [http.Request] with the required headers.

--- a/common/headers.go
+++ b/common/headers.go
@@ -28,7 +28,8 @@ func SetPublicIP(ip string) {
 }
 
 const (
-	// Required common headers to send to the proxy server.
+	// Common Lantern headers. All are request headers sent to the proxy server
+	// except OriginHeader, which the server sets on responses.
 	AppVersionHeader        = "X-Lantern-App-Version"
 	VersionHeader           = "X-Lantern-Version"
 	PlatformHeader          = "X-Lantern-Platform"
@@ -45,10 +46,9 @@ const (
 	ContentTypeHeader       = "content-type"
 	AcceptHeader            = "accept"
 
-	// OriginHeader is set by Lantern origins on every response (see
-	// lantern-cloud's router.OriginMarker). Unlike the headers above it is a
-	// response header: fronted requests use its presence to tell an origin-issued
-	// status from a CDN edge's, since a CDN relays the origin's response verbatim.
+	// OriginHeader is set by Lantern origins on every response. Fronted requests
+	// read it to tell an origin-issued status from a CDN edge's, which is
+	// otherwise impossible: a CDN relays the origin's response verbatim.
 	OriginHeader = "X-Lantern-Origin"
 )
 

--- a/kindling/fronted/fronted.go
+++ b/kindling/fronted/fronted.go
@@ -8,12 +8,14 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"net/http"
 	"path/filepath"
 
 	"go.opentelemetry.io/otel"
 
 	"github.com/getlantern/domainfront"
 	"github.com/getlantern/radiance/bypass"
+	"github.com/getlantern/radiance/common"
 	"github.com/getlantern/radiance/kindling/smart"
 )
 
@@ -43,6 +45,19 @@ type bypassDialer struct{}
 
 func (bypassDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	return bypass.DialContext(ctx, network, addr)
+}
+
+// retryableResponse treats 403/5xx as a front failure only when
+// common.OriginHeader is absent. Our API returns 403 for ordinary auth outcomes
+// (unknown email, expired SRP state), and retrying those discards healthy fronts
+// and buries the real error. The signal has to be a positive one from the origin:
+// CloudFront sets "x-cache: Error from cloudfront" even when proxying an origin
+// 4xx. Unmarked third-party origins keep domainfront's default behavior.
+func retryableResponse(resp *http.Response) bool {
+	if resp.StatusCode != http.StatusForbidden && resp.StatusCode < 500 {
+		return false
+	}
+	return resp.Header.Get(common.OriginHeader) == ""
 }
 
 // NewFronted builds a domainfront.Client for use with kindling's
@@ -80,6 +95,7 @@ func NewFronted(ctx context.Context, cacheFile string, logWriter io.Writer) (*do
 		domainfront.WithLogger(slog.Default()),
 		domainfront.WithConfigURL(configURL, mirrorConfigURL),
 		domainfront.WithHTTPClient(smartClient),
+		domainfront.WithRetryableResponse(retryableResponse),
 	}
 	return domainfront.New(ctx, seed, opts...)
 }

--- a/kindling/fronted/fronted.go
+++ b/kindling/fronted/fronted.go
@@ -54,9 +54,12 @@ func (bypassDialer) DialContext(ctx context.Context, network, addr string) (net.
 // CloudFront sets "x-cache: Error from cloudfront" even when proxying an origin
 // 4xx. Unmarked third-party origins keep domainfront's default behavior.
 func retryableResponse(resp *http.Response) bool {
-	if resp.StatusCode != http.StatusForbidden && resp.StatusCode < 500 {
+	is5xx := resp.StatusCode >= 500 && resp.StatusCode < 600
+	if resp.StatusCode != http.StatusForbidden && !is5xx {
 		return false
 	}
+	// Get, not a direct map read: it canonicalizes the key, and an empty value is
+	// not a usable marker, so it falls back to the default retry behavior.
 	return resp.Header.Get(common.OriginHeader) == ""
 }
 

--- a/kindling/fronted/fronted_test.go
+++ b/kindling/fronted/fronted_test.go
@@ -2,11 +2,14 @@ package fronted
 
 import (
 	"bytes"
+	"net/http"
 	"testing"
 
 	"github.com/getlantern/domainfront"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/getlantern/radiance/common"
 )
 
 // TestEmbeddedConfigValid guards the offline-boot guarantee: NewFronted seeds
@@ -18,4 +21,59 @@ func TestEmbeddedConfigValid(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 	assert.NotEmpty(t, cfg.Providers, "embedded fronted config must contain providers")
+}
+
+// TestRetryableResponse pins the origin-vs-edge distinction: an origin-issued
+// rejection is a real answer and must reach the caller; the same status from an
+// edge means "wrong front, try another".
+func TestRetryableResponse(t *testing.T) {
+	// Header sets observed on the wire. Only common.OriginHeader may sway the
+	// verdict — CloudFront stamps x-cache/via onto proxied origin 4xx too.
+	origin := http.Header{
+		common.OriginHeader: []string{"1"},
+		"Content-Type":      []string{"application/x-protobuf"},
+	}
+	originViaCloudFront := http.Header{
+		common.OriginHeader: []string{"1"},
+		"Content-Type":      []string{"application/x-protobuf"},
+		"X-Cache":           []string{"Error from cloudfront"},
+		"Via":               []string{"1.1 google, 1.1 abc.cloudfront.net (CloudFront)"},
+	}
+	cloudFrontEdge := http.Header{
+		"Content-Type": []string{"text/html"},
+		"Server":       []string{"CloudFront"},
+		"X-Cache":      []string{"Error from cloudfront"},
+	}
+	akamaiEdge := http.Header{
+		"Content-Type": []string{"text/html"},
+		"Server":       []string{"AkamaiGHost"},
+	}
+
+	for _, tc := range []struct {
+		name   string
+		status int
+		header http.Header
+		want   bool
+	}{
+		{"origin 403 is a real answer", 403, origin, false},
+		{"origin 403 relayed by cloudfront", 403, originViaCloudFront, false},
+		{"origin 500 is the origin's own failure", 500, origin, false},
+		{"origin 503", 503, origin, false},
+		{"cloudfront edge 403", 403, cloudFrontEdge, true},
+		{"akamai edge 403", 403, akamaiEdge, true},
+		{"edge 502 with no marker", 502, http.Header{}, true},
+		// Third-party fronted origins can't set the marker, so they keep the
+		// default behavior rather than gaining a pass-through.
+		{"third-party origin 403", 403, http.Header{"Server": []string{"GitHub.com"}}, true},
+		// Non-rejection statuses are never a front failure, marker or not.
+		{"origin 200", 200, origin, false},
+		{"edge 200", 200, cloudFrontEdge, false},
+		{"404 is a real answer even unmarked", 404, http.Header{}, false},
+		{"301 is not a front failure", 301, http.Header{}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := retryableResponse(&http.Response{StatusCode: tc.status, Header: tc.header})
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }

--- a/kindling/fronted/fronted_test.go
+++ b/kindling/fronted/fronted_test.go
@@ -70,6 +70,11 @@ func TestRetryableResponse(t *testing.T) {
 		{"edge 200", 200, cloudFrontEdge, false},
 		{"404 is a real answer even unmarked", 404, http.Header{}, false},
 		{"301 is not a front failure", 301, http.Header{}, false},
+		// Outside 5xx, so not a rejection status even though it exceeds 500.
+		{"malformed 600 is not a front failure", 600, http.Header{}, false},
+		// An empty marker is unusable, so it falls back to the default behavior
+		// rather than being honored as proof of origin.
+		{"empty marker is not proof of origin", 403, http.Header{common.OriginHeader: []string{""}}, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got := retryableResponse(&http.Response{StatusCode: tc.status, Header: tc.header})


### PR DESCRIPTION
## Problem

`domainfront`'s default predicate treats **any** 403/5xx as a front failure:

```go
// domainfront/roundtrip.go:42
func defaultRetryableResponse(resp *http.Response) bool {
	return resp.StatusCode == http.StatusForbidden || resp.StatusCode >= 500
}
```

But our API returns 403 for ordinary auth outcomes — an unknown email on `/users/prepare`, an expired SRP state on `/users/login` — and 5xx for its own failures. When that happens the client:

1. marks a **healthy** front failed and drops it from rotation (`pool.Return(f, false)`),
2. marks the whole provider tried,
3. repeats for `maxRetries` fronts across providers,
4. reports `domain fronting failed after N attempts` — burying the actionable error.

Both the wasted fronts (scarce exactly where it matters, e.g. CN) and the lost error are real costs. In Freshdesk 181129 a user typing an email with no account produced four such 403 rounds, and the surfaced error looked like a network problem rather than "no such account".

```mermaid
sequenceDiagram
    autonumber
    participant C as radiance<br/>kindling/fronted/fronted.go
    participant E as CDN edge<br/>CloudFront
    participant O as api origin<br/>cmd/api/users/prepare.go

    C->>E: POST /users/prepare over a front<br/>Host rewritten to the provider alias
    E->>O: forward to origin
    Note over O: prepare.go:43 GetUserByEmail finds nothing<br/>prepare.go:45 returns 403 Forbidden ⚠️
    O-->>E: 403 + X-Lantern-Origin: 1
    Note over E: relays the origin response verbatim<br/>but also stamps x-cache: Error from cloudfront
    E-->>C: 403, origin marker intact

    rect rgba(255, 200, 200, 0.3)
        Note over C: BEFORE — domainfront roundtrip.go:42 🐛<br/>403 assumed to mean bad front<br/>pool.Return f,false drops a healthy front<br/>retries across N fronts, then fails with<br/>domain fronting failed after N attempts
    end

    Note over C: AFTER — retryableResponse checks the marker<br/>marker present → not a front failure<br/>403 reaches Login as a real answer ✅
```

## Why the marker, and not a CDN fingerprint

A CDN relays the origin's response verbatim, so vendor headers cannot separate the two cases. Measured on the wire, **CloudFront sets `x-cache: Error from cloudfront` even when faithfully proxying an origin 4xx** — so fingerprinting the CDN would misclassify precisely the responses we care about. The signal has to be a positive one from the origin, which getlantern/lantern-cloud#3123 now provides.

## Change

`retryableResponse` treats **403 or 500-599** as a front failure only when `common.OriginHeader` is absent, wired in via `domainfront.WithRetryableResponse`. No dependency bump — the pinned `domainfront` already exports the hook.

Two deliberate details:

- **The 5xx range is bounded.** A malformed 6xx status is not a rejection status, matching what the doc comment claims.
- **Marker presence is read via `Header.Get`, not a direct map read.** `Get` applies `CanonicalHeaderKey` (a direct read does not, which breaks silently if the constant is ever written non-canonically), and an empty value is not usable proof of origin — treating it as absent falls back to the default retry behavior, so a malformed or injected bare header can't suppress retries onto a healthy front.

This is a **strict narrowing**: it can only turn a retry into a pass-through, and only when the origin marker is present. Absent the marker — old server, third-party fronted origin like `github.com`, or a genuine edge rejection — behavior is bit-identical to the default.

## Testing

`TestRetryableResponse` covers 14 cases: an origin 403 relayed through CloudFront *with* the misleading `x-cache`/`via` headers present, both CDN edge rejections, third-party origins, non-rejection statuses, a malformed 600, and an empty marker value.

`gofmt`, `go vet`, and the full `./kindling/...` suite are clean.

## Rollout

Deploy getlantern/lantern-cloud#3123 first; until then this is inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVgb2MDpZ4wpH6fywKC2hE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of forbidden and server-error responses when connecting through domain-fronted services.
  * Preserved normal API authentication errors instead of retrying them unnecessarily.
  * Added origin response identification to support more accurate retry behavior.

* **Tests**
  * Added coverage for origin, CDN, edge, third-party, and non-error responses to verify retry handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
