### PR TITLE
fix(vpn): start memory monitor early with a single monitor

### DIFF
--- a/vpn/memmon.go
+++ b/vpn/memmon.go
@@ -94,6 +94,8 @@ func startMemoryMonitor(ctx context.Context) (*memmon.Monitor, io.Closer) {
 	return monitor, runMonitor(ctx, monitor)
 }
 
+// initExecutor attaches reclaim and admission control after the clash server
+// becomes available. The monitor starts earlier in visibility-only mode.
 func initExecutor(monitor *memmon.Monitor, server *clashServer) {
 	// Use a dedicated sensor here. Sharing the monitor sensor would race its
 	// reused runtime/metrics buffers.

--- a/vpn/memmon.go
+++ b/vpn/memmon.go
@@ -80,32 +80,24 @@ func closeAllRouted(tracker *connTracker) {
 	tracker.closeAllTracked()
 }
 
-func startMemoryMonitor(ctx context.Context, server *clashServer) io.Closer {
-	if common.IsIOS() {
-		return startIOSMemoryMonitor(ctx, server)
-	}
-
-	return startFixedMemoryMonitor(ctx)
-}
-
-func startFixedMemoryMonitor(ctx context.Context) io.Closer {
-	limit := memmon.FixedLimit(defaultNonIOSMemLimitBytes)
-	// Non-iOS uses the monitor for visibility only. Reclaim and admission
-	// control remain disabled by passing a nil executor.
+// startMemoryMonitor creates and starts a visibility-only memory monitor,
+// returning the monitor so an executor can be installed later and a Closer that
+// stops the run loop and waits for it to exit.
+func startMemoryMonitor(ctx context.Context) (*memmon.Monitor, io.Closer) {
+	limit := getLimit()
 	monitor := memmon.New(
 		memoryMonitorConfig(limit),
 		memmon.NewSensor(limit),
 		nil,
 	)
 
-	return runMonitor(ctx, monitor)
+	return monitor, runMonitor(ctx, monitor)
 }
 
-func startIOSMemoryMonitor(ctx context.Context, server *clashServer) io.Closer {
-	limit := memmon.FixedLimit(monitorLimitBytes())
-
+func initExecutor(monitor *memmon.Monitor, server *clashServer) {
 	// Use a dedicated sensor here. Sharing the monitor sensor would race its
 	// reused runtime/metrics buffers.
+	limit := getLimit()
 	gate := memmon.NewAdmissionGate(
 		memmon.AdmissionConfig{},
 		memmon.NewSensor(limit),
@@ -121,14 +113,14 @@ func startIOSMemoryMonitor(ctx context.Context, server *clashServer) io.Closer {
 		common.Version,
 		gate,
 	)
+	monitor.SetExecutor(executor)
+}
 
-	monitor := memmon.New(
-		memoryMonitorConfig(limit),
-		memmon.NewSensor(limit),
-		executor,
-	)
-
-	return runMonitor(ctx, monitor)
+func getLimit() memmon.LimitProvider {
+	if common.IsIOS() {
+		return memmon.FixedLimit(monitorLimitBytes())
+	}
+	return memmon.FixedLimit(defaultNonIOSMemLimitBytes)
 }
 
 func monitorLimitBytes() uint64 {

--- a/vpn/memmon/monitor.go
+++ b/vpn/memmon/monitor.go
@@ -3,6 +3,7 @@ package memmon
 import (
 	"context"
 	"log/slog"
+	"sync/atomic"
 	"time"
 )
 
@@ -85,7 +86,7 @@ type Executor interface {
 type Monitor struct {
 	engine       *DecisionEngine
 	readSample   func(now time.Time) Sample
-	executor     Executor
+	executor     atomic.Pointer[Executor]
 	baseInterval time.Duration
 
 	lastLevel   PressureLevel
@@ -105,12 +106,27 @@ const (
 // executor.
 func New(cfg Config, sampler Sampler, executor Executor) *Monitor {
 	engine := NewDecisionEngine(cfg)
-	return &Monitor{
+	m := &Monitor{
 		engine:       engine,
 		readSample:   sampler.Sample,
-		executor:     executor,
 		baseInterval: engine.cfg.BaseInterval,
 	}
+	m.SetExecutor(executor)
+	return m
+}
+
+// SetExecutor sets the executor consulted on each tick. A nil executor leaves
+// the monitor visibility-only (sample and log, no reclaim). Safe to call
+// concurrently with the run loop.
+func (m *Monitor) SetExecutor(executor Executor) {
+	if executor == nil {
+		// Storing &executor would wrap a nil interface in a non-nil *Executor,
+		// which Step then dereferences and calls, panicking. Store a nil pointer
+		// so the load-side guard skips it.
+		m.executor.Store(nil)
+		return
+	}
+	m.executor.Store(&executor)
 }
 
 // Run drives the loop until ctx is canceled. It blocks.
@@ -118,6 +134,7 @@ func (m *Monitor) Run(ctx context.Context) {
 	interval := m.baseInterval
 	timer := time.NewTimer(interval)
 	defer timer.Stop()
+	m.Step(time.Now())
 	for {
 		select {
 		case <-ctx.Done():
@@ -140,8 +157,8 @@ func (m *Monitor) Step(now time.Time) Decision {
 	sample := m.readSample(now)
 	decision := m.engine.Decide(sample)
 	m.logTick(now, sample, decision)
-	if m.executor != nil {
-		m.executor.Apply(decision, now)
+	if executor := m.executor.Load(); executor != nil {
+		(*executor).Apply(decision, now)
 	}
 	return decision
 }

--- a/vpn/memmon/monitor_test.go
+++ b/vpn/memmon/monitor_test.go
@@ -2,6 +2,7 @@ package memmon
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,6 +12,40 @@ import (
 type noopExecutor struct{}
 
 func (noopExecutor) Apply(Decision, time.Time) {}
+
+type countingExecutor struct {
+	n atomic.Int32
+}
+
+func (c *countingExecutor) Apply(Decision, time.Time) {
+	c.n.Add(1)
+}
+
+func (c *countingExecutor) count() int {
+	return int(c.n.Load())
+}
+
+func TestStepNilExecutorSafe(t *testing.T) {
+	fs := &fakeSampler{pressure: 0.1}
+	mon := New(Config{BaseInterval: time.Millisecond}, fs, nil)
+	require.NotPanics(t, func() { mon.Step(gateBase) })
+
+	mon.SetExecutor(nil)
+	require.NotPanics(t, func() { mon.Step(gateBase) })
+}
+
+func TestSetExecutorAppliesOnLaterTicks(t *testing.T) {
+	fs := &fakeSampler{pressure: 0.1}
+	mon := New(Config{BaseInterval: time.Millisecond}, fs, nil)
+
+	exec := &countingExecutor{}
+	mon.Step(gateBase)
+	require.Equal(t, 0, exec.count(), "nil executor must not be applied")
+
+	mon.SetExecutor(exec)
+	mon.Step(gateBase.Add(time.Millisecond))
+	require.Equal(t, 1, exec.count(), "installed executor is applied on the next tick")
+}
 
 func TestRunTicksThenStopsOnCancel(t *testing.T) {
 	fs := &fakeSampler{pressure: 0.1} // Normal level → reschedule at BaseInterval

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -39,6 +39,7 @@ import (
 	"github.com/getlantern/radiance/kindling"
 	rlog "github.com/getlantern/radiance/log"
 	"github.com/getlantern/radiance/servers"
+	"github.com/getlantern/radiance/vpn/memmon"
 )
 
 type tunnel struct {
@@ -58,6 +59,7 @@ type tunnel struct {
 	outboundMgr adapter.OutboundManager
 
 	clientContextTracker *clientcontext.ClientContextInjector
+	memoryMonitor        *memmon.Monitor
 
 	// connObserver, if non-nil, is attached to clashServer's tracker at connect to receive
 	// connection-close pushes for telemetry.
@@ -132,6 +134,18 @@ func (t *tunnel) init(ctx context.Context, options string, platformIfce libbox.P
 	}()
 
 	slog.Log(nil, rlog.LevelTrace, "Initializing tunnel")
+	if common.IsMobile() {
+		var monitorCloser io.Closer
+		t.memoryMonitor, monitorCloser = startMemoryMonitor(t.ctx)
+		t.closers = append(t.closers, monitorCloser)
+
+		if common.IsIOS() {
+			// Pin GOMEMLIMIT before the allocation-heavy libbox bring-up so GC
+			// gets its turn during it. Only iOS needs this: it silently kills the
+			// extension past a hard cap; Android applies no such restriction.
+			setMobileMemoryLimits()
+		}
+	}
 
 	// setup libbox service
 	dataPath := t.dataPath
@@ -193,12 +207,6 @@ func (t *tunnel) init(ctx context.Context, options string, platformIfce libbox.P
 
 	t.closers = append(t.closers, lb)
 	t.lbService = lb
-
-	if common.IsIOS() {
-		// only set memory limits on iOS since Android doesn't appear to apply any restrictions.
-		// we still start the memory monitor on Android so we can log usage.
-		setMobileMemoryLimits()
-	}
 
 	slog.Info("Tunnel initializated")
 	return nil
@@ -292,9 +300,10 @@ func (t *tunnel) connect(ctx context.Context) (err error) {
 	t.outboundMgr = service.FromContext[adapter.OutboundManager](t.ctx)
 	t.clashServer.connTracker.SetObserver(t.connObserver)
 
-	if common.IsMobile() {
-		// still start the memory monitor on Android so we can still monitor and log usage
-		t.closers = append(t.closers, startMemoryMonitor(t.ctx, t.clashServer))
+	if common.IsIOS() {
+		// Only iOS enforces a hard memory cap, so only it gets reclaim and
+		// admission control. Android runs the monitor for visibility only.
+		initExecutor(t.memoryMonitor, t.clashServer)
 	}
 
 	var mutGrpMgr *groups.MutableGroupManager

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -59,7 +59,10 @@ type tunnel struct {
 	outboundMgr adapter.OutboundManager
 
 	clientContextTracker *clientcontext.ClientContextInjector
-	memoryMonitor        *memmon.Monitor
+
+	// memoryMonitor starts during tunnel init in visibility-only mode.
+	// On iOS, its executor is installed later, after the clash server exists.
+	memoryMonitor *memmon.Monitor
 
 	// connObserver, if non-nil, is attached to clashServer's tracker at connect to receive
 	// connection-close pushes for telemetry.
@@ -208,7 +211,7 @@ func (t *tunnel) init(ctx context.Context, options string, platformIfce libbox.P
 	t.closers = append(t.closers, lb)
 	t.lbService = lb
 
-	slog.Info("Tunnel initializated")
+	slog.Info("Tunnel initialized")
 	return nil
 }
 


### PR DESCRIPTION
## What

Start memory monitoring as early as possible during tunnel bring-up, using a single monitor whose reclaim/admission executor is installed later once the clash server exists.

Previously the monitor was constructed in `connect()` — after `libbox.Setup` and `NewServiceWithContext` — so the allocation-heavy setup window ran unmonitored. That window is exactly where an iOS network extension can cross the jetsam ceiling.

## Changes

- **Single monitor + deferred executor.** The monitor now starts at the top of `tunnel.init()` (mobile only) in visibility-only mode. On iOS, `initExecutor` installs the reclaimer + admission gate via a new `Monitor.SetExecutor` once the clash server is available in `connect()`. This replaces the previous iOS/non-iOS two-constructor split.
- **`SetExecutor` nil guard.** `Executor` is an interface, so storing `&executor` for a nil executor wraps a nil interface in a non-nil `*Executor`; the load-side guard then passes and `Apply` panics on the first tick. `SetExecutor(nil)` now stores a nil pointer so the visibility-only path is safe.
- **Deterministic shutdown.** The monitor runs on `t.ctx` and its closer is registered in `t.closers`, so `close()` cancels and waits for it. Previously it ran on an uncancelable context and was never stopped, leaking a sampler goroutine per connect/disconnect cycle.
- **GOMEMLIMIT pinned earlier.** `setMobileMemoryLimits()` moved ahead of the libbox bring-up so GC acts during it. Still iOS-only — Android applies no hard cap.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile memory monitoring during tunnel setup and connection.
  * iOS now applies memory and garbage-collection limits earlier for improved resource management.
  * Android retains memory visibility monitoring without reclaim or admission controls.
  * Memory monitoring now responds immediately when started, rather than waiting for the first timer interval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->