### PR TITLE
issue: bound the bytes the archiver holds in memory

### DIFF
--- a/issue/archive.go
+++ b/issue/archive.go
@@ -11,14 +11,23 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/getlantern/radiance/common"
 )
 
 const (
 	// maxLogReadFactor bounds how much uncompressed log to read toward an archive:
 	// maxArchiveSize * maxLogReadFactor bytes. Logs compress by at most roughly this
 	// factor, so reading more than this can never be needed to reach the compressed
-	// size budget.
+	// size budget. That is a compression bound, not a memory one — see
+	// maxMobileInputBytes.
 	maxLogReadFactor int64 = 20
+	// maxMobileInputBytes caps the uncompressed bytes the archiver holds at once on
+	// mobile. maxLogReadFactor alone permits 19.5 MB * 20 = 390 MB per file, no
+	// constraint at all inside the iOS network extension's fatal 50 MB jetsam cap:
+	// reporting an issue while connected read 42 MB of logs and the extension was
+	// killed mid-archive, dropping the tunnel. engineering#3820.
+	maxMobileInputBytes int64 = 8 * 1024 * 1024
 	// backupTimeFormat matches the timestamp format used in rotated backup
 	// filenames: "<log-name>-<timestamp>.log.gz".
 	backupTimeFormat = "2006-01-02T15-04-05.000"
@@ -38,8 +47,16 @@ func buildIssueArchive(logDir string, additionalFiles []string, maxSize int64) (
 	var primaryLogData []byte
 	var secondaryLogs []extraFile
 
+	// One budget shared across every read below, so the archiver's peak is bounded
+	// by the platform rather than by the sum of whatever happens to be on disk.
+	// Reading the tail means a smaller budget costs history, not correctness.
+	budget := archiveInputBudget(maxSize)
 	for _, lf := range logFiles {
-		data, err := snapshotLogFile(lf, maxSize)
+		if budget <= 0 {
+			slog.Warn("archive input budget exhausted, skipping log", "path", lf)
+			continue
+		}
+		data, err := snapshotLogFile(lf, budget)
 		if err != nil {
 			slog.Warn("unable to snapshot log file", "path", lf, "error", err)
 			continue
@@ -47,6 +64,7 @@ func buildIssueArchive(logDir string, additionalFiles []string, maxSize int64) (
 		if len(data) == 0 {
 			continue
 		}
+		budget -= int64(len(data))
 		if filepath.Base(lf) == logArchiveName {
 			primaryLogData = data
 		} else {
@@ -58,22 +76,36 @@ func buildIssueArchive(logDir string, additionalFiles []string, maxSize int64) (
 	}
 
 	attachments := readExtraFiles(additionalFiles)
+	for _, a := range attachments {
+		budget -= int64(len(a.data))
+	}
 
 	primaryPath := filepath.Join(logDir, logArchiveName)
-	primaryLogData = prependMostRecentBackup(primaryPath, primaryLogData, maxSize)
+	primaryLogData = prependMostRecentBackup(primaryPath, primaryLogData, budget)
 
 	return fitArchive(primaryLogData, secondaryLogs, attachments, maxSize)
 }
 
+// archiveInputBudget is the total uncompressed bytes the archiver may hold. On
+// mobile the process ceiling matters more than archive completeness.
+func archiveInputBudget(maxSize int64) int64 {
+	budget := maxSize * maxLogReadFactor
+	if common.IsMobile() && budget > maxMobileInputBytes {
+		return maxMobileInputBytes
+	}
+	return budget
+}
+
 // prependMostRecentBackup prepends the newest rotated gzip backup, if present,
 // so a mid-session rotation does not lose earlier log history.
-func prependMostRecentBackup(primaryLogPath string, current []byte, maxArchiveSize int64) []byte {
+// remaining is what is left of the archiver's shared input budget; the backup is
+// decompressed into memory, so it has to draw from the same pool as the live logs.
+func prependMostRecentBackup(primaryLogPath string, current []byte, remaining int64) []byte {
 	backupPath, ok := findMostRecentCompressedBackup(primaryLogPath)
 	if !ok {
 		return current
 	}
 
-	remaining := maxArchiveSize*maxLogReadFactor - int64(len(current))
 	if remaining <= 0 {
 		return current
 	}
@@ -177,9 +209,9 @@ func globFiles(dir, pattern string) []string {
 	return matches
 }
 
-// snapshotLogFile opens the log file, records its current size, and reads the tail
-// up to a reasonable cap.
-func snapshotLogFile(logPath string, maxCompressed int64) ([]byte, error) {
+// snapshotLogFile opens the log file, records its current size, and reads at most
+// maxRead bytes of the tail.
+func snapshotLogFile(logPath string, maxRead int64) ([]byte, error) {
 	f, err := os.Open(logPath)
 	if err != nil {
 		return nil, err
@@ -196,7 +228,6 @@ func snapshotLogFile(logPath string, maxCompressed int64) ([]byte, error) {
 		return nil, nil
 	}
 
-	maxRead := maxCompressed * maxLogReadFactor
 	readSize := size
 	if readSize > maxRead {
 		readSize = maxRead

--- a/issue/archive_test.go
+++ b/issue/archive_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/getlantern/radiance/common"
 )
 
 func TestSnapshotLogFile(t *testing.T) {
@@ -30,12 +32,13 @@ func TestSnapshotLogFile(t *testing.T) {
 		dir := t.TempDir()
 		logPath := filepath.Join(dir, "test.log")
 
-		// maxCompressed=100 → maxRead = 100*20 = 2000
-		// Write 5000 bytes so the file exceeds the cap.
+		// The cap is bytes now, not a compressed-size budget scaled up by
+		// maxLogReadFactor: the archiver's peak has to be bounded by what the
+		// process can actually hold.
 		full := bytes.Repeat([]byte("X"), 5000)
 		require.NoError(t, os.WriteFile(logPath, full, 0644))
 
-		data, err := snapshotLogFile(logPath, 100)
+		data, err := snapshotLogFile(logPath, 2000)
 		require.NoError(t, err)
 		assert.Equal(t, 2000, len(data))
 		// Should be the tail of the file.
@@ -332,6 +335,31 @@ func TestAddExtrasGreedily(t *testing.T) {
 		require.Len(t, entries, 1)
 		assert.Equal(t, logArchiveName, entries[0].name)
 	})
+}
+
+// The archiver reads whole files into memory. maxLogReadFactor bounds reads
+// against the compression ratio (19.5 MB * 20 = 390 MB), which is no memory
+// bound at all: on iOS this runs inside a network extension with a fatal 50 MB
+// cap, and reporting an issue while connected read 42 MB of logs and killed the
+// tunnel. engineering#3820. Guard the total the archiver is willing to hold.
+func TestArchiveInputBudgetIsBoundedOnMobile(t *testing.T) {
+	const archiveSize = int64(19.5 * 1024 * 1024) // the real maxTotalAttachmentBytes
+
+	unbounded := archiveSize * maxLogReadFactor
+	require.Greater(t, unbounded, int64(300*1024*1024),
+		"sanity: the compression-derived bound really is this loose")
+
+	// archiveInputBudget keys off common.IsMobile(), a compile-time GOOS check, so
+	// assert the branch that applies to the platform the tests run on.
+	got := archiveInputBudget(archiveSize)
+	if common.IsMobile() {
+		assert.LessOrEqual(t, got, maxMobileInputBytes,
+			"mobile must not let the archiver hold more than the process can survive")
+	} else {
+		assert.Equal(t, unbounded, got, "desktop keeps the compression-derived bound")
+	}
+	assert.LessOrEqual(t, maxMobileInputBytes, int64(16*1024*1024),
+		"the mobile cap has to leave room under a 50 MB process ceiling")
 }
 
 func TestBuildIssueArchive(t *testing.T) {


### PR DESCRIPTION
Submitting an issue report from the iOS app **while the VPN is connected** killed the tunnel. Closes the immediate crash in getlantern/engineering#3820.

## What was happening

The extension was healthy one second before the submit — this is the archiver, not tunnel memory growth:

```
16:43:15.578  extension healthy — footprint 31.25 MB, available 18.75 MB
16:43:16.142  POST /issue arrives
              ...per-second memory samples stop entirely...
16:43:16      app: Error reporting issue: ipc request POST /issue failed
16:43:21      Disconnecting / Disconnected      <-- unprompted
16:43:22      retry succeeds (tunnel down, so the *app* builds the archive)
```

Reproduced twice on iPhone 16 / iOS 26.6.

## Why

`buildIssueArchive` reads whole files into memory and zips into a `bytes.Buffer`. `maxLogReadFactor` looks like a bound but is a **compression** bound, not a memory one — `maxArchiveSize * 20` is **390 MB per file** — and it was applied per file rather than across the set. The reproducing device had **42 MB** in the log dir:

| file | size |
|---|---|
| `lantern.log` | 26 MB |
| `lantern_ios.log` | 10 MB |
| attachments | ~68 KB |

42 MB of reads plus the zip buffer, on top of a ~31 MB working set, inside a process with a **fatal 50 MB** jetsam cap.

## The change

One budget threaded through every read, so the peak is bounded by the platform rather than by whatever happens to be on disk, capped at **8 MB on mobile**. Reading the tail means a smaller budget costs history, not correctness. `prependMostRecentBackup` now draws from the same pool, since it decompresses into memory too.

`snapshotLogFile`'s second parameter is now bytes rather than a compressed-size budget to scale up; its existing test moves with it.

## Scope — deliberately partial

This **bounds** the archiver. It does not stop the archive being built inside the extension, which is the better fix: `IssueReporter` only needs an HTTP client and `settings.LogPathKey`, and on iOS that log dir is the **shared App Group container** the app can read directly. Moving report-building to the app removes the 50 MB constraint entirely. Tracked in engineering#3820, and worth doing next — this is the stop-the-bleeding half.

Streaming the archive to a temp file instead of buffering is the other half. It is a real refactor (`fitArchive` buffers deliberately, because it needs the *compressed* size to decide how much of the primary log to keep, and `issue.go` then `proto.Marshal`s the bytes, duplicating them again), so it wants its own PR rather than being rushed in alongside this.

## Tests

`TestArchiveInputBudgetIsBoundedOnMobile` asserts the budget is actually bounded on mobile and documents how loose the compression-derived one is (>300 MB). The updated `TestSnapshotLogFile` covers the byte-cap semantics.

I wrote and then **deleted** a `TestBuildIssueArchiveStopsReadingAtTheBudget` — it passed with and without the fix, because it measured the zip output (already truncated by `fitArchive`) rather than bytes read into memory. Peak read memory is not observable from the archive output, so a test asserting it there is theatre. Better to say so than ship a guard that does not guard.

`go build -tags with_clash_api`, `gofmt`, and `go test -race ./issue/` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkKS8hGeHM5g4BDPvxcamg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Log archives now use a shared input limit across snapshots, attachments, and rotated backups.
  - Mobile devices limit archived log data to 8 MiB, helping prevent excessive resource usage.
  - When the limit is reached, additional logs are skipped.
  - Rotated backups now receive only the remaining available archive capacity.
  - Desktop archiving continues to respect its existing compression-based limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->