### PR TITLE
fix(datacap): handle cap_exhausted as terminal, fix backoff reset

### DIFF
--- a/account/datacap.go
+++ b/account/datacap.go
@@ -16,12 +16,62 @@ import (
 
 	"github.com/getlantern/radiance/common"
 	"github.com/getlantern/radiance/common/settings"
+	"github.com/getlantern/radiance/log"
 	"github.com/getlantern/radiance/traces"
 )
 
 type sseEvent struct {
 	Type string
 	Data string
+}
+
+const (
+	// healthyStreamDuration is the minimum time a stream must stay healthy before a
+	// later drop is treated as transient and allowed to reset reconnect backoff.
+	healthyStreamDuration = 5 * time.Minute
+
+	// exhaustedRetryFallback is used when the reset time is unknown.
+	exhaustedRetryFallback = time.Hour
+
+	// minExhaustedRetry prevents a tight reconnect loop if the reset time is
+	// already in the past.
+	minExhaustedRetry = time.Minute
+
+	// exhaustedRetryGrace waits just past the reported reset time.
+	exhaustedRetryGrace = 30 * time.Second
+)
+
+// errCapExhausted marks a deliberate server close after the daily allotment is
+// spent. Callers should wait for reset instead of reconnecting immediately.
+var errCapExhausted = errors.New("datacap exhausted")
+
+type dataCapStreamState struct {
+	progressed   bool
+	allotmentEnd time.Time
+}
+
+// wrap records stream progress and the latest allotment end time before calling
+// the caller-provided handler.
+func (s *dataCapStreamState) wrap(handler func(*DataCapInfo)) func(*DataCapInfo) {
+	return func(info *DataCapInfo) {
+		s.progressed = true
+		s.allotmentEnd = parseAllotmentEnd(info.Usage)
+		handler(info)
+	}
+}
+
+// parseAllotmentEnd extracts and parses the reset time from usage data.
+func parseAllotmentEnd(usage *DataCapUsageDetails) time.Time {
+	if usage == nil || usage.AllotmentEndTime == "" {
+		return time.Time{}
+	}
+
+	t, err := time.Parse(time.RFC3339, usage.AllotmentEndTime)
+	if err != nil {
+		slog.Warn("datacap allotmentEndTime parse failed", "value", usage.AllotmentEndTime, "error", err)
+		return time.Time{}
+	}
+	return t
 }
 
 // readSSE reads Server-Sent Events from body and sends parsed events on the
