### PR TITLE
fix: guard against concurrent VPN connect requests

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -66,6 +66,10 @@ type LocalBackend struct {
 	shutdownFuncs []func() error
 	closeOnce     sync.Once
 
+	// Rejects overlapping ConnectVPN calls (TryLock) so a burst can't each
+	// drive a full tunnel bring-up.
+	connectMu sync.Mutex
+
 	deviceID string
 
 	telemetryCfgSub *events.Subscription[config.NewConfigEvent]
@@ -1039,7 +1043,21 @@ func (r *LocalBackend) VPNStatus() vpn.VPNStatus {
 	return r.vpnClient.Status()
 }
 
-func (r *LocalBackend) ConnectVPN(tag string) error {
+// ErrConnectInProgress signals that a connect attempt is already running. It is
+// benign, not a failure: bursts of connect requests (e.g. rapid taps while every
+// attempt is blocked in a censored network) must not each drive a full tunnel
+// bring-up.
+var ErrConnectInProgress = errors.New("connect already in progress")
+
+func (r *LocalBackend) ConnectVPN(ctx context.Context, tag string) error {
+	// Shed overlapping connects before getBoxOptions: it assembles the full
+	// outbound set, and without this each queued request also stacks a full
+	// sing-box bring-up behind vpnClient's mutex.
+	if !r.connectMu.TryLock() {
+		return ErrConnectInProgress
+	}
+	defer r.connectMu.Unlock()
+
 	if tag == "" {
 		tag = vpn.AutoSelectTag
 	}
@@ -1050,7 +1068,7 @@ func (r *LocalBackend) ConnectVPN(tag string) error {
 	}
 	bOptions := r.getBoxOptions()
 	bOptions.InitialServer = tag
-	if err := r.vpnClient.Connect(bOptions); err != nil {
+	if err := r.vpnClient.Connect(ctx, bOptions); err != nil {
 		return fmt.Errorf("failed to connect VPN: %w", err)
 	}
 	r.persistSelection(tag)

--- a/backend/radiance_test.go
+++ b/backend/radiance_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -305,4 +306,32 @@ func endpointTags(endpoints []option.Endpoint) []string {
 		tags = append(tags, endpoint.Tag)
 	}
 	return tags
+}
+
+func TestConnectVPN_ShedsConcurrentCalls(t *testing.T) {
+	r := &LocalBackend{}
+
+	// Simulate an in-flight connect holding the guard. TryLock is the first thing
+	// ConnectVPN does, so contended calls return before touching any dependency.
+	require.True(t, r.connectMu.TryLock())
+
+	const n = 8
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = r.ConnectVPN(context.Background(), vpn.AutoSelectTag)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		assert.ErrorIsf(t, err, ErrConnectInProgress, "call %d should be shed", i)
+	}
+
+	// The reject path must not release the guard; only the holder unlocks it.
+	r.connectMu.Unlock()
+	assert.True(t, r.connectMu.TryLock())
 }

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -347,7 +347,11 @@ func (s *localapi) vpnConnectHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if err := s.backend(r.Context()).ConnectVPN(req.Tag); err != nil {
+	if err := s.backend(r.Context()).ConnectVPN(r.Context(), req.Tag); err != nil {
+		if errors.Is(err, backend.ErrConnectInProgress) {
+			w.WriteHeader(http.StatusOK) // a connect is already running; no-op
+			return
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/tester/main.go
+++ b/tester/main.go
@@ -74,7 +74,7 @@ func performLanternPing(urlToHit string, runId string, deviceId string, userId i
 		}
 	}
 	t1 := time.Now()
-	if err = be.ConnectVPN(vpn.AutoSelectTag); err != nil {
+	if err = be.ConnectVPN(context.Background(), vpn.AutoSelectTag); err != nil {
 		return fmt.Errorf("quick connect failed: %w", err)
 	}
 	fmt.Println("Quick connect successful")

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -113,11 +113,8 @@ func NewVPNClient(dataPath string, logger *slog.Logger, platformIfce PlatformInt
 	return c
 }
 
-func (c *VPNClient) Connect(boxOptions BoxOptions) error {
-	ctx, span := otel.Tracer(tracerName).Start(
-		context.Background(),
-		"connect",
-	)
+func (c *VPNClient) Connect(ctx context.Context, boxOptions BoxOptions) error {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "connect")
 	defer span.End()
 
 	c.mu.Lock()
@@ -125,7 +122,11 @@ func (c *VPNClient) Connect(boxOptions BoxOptions) error {
 	c.offlineTestCancel()
 	done := c.offlineTestDone
 	c.mu.Unlock()
-	<-done
+	select {
+	case <-done:
+	case <-ctx.Done():
+		return traces.RecordError(ctx, ctx.Err())
+	}
 
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -128,6 +128,10 @@ func (c *VPNClient) Connect(ctx context.Context, boxOptions BoxOptions) error {
 		return traces.RecordError(ctx, ctx.Err())
 	}
 
+	// The bring-up below must outlive the request that triggered it, so detach
+	// from the caller's cancellation while keeping trace context (span values).
+	ctx = context.WithoutCancel(ctx)
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.tunnel != nil {

--- a/vpn/vpn_test.go
+++ b/vpn/vpn_test.go
@@ -1,6 +1,7 @@
 package vpn
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"os"
@@ -87,7 +88,7 @@ func TestConnect(t *testing.T) {
 		c.status.Store(Connected)
 		c.tunnel = &tunnel{}
 
-		err := c.Connect(BoxOptions{})
+		err := c.Connect(context.Background(), BoxOptions{})
 		assert.ErrorIs(t, err, ErrTunnelAlreadyConnected)
 	})
 
@@ -98,7 +99,7 @@ func TestConnect(t *testing.T) {
 				c.status.Store(status)
 				c.tunnel = &tunnel{}
 
-				err := c.Connect(BoxOptions{})
+				err := c.Connect(context.Background(), BoxOptions{})
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), string(status))
 			})
@@ -114,12 +115,25 @@ func TestConnect(t *testing.T) {
 
 				// Connect fails because BoxOptions has no outbounds, but the stale
 				// tunnel should be cleared first so the error comes from buildOptions.
-				err := c.Connect(BoxOptions{BasePath: t.TempDir()})
+				err := c.Connect(context.Background(), BoxOptions{BasePath: t.TempDir()})
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "no outbounds")
 			})
 		}
 	})
