### PR TITLE
smart: only the primary config host searches at startup

### DIFF
--- a/kindling/smart/client.go
+++ b/kindling/smart/client.go
@@ -62,19 +62,21 @@ func NewHTTPClientWithSmartTransport(logWriter io.Writer, addresses ...string) (
 		return nil, err
 	}
 	byHost := make(map[string]*hostTransport, len(hosts))
-	for _, host := range hosts {
+	for i, host := range hosts {
 		ht := &hostTransport{
 			host:         host,
 			logWriter:    logWriter,
 			newTransport: newSmartTransport,
 		}
 		byHost[host] = ht
-		// Searching now keeps the client constructible while offline yet still
-		// spends the search before anything waits on it. Callers bound a whole
-		// config fetch at a timeout of the same order as the search itself, so
-		// one that pays for the search inside that budget has little of it left
-		// for the request.
-		ht.beginSearch()
+		// Only the primary searches up front. A search probes the whole strategy
+		// space at once, and two running concurrently overran the iOS extension's
+		// 50 MB jetsam cap. Fallbacks search on first use in roundTripper, paying
+		// for it inside that caller's timeout — a cost borne only on the path
+		// taken when the primary is already blocked.
+		if i == 0 {
+			ht.beginSearch()
+		}
 	}
 	lz := &lazyDialingRoundTripper{hosts: hosts, byHost: byHost}
 	return &http.Client{Transport: traces.NewRoundTripper(lz)}, nil

--- a/kindling/smart/client.go
+++ b/kindling/smart/client.go
@@ -57,6 +57,16 @@ var newSmartTransport = func(logWriter io.Writer, host string) (http.RoundTrippe
 // one strategy unblocks every one of them, and a host that is blocked outright
 // then takes the reachable ones down with it.
 func NewHTTPClientWithSmartTransport(logWriter io.Writer, addresses ...string) (*http.Client, error) {
+	lz, err := newLazyDialingRoundTripper(logWriter, addresses...)
+	if err != nil {
+		return nil, err
+	}
+	return &http.Client{Transport: traces.NewRoundTripper(lz)}, nil
+}
+
+// newLazyDialingRoundTripper builds the per-host transports. Split out so tests
+// can read which hosts have a search under way without unwrapping the client.
+func newLazyDialingRoundTripper(logWriter io.Writer, addresses ...string) (*lazyDialingRoundTripper, error) {
 	hosts, err := configHosts(addresses)
 	if err != nil {
 		return nil, err
@@ -78,8 +88,7 @@ func NewHTTPClientWithSmartTransport(logWriter io.Writer, addresses ...string) (
 			ht.beginSearch()
 		}
 	}
-	lz := &lazyDialingRoundTripper{hosts: hosts, byHost: byHost}
-	return &http.Client{Transport: traces.NewRoundTripper(lz)}, nil
+	return &lazyDialingRoundTripper{hosts: hosts, byHost: byHost}, nil
 }
 
 // configHosts returns each address's host, in order and deduplicated.

--- a/kindling/smart/client_test.go
+++ b/kindling/smart/client_test.go
@@ -213,6 +213,36 @@ func TestConstructionStartsTheSearchWithoutBlocking(t *testing.T) {
 	}
 }
 
+func TestOnlyPrimarySearchesAtConstruction(t *testing.T) {
+	// Each search probes the whole strategy space at once; two of them running
+	// concurrently overran the iOS extension's 50 MB jetsam cap and the tunnel
+	// was killed seconds after connecting.
+	searched := make(chan string, 4)
+	stubSmartTransport(t, func(host string) (http.RoundTripper, error) {
+		searched <- host
+		return echoHostRoundTripper{host: host}, nil
+	})
+
+	client, err := NewHTTPClientWithSmartTransport(io.Discard,
+		"https://primary.example/config", "https://mirror.example/config")
+	require.NoError(t, err)
+
+	select {
+	case host := <-searched:
+		assert.Equal(t, "primary.example", host)
+	case <-time.After(5 * time.Second):
+		t.Fatal("the primary has to search before a caller waits on it")
+	}
+	select {
+	case host := <-searched:
+		t.Fatalf("only the primary may search at construction, but %q searched too", host)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// The deferred search still has to happen when something actually asks.
+	assert.Equal(t, "mirror.example", getBody(t, client, "https://mirror.example/config"))
+}
+
 func TestRequestGivesUpOnSearchWhenItsContextEnds(t *testing.T) {
 	neverFinishes := make(chan struct{})
 	t.Cleanup(func() { close(neverFinishes) })

--- a/kindling/smart/client_test.go
+++ b/kindling/smart/client_test.go
@@ -213,13 +213,41 @@ func TestConstructionStartsTheSearchWithoutBlocking(t *testing.T) {
 	}
 }
 
+// inFlightSearch reports ht's pending search, read under the lock that guards it.
+func inFlightSearch(ht *hostTransport) *pendingSearch {
+	ht.mu.Lock()
+	defer ht.mu.Unlock()
+	return ht.inFlight
+}
+
 func TestOnlyPrimarySearchesAtConstruction(t *testing.T) {
 	// Each search probes the whole strategy space at once; two of them running
 	// concurrently overran the iOS extension's 50 MB jetsam cap and the tunnel
 	// was killed seconds after connecting.
-	searched := make(chan string, 4)
+	//
+	// beginSearch records inFlight under the lock before it spawns the search
+	// goroutine, so construction alone decides these values — no wall-clock wait
+	// can make a regression pass here. The search blocks until cleanup so that a
+	// mistakenly started one cannot finish and clear inFlight behind our back.
+	searching := make(chan struct{})
+	t.Cleanup(func() { close(searching) })
 	stubSmartTransport(t, func(host string) (http.RoundTripper, error) {
-		searched <- host
+		<-searching
+		return echoHostRoundTripper{host: host}, nil
+	})
+
+	lz, err := newLazyDialingRoundTripper(io.Discard,
+		"https://primary.example/config", "https://mirror.example/config")
+	require.NoError(t, err)
+
+	assert.NotNil(t, inFlightSearch(lz.byHost["primary.example"]),
+		"the primary has to search before a caller waits on it")
+	assert.Nil(t, inFlightSearch(lz.byHost["mirror.example"]),
+		"only the primary may search at construction")
+}
+
+func TestFallbackHostSearchesOnFirstUse(t *testing.T) {
+	stubSmartTransport(t, func(host string) (http.RoundTripper, error) {
 		return echoHostRoundTripper{host: host}, nil
 	})
 
@@ -227,19 +255,7 @@ func TestOnlyPrimarySearchesAtConstruction(t *testing.T) {
 		"https://primary.example/config", "https://mirror.example/config")
 	require.NoError(t, err)
 
-	select {
-	case host := <-searched:
-		assert.Equal(t, "primary.example", host)
-	case <-time.After(5 * time.Second):
-		t.Fatal("the primary has to search before a caller waits on it")
-	}
-	select {
-	case host := <-searched:
-		t.Fatalf("only the primary may search at construction, but %q searched too", host)
-	case <-time.After(100 * time.Millisecond):
-	}
-
-	// The deferred search still has to happen when something actually asks.
+	// Deferring the mirror's search must not cost it reachability.
 	assert.Equal(t, "mirror.example", getBody(t, client, "https://mirror.example/config"))
 }
 


### PR DESCRIPTION
Fixes the iOS beta that "will not stay connected" — the tunnel connects, then dies a few seconds later, repeatedly. Reported by two testers on 9.1.20-beta, reproduced on a third device.

## Root cause

iOS jetsam kills the network extension for exceeding its **fatal 50 MB per-process limit**:

```
kernel: memorystatus: Tunnel [1879] exceeded mem limit: ActiveHard 50 MB (fatal)
kernel: memorystatus: killing_specific_process pid 1879 [Tunnel] (per-process-limit ...) 51200KB
ReportSystemMemory: Process Tunnel [1879] killed by jetsam reason per-process-limit
```

Bisected on device to #575, which added the jsDelivr mirror as a second fronted config source. `NewHTTPClientWithSmartTransport` called `beginSearch()` for **every** host in its constructor, so both hosts ran a full Outline strategy search concurrently at connect. Each search probes the entire space in `smart_dialer_config.yml` — **11 DNS entries x 5 TLS strategies** — with a goroutine, TLS handshake buffers and connection state per probe.

One search already peaks near 38.5 MB inside a 50 MB cap. Two overran it.

## Device bisect

All on one phone (iPhone 16 / iOS 26.6), with per-second memory sampling from getlantern/lantern#8971:

| radiance commit | footprint | result |
|---|---|---|
| `a602efd` (immediately before #575) | 38.50 MB, settles **35.19 MB** steady | holds |
| `584a056` (**#575**) | 37.41 MB → 50 MB | **killed** |
| `612cd2d` (#575 + #579) | **26.95 MB** → 50 MB in under a second | **killed** |
| **`9b6eccd` (this PR)** | 39.88 MB peak, settles **36.75 MB** steady | **holds** |

Note `612cd2d` started *lower* than the build that survived. **This is a burst, not a raised resting footprint** — which is why memory limits were the wrong lever (I tried, and closed it: #595). Nothing can GC out of a sub-second spike, and at rest the extension is fine: ~12 MB of live heap objects, the whole remote rule-set is 9.8 KB.

## The change

Warm only the first host. `roundTripper` already searches on demand with single-flight, so fallback hosts keep working — they pay for the search inside the first caller's timeout, on a path only taken once the primary is blocked. #575's reason for existing (raw.githubusercontent.com is blocked in China) is unaffected.

`TestOnlyPrimarySearchesAtConstruction` covers it, and **fails without the fix** (`only the primary may search at construction, but "mirror.example" searched too`). `go test -race ./kindling/smart/` clean.

## Follow-up worth filing

Even fixed, startup peaks at 39.88 MB against a 50 MB cap — about 10 MB of headroom. This PR removes the second search, but the next config host or strategy-table entry puts us back here. Bounding search concurrency structurally (rather than by counting hosts) would make that safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkKS8hGeHM5g4BDPvxcamg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved client startup by limiting initial service discovery to the primary configured host.
  * Additional hosts are discovered on demand when first needed.

* **Reliability**
  * Deferred discovery now runs within the request timeout, helping preserve request responsiveness and mirror-host functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->