@@ -35,12 +85,17 @@ func readSSE(ctx context.Context, body io.Reader) (<-chan sseEvent, func() error
 	go func() {
 		defer close(ch)
 		scanner := bufio.NewScanner(body)
-		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024) // 1 MB max token
+		buf := make([]byte, 0, 64*1024)
+		scanner.Buffer(buf, 1024*1024)
+
 		var evt sseEvent
 		for scanner.Scan() {
-			if ctx.Err() != nil {
+			select {
+			case <-ctx.Done():
 				return
+			default:
 			}
+
 			line := scanner.Text()
 			switch {
 			case strings.HasPrefix(line, "event:"):
@@ -71,29 +126,73 @@ func readSSE(ctx context.Context, body io.Reader) (<-chan sseEvent, func() error
 	return ch, func() error { return scanErr }
 }
 
-// DataCapStream connects to the datacap SSE endpoint and calls handler whenever
-// the server pushes an update. The method blocks until ctx is cancelled,
-// reconnecting with backoff on stream errors.
+// DataCapStream connects to the datacap SSE endpoint and keeps reconnecting on
+// stream errors. If the server closes with cap_exhausted, it waits for the
+// allotment reset instead of retrying immediately.
 func (a *Client) DataCapStream(ctx context.Context, handler func(*DataCapInfo)) error {
 	bo := common.NewBackoff(2 * time.Minute)
 	for {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
+
 		start := time.Now()
-		err := a.connectDataCapSSE(ctx, handler)
+		state := dataCapStreamState{}
+
+		err := a.connectDataCapSSE(ctx, state.wrap(handler))
 		if err != nil {
 			slog.Debug("datacap SSE stream ended", "error", err)
 		}
-		if ctx.Err() != nil {
-			return ctx.Err()
+		if err := ctx.Err(); err != nil {
+			return err
 		}
-		// Reset backoff if the connection was up for a while before dropping,
-		// so we reconnect quickly after a transient disconnect.
-		if time.Since(start) > 30*time.Second {
+
+		if errors.Is(err, errCapExhausted) {
+			if err := a.waitForAllotmentReset(ctx, state.allotmentEnd); err != nil {
+				return err
+			}
+			bo.Reset()
+			continue
+		}
+
+		// Only streams that made progress and stayed up long enough reset
+		// backoff. Early failures keep backing off.
+		if streamWasHealthy(state.progressed, time.Since(start)) {
 			bo.Reset()
 		}
 		bo.Wait(ctx)
+	}
+}
+
+// streamWasHealthy reports whether a disconnected stream should be treated as a
+// transient failure for backoff purposes.
+func streamWasHealthy(progressed bool, upFor time.Duration) bool {
+	return progressed && upFor > healthyStreamDuration
+}
+
+// allotmentResetWait returns how long to wait before reconnecting after a
+// cap_exhausted close.
+func allotmentResetWait(allotmentEnd time.Time) time.Duration {
+	if allotmentEnd.IsZero() {
+		return exhaustedRetryFallback
+	}
+	return max(time.Until(allotmentEnd)+exhaustedRetryGrace, minExhaustedRetry)
+}
+
+// waitForAllotmentReset blocks until the next expected reset time or until the
+// context is cancelled.
+func (a *Client) waitForAllotmentReset(ctx context.Context, allotmentEnd time.Time) error {
+	wait := allotmentResetWait(allotmentEnd)
+	slog.Info("datacap exhausted; waiting for allotment reset", "wait", wait, "allotmentEnd", allotmentEnd)
+
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
 	}
 }
 
@@ -121,21 +220,47 @@ func (a *Client) connectDataCapSSE(ctx context.Context, handler func(*DataCapInf
 	}
 
 	slog.Debug("connected to datacap SSE stream")
+
 	eventCh, scanErr := readSSE(ctx, resp.Body)
+	var (
+		last         DataCapInfo
+		hasLast      bool
+		capExhausted bool
+	)
 	for evt := range eventCh {
 		switch evt.Type {
 		case "datacap":
 			var datacap DataCapInfo
 			if err := json.Unmarshal([]byte(evt.Data), &datacap); err != nil {
-				slog.Debug("datacap SSE unmarshal error", "error", err)
+				// Log only a short prefix so malformed payloads are diagnosable
+				// without dumping the full response.
+				prefix := evt.Data
+				if len(prefix) > 64 {
+					prefix = prefix[:64]
+				}
+				slog.Warn("datacap SSE payload not valid JSON", "error", err, "payloadPrefix", prefix)
 				continue
 			}
+
+			last = datacap
+			hasLast = true
 			handler(&datacap)
+
 			if datacap.Usage != nil {
 				slog.Debug("datacap updated", "bytesUsed", datacap.Usage.BytesUsed)
 			}
 		case "cap_exhausted":
-			slog.Warn("datacap exhausted")
+			slog.Log(nil, log.LevelTrace, "datacap SSE cap_exhausted event received")
+			// The server closes intentionally after this event. Re-emit the last
+			// known datacap state with Exhausted set so callers get the reset time.
+			capExhausted = true
+
+			exhausted := DataCapInfo{Exhausted: true}
+			if hasLast {
+				exhausted = last
+				exhausted.Exhausted = true
+			}
+			handler(&exhausted)
 		default:
 			// heartbeat or unknown event — ignore
 		}
@@ -143,8 +268,11 @@ func (a *Client) connectDataCapSSE(ctx context.Context, handler func(*DataCapInf
 	if err := ctx.Err(); err != nil {
 		return traces.RecordError(ctx, err)
 	}
+	if capExhausted {
+		return errCapExhausted
+	}
 	if err := scanErr(); err != nil {
 		return traces.RecordError(ctx, fmt.Errorf("datacap SSE scanner: %w", err))
 	}
-	return traces.RecordError(ctx, errors.New("datacap SSE stream ended unexpectedly"))
+	return io.EOF
 }

--- a/account/datacap.go
+++ b/account/datacap.go
@@ -39,6 +39,11 @@ const (
 
 	// exhaustedRetryGrace waits just past the reported reset time.
 	exhaustedRetryGrace = 30 * time.Second
+
+	// datacapDisabledRetry is how long to pause before rechecking after the
+	// server reports datacap is disabled for this device. This state rarely
+	// changes, so recheck infrequently.
+	datacapDisabledRetry = time.Hour
 )
 
 // errCapExhausted marks a deliberate server close after the daily allotment is
@@ -47,14 +52,16 @@ var errCapExhausted = errors.New("datacap exhausted")
 
 type dataCapStreamState struct {
 	progressed   bool
+	enabled      bool
 	allotmentEnd time.Time
 }
 
-// wrap records stream progress and the latest allotment end time before calling
-// the caller-provided handler.
+// wrap records stream progress, whether datacap is enabled, and the latest
+// allotment end time before calling the caller-provided handler.
 func (s *dataCapStreamState) wrap(handler func(*DataCapInfo)) func(*DataCapInfo) {
 	return func(info *DataCapInfo) {
 		s.progressed = true
+		s.enabled = info.Enabled
 		s.allotmentEnd = parseAllotmentEnd(info.Usage)
 		handler(info)
 	}
@@ -155,6 +162,18 @@ func (a *Client) DataCapStream(ctx context.Context, handler func(*DataCapInfo)) 
 			continue
 		}
 
+		// Datacap disabled: the server sends a single Enabled:false event and
+		// closes. Recheck on a long interval rather than reconnecting into an
+		// immediate close.
+		if state.progressed && !state.enabled {
+			slog.Info("datacap disabled; pausing before recheck", "retryIn", datacapDisabledRetry)
+			if err := waitOrDone(ctx, datacapDisabledRetry); err != nil {
+				return err
+			}
+			bo.Reset()
+			continue
+		}
+
 		// Only streams that made progress and stayed up long enough reset
 		// backoff. Early failures keep backing off.
 		if streamWasHealthy(state.progressed, time.Since(start)) {
@@ -184,10 +203,14 @@ func allotmentResetWait(allotmentEnd time.Time) time.Duration {
 func (a *Client) waitForAllotmentReset(ctx context.Context, allotmentEnd time.Time) error {
 	wait := allotmentResetWait(allotmentEnd)
 	slog.Info("datacap exhausted; waiting for allotment reset", "wait", wait, "allotmentEnd", allotmentEnd)
+	return waitOrDone(ctx, wait)
+}
 
-	timer := time.NewTimer(wait)
+// waitOrDone blocks for d or until ctx is cancelled, returning ctx.Err() on
+// cancellation and nil once d elapses.
+func waitOrDone(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
 	defer timer.Stop()
-
 	select {
 	case <-ctx.Done():
 		return ctx.Err()

--- a/account/datacap_test.go
+++ b/account/datacap_test.go
@@ -156,6 +156,22 @@ func TestAllotmentResetWait(t *testing.T) {
 	assert.Equal(t, minExhaustedRetry, allotmentResetWait(now.Add(-time.Hour)))
 }
 
+func TestDataCapStreamState_Wrap(t *testing.T) {
+	var s dataCapStreamState
+	var delivered bool
+	h := s.wrap(func(*DataCapInfo) { delivered = true })
+
+	h(&DataCapInfo{
+		Enabled: false,
+		Usage:   &DataCapUsageDetails{AllotmentEndTime: "2026-08-13T00:00:00Z"},
+	})
+
+	assert.True(t, delivered, "wrap must call the wrapped handler")
+	assert.True(t, s.progressed)
+	assert.False(t, s.enabled, "Enabled:false must be recorded so DataCapStream can pause")
+	assert.False(t, s.allotmentEnd.IsZero(), "a valid AllotmentEndTime must be parsed")
+}
+
 func TestStreamWasHealthy(t *testing.T) {
 	// The reset must key on progress AND a duration well past the server's
 	// update cadence; a stream that dies near the cadence must not reset.

--- a/account/datacap_test.go
+++ b/account/datacap_test.go
@@ -3,6 +3,8 @@ package account
 import (
 	"context"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -103,6 +105,64 @@ func TestReadSSE_EmptyLinesIgnored(t *testing.T) {
 
 	_, ok := <-ch
 	assert.False(t, ok)
+}
+
+func TestConnectDataCapSSE_CapExhausted(t *testing.T) {
+	const endTime = "2026-08-13T00:00:00Z"
+	body := "event: datacap\n" +
+		`data: {"enabled":true,"usage":{"bytesAllotted":"100","bytesUsed":"100","allotmentEndTime":"` + endTime + `"}}` + "\n\n" +
+		"event: cap_exhausted\ndata: device123\n\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, body)
+	}))
+	defer srv.Close()
+
+	a := &Client{httpClient: srv.Client(), authURL: srv.URL}
+	var got []DataCapInfo
+	err := a.connectDataCapSSE(context.Background(), func(info *DataCapInfo) {
+		got = append(got, *info)
+	})
+
+	assert.ErrorIs(t, err, errCapExhausted)
+	require.Len(t, got, 2)
+	assert.False(t, got[0].Exhausted)
+	assert.True(t, got[1].Exhausted, "cap_exhausted must re-emit the info with Exhausted set")
+	require.NotNil(t, got[1].Usage)
+	assert.Equal(t, endTime, got[1].Usage.AllotmentEndTime, "exhausted info must carry the reset time from the preceding datacap event")
+}
+
+func TestWaitForAllotmentReset_ContextCancelled(t *testing.T) {
+	a := &Client{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	// A cancelled context must return immediately even when the fallback wait
+	// would otherwise be long.
+	err := a.waitForAllotmentReset(ctx, time.Time{})
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestAllotmentResetWait(t *testing.T) {
+	now := time.Now()
+
+	// Unknown reset time falls back to the fixed poll.
+	assert.Equal(t, exhaustedRetryFallback, allotmentResetWait(time.Time{}))
+
+	// A future reset time waits until just past it.
+	future := allotmentResetWait(now.Add(time.Hour))
+	assert.InDelta(t, (time.Hour + 30*time.Second).Seconds(), future.Seconds(), 2)
+
+	// A reset time already in the past retries promptly, not after the fallback.
+	assert.Equal(t, minExhaustedRetry, allotmentResetWait(now.Add(-time.Hour)))
+}
+
+func TestStreamWasHealthy(t *testing.T) {
+	// The reset must key on progress AND a duration well past the server's
+	// update cadence; a stream that dies near the cadence must not reset.
+	assert.False(t, streamWasHealthy(false, healthyStreamDuration+time.Minute), "no event received")
+	assert.False(t, streamWasHealthy(true, 31*time.Second), "died near the 30s update cadence")
+	assert.False(t, streamWasHealthy(true, healthyStreamDuration), "exactly at threshold is not past it")
+	assert.True(t, streamWasHealthy(true, healthyStreamDuration+time.Second), "long-lived stream with progress")
 }
 
 func TestReadSSE_ScannerError(t *testing.T) {

--- a/account/user.go
+++ b/account/user.go
@@ -98,6 +98,10 @@ type DataCapInfo struct {
 	Enabled bool `json:"enabled"`
 	// Data cap usage details (only populated if enabled is true)
 	Usage *DataCapUsageDetails `json:"usage,omitempty"`
+	// Exhausted is set locally when the SSE stream emits cap_exhausted. It is not
+	// part of the server JSON payload. If present, the AllotmentEndTime at which
+	// the allotment resets is stored in Usage.AllotmentEndTime.
+	Exhausted bool `json:"exhausted,omitempty"`
 }
 
 type DataCapUsageDetails struct {


### PR DESCRIPTION
Fixes the client-side defects in the datacap SSE stream from getlantern/engineering#3769. The client treated the server's deliberate `cap_exhausted` close as a retryable failure and reconnected against a state that cannot change until the daily allotment resets.

## Changes

**1. `cap_exhausted` is terminal, not a retryable error.** `connectDataCapSSE` now returns an `errCapExhausted` sentinel when the server closes after signalling exhaustion. `DataCapStream` waits until the reported `AllotmentEndTime` (with a short grace, clamped to a minimum, and a fixed fallback when the reset time is unknown) instead of tight-retrying the terminal state.

**2. The exhausted signal reaches callers.** Added `DataCapInfo.Exhausted` (client-set, not part of the server JSON) and re-emit the last known usage with it set on `cap_exhausted`, so the UI gets the explicit signal and the reset time rather than a log-only event.

**3. Backoff reset keys on health, not the wall clock.** Reset the reconnect backoff only when a stream made progress and stayed up past a threshold well above the server's ~30s update cadence. The previous `time.Since(start) > 30s` matched that cadence, so mid-duration failures reset backoff to zero and effectively disabled it.

**Diagnostics.** A non-JSON SSE payload is now logged at `Warn` with a bounded prefix of the raw bytes, so a server/client serialization mismatch is visible at default log level instead of a Debug line plus a generic "stream ended" error.

## Tests

Added coverage for the cap_exhausted flow (sentinel + exhausted re-emit carrying the reset time), the reset-wait duration branches (future / past / unknown), the backoff-health predicate, and context-cancellation of the wait. `go build ./...`, `go vet`, and `go test -race ./...` pass.

closes getlantern/engineering#3769

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Data-cap status now reports when the allowance is exhausted.
  * Usage information is preserved and re-emitted during exhaustion events.
  * Allotment reset timing is tracked for clearer recovery expectations.

* **Bug Fixes**
  * Improved handling of interrupted or cancelled data-cap streams.
  * Added more reliable reconnection behavior after unhealthy connections.
  * Clean stream closures and malformed event data are handled more safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->