### PR TITLE
vpn: give the iOS extension headroom under the fatal 50 MB jetsam cap

### DIFF
--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -212,14 +212,22 @@ const (
 	// mobileMemoryLimit is the GOMEMLIMIT soft cap. This needs to be below the iOS hard cap
 	// to leave room for the non-Go side (Swift, cgo, etc.).
 	mobileMemoryLimit = 40 * 1024 * 1024 // 40 MB
+
+	// iosGoMemLimit is the GOMEMLIMIT for the iOS network extension. The kernel cap is
+	// fatal ("exceeded mem limit: ActiveHard 50 MB (fatal)" → jetsam per-process-limit),
+	// and GOMEMLIMIT is only a soft target: field memdumps show go_bytes reaching 44 MB
+	// under a 40 MB limit, which with ~4 MB of non-Go footprint lands 2 MB from the cap.
+	// 36 MB keeps the projected peak near 44 MB while staying clear of the ~30 MB of live
+	// heap plus goroutine stacks seen in those dumps, below which GC would thrash.
+	iosGoMemLimit = 36 * 1024 * 1024 // 36 MB
 )
 
 func setMobileMemoryLimits() {
 	slog.Debug("Setting memory limits for mobile platform", "platform", common.Platform,
-		"gc_percent", mobileGCPercent, "go_mem_limit", mobileMemoryLimit,
+		"gc_percent", mobileGCPercent, "go_mem_limit", iosGoMemLimit,
 	)
 	runtimeDebug.SetGCPercent(mobileGCPercent)
-	runtimeDebug.SetMemoryLimit(mobileMemoryLimit)
+	runtimeDebug.SetMemoryLimit(iosGoMemLimit)
 }
 
 func newClientContextInjector(outboundMgr adapter.OutboundManager, dataPath string) *clientcontext.ClientContextInjector {


### PR DESCRIPTION
Testers reported that the latest iOS beta "will not stay connected" — the tunnel connects, then drops after a few seconds, repeatedly.

## Root cause

iOS jetsam kills the network extension for exceeding its **fatal 50 MB per-process limit**. Captured from the device console (`idevicesyslog`) on a reproducing phone — iPhone 16, iOS 26.6, Lantern 9.1.20 build 737:

```
08:52:23.627  Tunnel[1509]   (lantern-tunnel) tunnel started successfully
08:52:23.709  Tunnel[1509]   PacketTunnelProvider memory [pressure=critical]
                             footprint: 40.22 MB, available: 9.78 MB
08:52:24.043  kernel         memorystatus: Tunnel [1509] exceeded mem limit: ActiveHard 50 MB (fatal)
08:52:24.043  kernel         memorystatus: killing process 1509 [Tunnel] in high band FOREGROUND (100)
08:52:24.044  kernel         memorystatus: killing_specific_process pid 1509 [Tunnel]
                             (per-process-limit ...) 51440KB
08:52:24.544  ReportSystemMemory: Process Tunnel [1509] killed by jetsam reason per-process-limit
```

Bisected on-device via TestFlight previous builds: **9.1.18 (build 711) holds on iOS 26.6; 9.1.19 and 9.1.20 both die.** So this is our regression, not an OS change — the two changed together on both testers' phones, which initially made iOS 26.6 look like the culprit.

## Why the margin is too thin

The cap is fatal, but GOMEMLIMIT is only a soft target. Field memdumps from two testers show `go_bytes` reaching **44 MB under the 40 MB limit**; with the ~4 MB of non-Go footprint those same dumps report, peak footprint lands about 2 MB below the cap. One dump peaked at **48.28 MB** (pressure 0.95). Any transient spike is fatal.

## The change

iOS GOMEMLIMIT 40 MB → **36 MB**, which projects a ~44 MB peak footprint.

Deliberately not lower: the dumps show ~15 MB of live heap objects plus up to **14 MB of goroutine stacks across 933 goroutines**, so a limit near 32 MB would sit on top of the live set and trade jetsam for GC thrashing.

Uses a **separate constant** rather than lowering `mobileMemoryLimit`. That constant is only applied as GOMEMLIMIT on iOS, but memmon also reads it for Android's soft-enter clamp (`vpn/memmon.go:155`) and as the floor for the `RADIANCE_MEMORY_LIMIT_MB` override (`vpn/memmon.go:26`) — reusing it would have made Android start evicting earlier as an invisible side effect.

## Scope — this is a mitigation, not the whole fix

Two things remain open and are tracked separately:

1. **The reclaim path that kept these devices alive on 9.1.18 is not running.** One tester's 9.1.18 log contains **1542** `hard reclaim: closing all connections`; the failing builds log no memmon activity at all. Restoring that net matters more than widening the margin. Note the admission gate only samples once *armed*, and arming happens on a monitor tick — so a monitor that never ticks also means a gate that never engages.
2. **The footprint regression itself is somewhere in 9.1.18..9.1.19.** First read is #579 (one smart dialer per config host); #575 (jsDelivr race) and the sing-box-minimal bump #581 are behind it.

## Verification

`go build ./vpn/...`, `go vet ./vpn/...`, `go test ./vpn/ ./vpn/memmon/` all clean.

**Not yet verified on device** — needs a gomobile build. Given the extension was already at 40.22 MB just 0.08s after start, shaving ~4 MB off the peak may not be sufficient alone; on-device confirmation is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkKS8hGeHM5g4BDPvxcamg