+}
+
+func TestConnect_CanceledDuringOfflineTestWait(t *testing.T) {
+	c := NewVPNClient(t.TempDir(), rlog.NoOpLogger(), nil)
+	// An open (never-closed) channel keeps the offline-test wait blocked, so the
+	// only way out of Connect is ctx cancellation.
+	c.offlineTestDone = make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := c.Connect(ctx, BoxOptions{})
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestDisconnect_NoTunnel(t *testing.T) {


### PR DESCRIPTION
## Problem

A burst of connect requests — e.g. rapid server taps while every attempt is blocked in a censored network — each ran `getBoxOptions` (assembling the full outbound set) and a full sing-box bring-up. These stacked behind the VPN client mutex and saturated CPU, surfacing as a flood of `POST /vpn/connect: context deadline exceeded`. [Fresh Desk ticket](https://support.lantern.io/a/tickets/181174).

## Change

- `LocalBackend.ConnectVPN` now `TryLock`s a mutex before any work and returns a new `ErrConnectInProgress` when a connect is already running, shedding overlapping calls before the expensive `getBoxOptions` + bring-up.
- The IPC handler maps `ErrConnectInProgress` to a benign `200` (same response shape as the success path), so the client sees a shed as a no-op.
- The request context is threaded through `ConnectVPN` into `VPNClient.Connect`, used for the tracing span and to make the pre-start offline-test wait cancellable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented overlapping VPN connection attempts from starting simultaneously.
  * Added cancellation support so in-progress VPN connections can stop when requests are canceled.
  * Improved handling of duplicate connection requests without returning unnecessary server errors.
* **Tests**
  * Added coverage for concurrent connection attempts and cancellation during VPN setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->