### PR TITLE
backend: cap the servers a client holds at 30

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -766,9 +766,13 @@ func (r *LocalBackend) RevokePrivateServerInvite(ip string, port int, accessToke
 	return r.srvManager.RevokePrivateServerInvite(ip, port, accessToken, inviteName)
 }
 
-// maxRetainedLanternServers caps the number of working Lantern servers retained
-// across config updates.
-const maxRetainedLanternServers = 60
+// maxLanternServers caps how many Lantern servers a client holds. The iOS network
+// extension runs under a fatal 50 MB jetsam cap and its startup work scales with
+// this set — each outbound carries adapter state, and the offline URL tests and
+// strategy search run across it. Enforced on the incoming batch as well as on
+// retention, so no config can push a client past it. Private servers are not
+// Lantern servers and are unaffected.
+const maxLanternServers = 30
 
 func (r *LocalBackend) updateServers(list servers.ServerList) error {
 	existing := r.srvManager.AllServers()
@@ -778,7 +782,16 @@ func (r *LocalBackend) updateServers(list servers.ServerList) error {
 		return exists
 	})
 
-	tagsToEvict := lanternServersToEvict(existing, len(list.Servers), maxRetainedLanternServers)
+	if capped := capServerBatch(list.Servers, maxLanternServers); len(capped) < len(list.Servers) {
+		slog.Debug(
+			"Truncating config batch to the client outbound cap",
+			"received", len(list.Servers),
+			"cap", maxLanternServers,
+		)
+		list.Servers = capped
+	}
+
+	tagsToEvict := lanternServersToEvict(existing, len(list.Servers), maxLanternServers)
 
 	if len(tagsToEvict) > 0 {
 		slog.Debug(
@@ -824,6 +837,15 @@ func serverTagSet(list []*servers.Server) map[string]struct{} {
 // later re-offer is treated as a fresh candidate and re-probed. Remaining
 // candidates are evicted oldest-first by SelectionHistory.UpdatedAt; missing
 // history sorts oldest.
+// capServerBatch truncates an incoming config batch to limit. Config order is the
+// server's preference, so the leading entries are the ones kept.
+func capServerBatch(srvs []*servers.Server, limit int) []*servers.Server {
+	if limit < 0 || len(srvs) <= limit {
+		return srvs
+	}
+	return srvs[:limit]
+}
+
 func lanternServersToEvict(
 	existing []*servers.Server,
 	incomingCount, limit int,

--- a/backend/radiance_test.go
+++ b/backend/radiance_test.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -214,6 +215,49 @@ func TestLanternServersToEvict(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := lanternServersToEvict(tt.existing, tt.incoming, tt.limit)
 			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}
+
+// The cap used to bound only retention, so a config larger than the limit was
+// added in full — production configs delivered 120 servers against a limit of 60.
+// The iOS extension pays for every one of them under a fatal 50 MB jetsam cap, so
+// what matters is the total the client is left holding, not just what it retained.
+func TestClientHoldsNoMoreThanTheCapAfterAnUpdate(t *testing.T) {
+	baseTime := time.Date(2026, 8, 13, 0, 0, 0, 0, time.UTC)
+
+	for _, tt := range []struct {
+		name              string
+		existingCount     int
+		incomingCount     int
+		limit             int
+		wantIncomingAfter int
+	}{
+		{"oversized config is truncated", 0, 120, 30, 30},
+		{"oversized config with existing servers", 45, 120, 30, 30},
+		{"config at the cap is untouched", 10, 30, 30, 30},
+		{"undersized config is untouched", 5, 12, 30, 12},
+		{"empty config keeps existing within the cap", 40, 0, 30, 0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			existing := make([]*servers.Server, 0, tt.existingCount)
+			for i := range tt.existingCount {
+				existing = append(existing,
+					newTestServer(fmt.Sprintf("existing-%d", i), true, false,
+						baseTime.Add(time.Duration(i)*time.Minute)))
+			}
+			incoming := make([]*servers.Server, 0, tt.incomingCount)
+			for i := range tt.incomingCount {
+				incoming = append(incoming, newTestServer(fmt.Sprintf("incoming-%d", i), true, false, baseTime))
+			}
+
+			capped := capServerBatch(incoming, tt.limit)
+			assert.Len(t, capped, tt.wantIncomingAfter)
+
+			evicted := lanternServersToEvict(existing, len(capped), tt.limit)
+			held := len(capped) + len(existing) - len(evicted)
+			assert.LessOrEqual(t, held, tt.limit,
+				"client would hold %d servers, over the %d cap", held, tt.limit)
 		})
 	}
 }


### PR DESCRIPTION
Closes getlantern/engineering#3816.

## The gap

`maxRetainedLanternServers` was applied only to *retention*:

```go
retentionBudget := max(limit-incomingCount, 0)
```

That budgets how many **existing** servers to keep. It never truncated the **incoming** batch, so a config delivering N servers added all N and simply evicted whatever was retained. The limit was 60; production configs deliver **120**, measured on two independent devices:

| ticket | device | `servers.json` entries |
|---|---|---|
| 181331 | Derek, iOS | 120 |
| 181479 | Adam, iOS | 120 |

So clients held double the nominal cap, with no client-side bound at all.

## Why it matters

The iOS network extension runs under a **fatal 50 MB** jetsam cap, and startup work scales with this set — each outbound carries adapter state, the offline URL tests ran with `server_count=60`, and the smart dialer probes `11 DNS entries x 5 TLS strategies` per config host.

Even after #596 and #597, a device capture (iPhone 16 / iOS 26.6) peaked at **46.08 MB — 3.92 MB from the cap** — while cycling connect/disconnect:

```
Tunnel[1263]  40.53 MB  (avail 9.47)
Tunnel[1263]  44.66 MB  (avail 5.34)
Tunnel[1263]  46.08 MB  (avail 3.92)
Tunnel[1281]  30.74 MB  (fresh process, healthy)
```

Five distinct PIDs, so not a leak across restarts — the growth is within one long-lived extension, and it mirrors the churn in the sessions that were being killed.

## The change

Cap at **30**, enforced on the incoming batch as well as on retention, so no config can push a client past it. Config order is the server's preference, so the leading entries are kept; the existing quality ordering (hard-demoted first, then selection age) still decides which retained servers go. Private servers are not Lantern servers and are unaffected.

This is a client-side guard — the server can still offer more, and the client keeps the best subset.

## Tests

`TestClientHoldsNoMoreThanTheCapAfterAnUpdate` asserts the invariant that actually broke: the **total** a client is left holding after an update, not just what it retained. Verified it fails without the fix, reproducing the production number exactly:

```
client would hold 120 servers, over the 30 cap
```

`go build -tags with_clash_api ./...`, `go vet`, and `go test -race ./backend/` all clean.

## Worth a look before merge

30 is what we agreed as the target. It is a behavioural change for users who currently get 120 — fewer servers to fail over to, so it is worth a sanity check that the bandit still has enough choice in hostile regions, where more outbounds may matter more than memory. Happy to make it platform-conditional (tight on iOS, looser elsewhere) if that trade reads better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkKS8hGeHM5g4BDPvxcamg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Limited clients to a maximum of 30 configured servers.
  - Ensured oversized server configurations retain the preferred entries within the limit.
  - Preserved private server availability without applying the cap.

- **Tests**
  - Added coverage for oversized, exact-limit, undersized, and empty server configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->