### PR TITLE
peer: report active client count on heartbeat

### DIFF
--- a/peer/api.go
+++ b/peer/api.go
@@ -30,6 +30,18 @@ type LifecycleRequest struct {
 	RouteID string `json:"route_id"`
 }
 
+// HeartbeatRequest is LifecycleRequest plus the peer's current load. Separate
+// from LifecycleRequest so verify and deregister, which have no load to
+// report, don't carry a field that would read as "zero clients".
+type HeartbeatRequest struct {
+	RouteID string `json:"route_id"`
+	// ActiveClients counts distinct remote IPs with at least one open
+	// connection, not connections: samizdat multiplexes many H2 streams over
+	// one TCP conn, and a client may hold several, so a connection count would
+	// overstate how many people are actually being helped.
+	ActiveClients int `json:"active_clients"`
+}
+
 // APIError carries the server's HTTP status and body. Callers map specific
 // statuses to user-facing errors (404 → not registered, 422 → not reachable
 // from the public internet, 503 → feature off).
@@ -77,11 +89,20 @@ func (a *API) Verify(ctx context.Context, routeID string) error {
 	return nil
 }
 
-// Heartbeat extends the peer route's TTL. The server owner-gates via
+// Heartbeat extends the peer route's TTL and reports how many distinct client
+// devices are currently connected. The server owner-gates via
 // X-Lantern-Device-Id, so a leaked route_id can't be used by another device
 // to keep the registration alive.
