### PR TITLE
go.mod: bump lantern-box to v0.0.111 for the broflake teardown fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/getlantern/domainfront v0.0.0-20260722204513-8c1f8acfa715
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3
 	github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464
-	github.com/getlantern/lantern-box v0.0.107
+	github.com/getlantern/lantern-box v0.0.111
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb
@@ -115,7 +115,7 @@ require (
 	github.com/gaissmai/bart v0.11.1 // indirect
 	github.com/gaukas/wazerofs v0.1.0 // indirect
 	github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52 // indirect
-	github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86 // indirect
+	github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952 // indirect
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 // indirect
 	github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 // indirect
 	github.com/go-chi/chi/v5 v5.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,8 @@ github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52 h1:w2/RqYPw7Pb
 github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52/go.mod h1:PrNR8tMXO26YNs8K9653XCUH7u2Kv4OdfFC3Ke1GsX0=
 github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c h1:ZzxuhIWO295y4eE6wPYUq8Smntlgg+y39L5OOyMJY+k=
 github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c/go.mod h1:b5teAOFT+vpBqc2CHoz74QTEM15iOv1PLdQogwXcfrM=
-github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86 h1:r7j54Ol1wak59OY0SK2Fw5lOI3YvrAEDW3QAQEj12mA=
-github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86/go.mod h1:bIxM6xon/ADgprn6tZXYdXGrUIMCzq6u8zO9rET50IE=
+github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952 h1:nD8iJ4IpaTq/09PhoOzmaGTwatOxsR41neSmbCY6RS8=
+github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952/go.mod h1:1+1kCIg9Zj+2CgN+vl868AlAZVUItuN4wLhFur5QakA=
 github.com/getlantern/common v1.2.1-0.20260708083946-cc657b08792c h1:Hpxu12ORnAcyYuIqV2yAqrmDAnTaY1Cd3yL7TvFB6ME=
 github.com/getlantern/common v1.2.1-0.20260708083946-cc657b08792c/go.mod h1:eSSuV4bMPgQJnczBw+KWWqWNo1itzmVxC++qUBPRTt0=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
@@ -246,8 +246,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvd
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464 h1:vZtMtKDsGO0ccBr+aQRRDKgcwFTg4psy13HtMttuBVQ=
 github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464/go.mod h1:ZEPFiB6rH6MtMN1O7b5gE+LJpCsRFzAn4u8lbIxHh3w=
-github.com/getlantern/lantern-box v0.0.107 h1:uTRoj5BKijO6Q2a9JZWunFL7Z29WDg8WzEuoliJ+kJg=
-github.com/getlantern/lantern-box v0.0.107/go.mod h1:HHdmZsGwkiaweBycCYv1Jolk3jkrXbb/R5UUXtY2n3o=
+github.com/getlantern/lantern-box v0.0.111 h1:1DNrhaxpn9mRE7qMX/efi1I4wYx4FoBh7stVFIEPcYU=
+github.com/getlantern/lantern-box v0.0.111/go.mod h1:avZOnXNHLNT/d/Mrkjqn8i02HB1C805Dk7EtcWYq9lw=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395/go.mod h1:3JpJgwi4KEI6rS9loOAvcBp+F2jP65d0tTg2GQcTPBU=
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 h1:3BwvWj0JZzFEvNNiMhCu4bf60nqcIuQpTYb00Ezm1ag=


### PR DESCRIPTION
## Why

Delivers the unbounded teardown-leak fix to clients. Radiance is the link in the chain that gets it from the SDK into a release.

Chain: getlantern/unbounded#412 (merged) → getlantern/lantern-box#297 (merged, tagged `v0.0.111`) → **this** → `lantern` → 9.1.20-beta.

## What was leaking

A broflake `WorkerFSM` parked in a control-plane send on `com.tx` could not be cancelled: the send had no ctx guard, and the FSM only checks `ctx.Done()` *between* states. So its `wg.Done()` never ran, and `BroflakeEngine.stop()` — which waited on that `WaitGroup` before cancelling the engine ctx — never released the bus, both routers, or any other worker. Every re-create of the unbounded outbound accumulated a full WebRTC/ICE stack.

Signature in Freshdesk 181174 (Windows 9.1.18, CN): the outbound re-created **82 times in 13h at a flat ~6/hr**, CPU climbing to 80% with disk at 0 MB/s and network at 0 Mbps — a per-event leak, not a spin. Reproduced in broflake's tests at 30 goroutines leaked over 10 create/stop cycles, 0 after the fix.

`v0.0.111` brings:
- cancellable control-plane sends (`sendCtx` across all 11 sites), checking `ctx.Err()` first so a cancelled ctx wins deterministically over an available buffer
- `NewWorkerFSM` initializing ctx/cancel — `Stop()` before `Start()` previously **panicked** on a nil `CancelFunc`
- a bounded engine-stop wait, so any future unguarded blocking send degrades to a bounded leak
- `unbounded.Outbound.Close()` stopping the workers before closing the QUIC layer they drain into

## Diff

`lantern-box v0.0.107 → v0.0.111`, which transitively upgrades the indirect `broflake f2cacf69fe86 → bef5e5234952`. Two lines in `go.mod`, four in `go.sum`; `go mod tidy` run, both committed together.

Verified the resolved module actually carries the fix (`go list -m` + `sendCtx` present in the resolved `broflake`), not just that the version string changed.

`v0.0.107 → v0.0.111` also carries three unrelated lantern-box changes: goodput metric buckets (#296) and peerconn accept-event / listener-registry work (#255, #256).

## Testing

`go build -tags "with_clash_api standalone" ./...` and `go test -tags "with_clash_api standalone" ./...` — 18 packages, 0 failures.

Note on the `standalone` tag: `cmd/lantern` calls the 0-arg `ipc.NewClient`, which only exists in `client_nonmobile.go` (`//go:build (!android && !ios && !darwin) || (darwin && standalone)`). On macOS without `standalone`, the toolchain selects the 2-arg mobile variant and `cmd/lantern` does not compile. CI builds on linux and so selects nonmobile — this is a local-only wrinkle, not a change in behavior, but worth knowing if you build on a Mac.

## Prod mitigation already in place

Track `unbounded-linode-free` (id 1570) had its client-version floor raised from `>=9.1.16` to `>=9.1.20-beta`, so no currently-released client receives unbounded. Verified live against `/v1/config-new`: 9.1.19 → 0/5 probes, 9.1.20-beta → 4/5, 9.1.20 → 4/5 (the misses are bandit selection, not eligibility). Once 9.1.20-beta ships with this bump, it will receive the fixed code.

## Pre-PR review (local Codex gate)
- Rounds: 1 — final: `CODEX GATE: verdict=approve critical=0 important=0 minor=0`
- Exit: `approve`
- Fixed: none (no findings raised)
- Dismissed: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVgb2MDpZ4wpH6fywKC2hE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to newer versions.
  * No visible changes to application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->