-func (a *API) Heartbeat(ctx context.Context, routeID string) error {
-	if err := a.do(ctx, http.MethodPost, "/peer/heartbeat", LifecycleRequest{RouteID: routeID}, nil); err != nil {
+//
+// activeClients lets the server stop handing this peer to new clients once it
+// is carrying its share. It is reported rather than inferred because the
+// server has no other view of it: assignment records only exist for WireGuard
+// variants, and a peer serves samizdat. Reporting also self-corrects — a count
+// measured now cannot go stale the way an assignment log does when clients
+// simply disappear.
+func (a *API) Heartbeat(ctx context.Context, routeID string, activeClients int) error {
+	req := HeartbeatRequest{RouteID: routeID, ActiveClients: activeClients}
+	if err := a.do(ctx, http.MethodPost, "/peer/heartbeat", req, nil); err != nil {
 		return fmt.Errorf("heartbeat: %w", err)
 	}
 	return nil

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand/v2"
+	"net"
 	"runtime/debug"
 	"sync"
 	"sync/atomic"
@@ -166,6 +167,16 @@ type Client struct {
 	// Setting this flag before box.Close drops the cascade inline.
 	listenerDraining atomic.Bool
 
+	// connsByIP counts open connections per remote IP so ActiveClients can
+	// report distinct devices. Keyed by IP rather than the "ip:port" Source
+	// because samizdat multiplexes many H2 streams over one TCP conn and a
+	// client may open several, so counting events or ports would report more
+	// people than are actually being helped. Guarded by its own mutex: the
+	// peerconn listener fires from box's accept/close goroutines and must not
+	// contend with Start/Stop holding c.mu.
+	connsMu   sync.Mutex
+	connsByIP map[string]int
+
 	// externalPort / internalPort persist the port mapping picked at
 	// Start so the cred-rotation loop can re-register against the same
 	// (address, port) tuple without re-probing UPnP / re-mapping. The
@@ -284,6 +295,7 @@ func (c *Client) Start(ctx context.Context) (retErr error) {
 		// callbacks short-circuit even if SetListener races (see Stop).
 		c.listenerDraining.Store(true)
 		peerconn.SetListener(nil)
+		c.resetConnTracking()
 		if box != nil {
 			_ = box.Close()
 		}
@@ -414,6 +426,7 @@ func (c *Client) Start(ctx context.Context) (retErr error) {
 		// per-connection breadcrumb.
 		slog.Debug("peer listener: forwarding connection event",
 			"state", state, "source", source)
+		c.trackConn(state, source)
 		events.Emit(ConnectionEvent{State: state, Source: source, Timestamp: time.Now().UnixMilli()})
 	})
 	slog.Info("peer listener: registered with peerconn", "route_id", regResp.RouteID)
@@ -532,6 +545,7 @@ func (c *Client) Stop(ctx context.Context) error {
 	// to release the listener closure's reference to this Client.
 	c.listenerDraining.Store(true)
 	peerconn.SetListener(nil)
+	c.resetConnTracking()
 
 	cancel()
 	<-done
@@ -593,6 +607,51 @@ func (c *Client) emitPhase(p Phase, errMsg string) {
 // heartbeatLoop closes done on exit so Stop can wait for the loop before
 // tearing down resources. The channel is passed in rather than read off the
 // Client because Stop nils c.runDone before waiting on its local copy.
+// trackConn maintains the per-IP open-connection tally behind ActiveClients.
+// A -1 for an IP with no recorded connection is ignored rather than allowed to
+// go negative: peerconn is process-wide and a disconnect for a connection
+// accepted before this Client registered its listener can still arrive.
+func (c *Client) trackConn(state int, source string) {
+	ip, _, err := net.SplitHostPort(source)
+	if err != nil {
+		ip = source
+	}
+	c.connsMu.Lock()
+	defer c.connsMu.Unlock()
+	if c.connsByIP == nil {
+		c.connsByIP = make(map[string]int)
+	}
+	switch {
+	case state > 0:
+		c.connsByIP[ip]++
+	case state < 0:
+		if n, ok := c.connsByIP[ip]; ok {
+			if n <= 1 {
+				delete(c.connsByIP, ip)
+			} else {
+				c.connsByIP[ip] = n - 1
+			}
+		}
+	}
+}
+
+// ActiveClients reports how many distinct remote IPs currently hold at least
+// one connection. Reported to the server on each heartbeat so it can stop
+// assigning new clients to a peer that is already carrying its share.
+func (c *Client) ActiveClients() int {
+	c.connsMu.Lock()
+	defer c.connsMu.Unlock()
+	return len(c.connsByIP)
+}
+
+// resetConnTracking drops the tally on teardown so a subsequent Start doesn't
+// inherit connections belonging to the previous session's box.
+func (c *Client) resetConnTracking() {
+	c.connsMu.Lock()
+	defer c.connsMu.Unlock()
+	c.connsByIP = nil
+}
+
 func (c *Client) heartbeatLoop(ctx context.Context, interval time.Duration, done chan struct{}) {
 	defer close(done)
 	t := time.NewTicker(interval)
@@ -609,7 +668,7 @@ func (c *Client) heartbeatLoop(ctx context.Context, interval time.Duration, done
 				return
 			}
 			hbCtx, cancel := context.WithTimeout(ctx, c.cfg.HeartbeatTimeout)
-			err := c.cfg.API.Heartbeat(hbCtx, routeID)
+			err := c.cfg.API.Heartbeat(hbCtx, routeID, c.ActiveClients())
 			cancel()
 			if err != nil {
 				// A single transient blip shouldn't kill the registration —

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -618,6 +618,16 @@ func (c *Client) trackConn(state int, source string) {
 	}
 	c.connsMu.Lock()
 	defer c.connsMu.Unlock()
+	// Re-check the drain flag here, not just in the listener wrapper. A
+	// callback that passed the wrapper's check before Stop set the flag can
+	// reach this point after resetConnTracking has already cleared the map,
+	// repopulating it and leaking a stale count into the next Start. Checking
+	// under connsMu is what makes this airtight rather than merely narrower:
+	// Stop sets the flag before taking connsMu to reset, so any call that
+	// acquires the lock after the reset necessarily observes the flag.
+	if c.listenerDraining.Load() {
+		return
+	}
 	if c.connsByIP == nil {
 		c.connsByIP = make(map[string]int)
 	}

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -1050,7 +1050,7 @@ func TestAPI_ForwardsCommonHeaders(t *testing.T) {
 	_, err := api.Register(ctx, RegisterRequest{ExternalIP: "203.0.113.42", ExternalPort: 5698, InternalPort: 35698})
 	require.NoError(t, err)
 	require.NoError(t, api.Verify(ctx, "00000000-0000-0000-0000-000000000123"))
-	require.NoError(t, api.Heartbeat(ctx, "00000000-0000-0000-0000-000000000123"))
+	require.NoError(t, api.Heartbeat(ctx, "00000000-0000-0000-0000-000000000123", 0))
 	require.NoError(t, api.Deregister(ctx, "00000000-0000-0000-0000-000000000123"))
 
 	for _, path := range []string{"/peer/register", "/peer/verify", "/peer/heartbeat", "/peer/deregister"} {
@@ -1188,4 +1188,61 @@ func TestClient_RotationRejectsLaunchCfgMissingAbuseRules(t *testing.T) {
 	assert.True(t, c.IsActive(), "the peer must stay active after a rejected rotation")
 	assert.Positive(t, srv.deregisterCount.Load(),
 		"the orphan route created for the rejected rotation must be deregistered")
+}
+
+// TestTrackConn_CountsDistinctIPsNotConnections pins the reason ActiveClients
+// keys on IP: samizdat multiplexes many H2 streams over one TCP conn and a
+// client may hold several, so counting events would report more people helped
+// than there are people.
+func TestTrackConn_CountsDistinctIPsNotConnections(t *testing.T) {
+	c := &Client{}
+
+	c.trackConn(1, "203.0.113.7:44001")
+	c.trackConn(1, "203.0.113.7:44002")
+	c.trackConn(1, "203.0.113.7:44003")
+	assert.Equal(t, 1, c.ActiveClients(), "one device with three connections is one client")
+
+	c.trackConn(1, "198.51.100.9:55001")
+	assert.Equal(t, 2, c.ActiveClients())
+
+	// The device stays counted until its LAST connection closes.
+	c.trackConn(-1, "203.0.113.7:44001")
+	c.trackConn(-1, "203.0.113.7:44002")
+	assert.Equal(t, 2, c.ActiveClients(), "still holding one connection")
+	c.trackConn(-1, "203.0.113.7:44003")
+	assert.Equal(t, 1, c.ActiveClients())
+}
+
+// TestTrackConn_IgnoresUnmatchedClose guards the count against going negative.
+// peerconn is process-wide, so a close for a connection accepted before this
+// Client registered its listener can still arrive.
+func TestTrackConn_IgnoresUnmatchedClose(t *testing.T) {
+	c := &Client{}
+
+	c.trackConn(-1, "203.0.113.7:44001")
+	assert.Equal(t, 0, c.ActiveClients())
+
+	c.trackConn(1, "203.0.113.7:44001")
+	c.trackConn(-1, "203.0.113.7:44001")
+	c.trackConn(-1, "203.0.113.7:44001")
+	assert.Equal(t, 0, c.ActiveClients(), "an extra close must not drive the tally below zero")
+
+	c.trackConn(1, "198.51.100.9:55001")
+	assert.Equal(t, 1, c.ActiveClients(), "and must not corrupt later counting")
+}
+
+// TestResetConnTracking_ClearsAcrossSessions covers Stop → Start: the new
+// session's box has its own connections, so inheriting the old tally would
+// report load that no longer exists.
+func TestResetConnTracking_ClearsAcrossSessions(t *testing.T) {
+	c := &Client{}
+	c.trackConn(1, "203.0.113.7:44001")
+	c.trackConn(1, "198.51.100.9:55001")
+	require.Equal(t, 2, c.ActiveClients())
+
+	c.resetConnTracking()
+	assert.Equal(t, 0, c.ActiveClients())
+
+	c.trackConn(1, "203.0.113.7:44001")
+	assert.Equal(t, 1, c.ActiveClients(), "tracking still works after a reset")
 }

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -1246,3 +1246,28 @@ func TestResetConnTracking_ClearsAcrossSessions(t *testing.T) {
 	c.trackConn(1, "203.0.113.7:44001")
 	assert.Equal(t, 1, c.ActiveClients(), "tracking still works after a reset")
 }
+
+// TestTrackConn_DropsCountsWhileDraining covers the race the drain flag exists
+// for. A peerconn callback that passed the listener wrapper's check before Stop
+// set the flag can still reach trackConn after resetConnTracking cleared the
+// map; without a second check under connsMu it would repopulate the map and
+// leak a stale count into the next Start.
+func TestTrackConn_DropsCountsWhileDraining(t *testing.T) {
+	c := &Client{}
+	c.trackConn(1, "203.0.113.7:44001")
+	require.Equal(t, 1, c.ActiveClients())
+
+	// Teardown ordering: flag first, then the reset.
+	c.listenerDraining.Store(true)
+	c.resetConnTracking()
+
+	// The straggler callback lands here.
+	c.trackConn(1, "198.51.100.9:55001")
+	assert.Equal(t, 0, c.ActiveClients(),
+		"a callback outliving Stop must not repopulate the tally")
+
+	// A subsequent Start clears the flag and counting resumes.
+	c.listenerDraining.Store(false)
+	c.trackConn(1, "198.51.100.9:55001")
+	assert.Equal(t, 1, c.ActiveClients())
+}


### PR DESCRIPTION
Replaces the approach in getlantern/lantern-cloud#3150, which was closed as a no-op. Pairs with the lantern-cloud follow-up that consumes this.

## Why the peer has to report it

A residential peer becomes an EXP3 arm and is handed to clients with nothing bounding its load — a lone volunteer absorbs a whole track. A tester with working UPnP saw continuous connect/disconnect churn and the app crashed.

Capping that server-side needs a load figure, and **the server has none**. Assignment records live in `singbox_protocols_auth_mappings`, which `generateAndStoreSingboxAuthMapping` only writes when `pcfg.IsWireguard(variant)` — and a peer serves samizdat (`peerTrackName = "samizdat-peer-1"`, and the register handler rejects any non-samizdat protocol). No row is ever written for a peer route, so any count derived from that table is permanently zero. That is exactly how #3150 shipped a cap that could never fire.

The peer, by contrast, already observes every connection through its `peerconn` listener.

A measured count is also the right shape for the question. **Clients are ephemeral**: a peer assigned five clients yesterday is idle today, and an assignment log would still be holding those slots. A number sampled now can't go stale that way.

## What changed

`Heartbeat` gains an `activeClients` argument, carried in a new `HeartbeatRequest`. Kept separate from `LifecycleRequest` so verify and deregister don't ship a field that would read as "zero clients".

The count is **distinct remote IPs holding at least one connection**, not connections. samizdat multiplexes many H2 streams over one TCP conn and a client may hold several, so counting events would report more people helped than there are people. The tally:

- ignores a close for an IP it never saw open — `peerconn` is process-wide, so a disconnect for a connection accepted before this `Client` registered its listener can still arrive, and an unguarded decrement would drive the count negative
- resets on teardown, at both `SetListener(nil)` sites, so a restart doesn't inherit the previous session's load
- lives under its own mutex, since the listener fires from box's accept/close goroutines and must not contend with `Start`/`Stop` holding `c.mu`

## Testing

`go test -race ./peer/...` passes, including three new tests covering the parts that would silently misreport:

- three connections from one IP count as **one** client, and the client stays counted until its **last** connection closes
- an unmatched close is ignored, and doesn't corrupt later counting
- teardown clears the tally, and tracking still works afterwards

## Note on trust

The figure is self-reported, so it bounds load for honest peers only — one that under-reports attracts more clients than its share. That is the right trade here: the cap protects volunteers from being swamped rather than defending against them, and a peer that wants more traffic can simply keep sharing. The server clamps the upper end so a peer can't push a nonsense value into the catalog filter.
