### PR TITLE
deps: bump lantern-box to v0.0.112 for auto-select probe optimization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/getlantern/domainfront v0.0.0-20260722204513-8c1f8acfa715
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3
 	github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464
-	github.com/getlantern/lantern-box v0.0.111
+	github.com/getlantern/lantern-box v0.0.112
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb

--- a/go.sum
+++ b/go.sum
@@ -248,6 +248,8 @@ github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464 h1:vZtMtKDsGO0
 github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464/go.mod h1:ZEPFiB6rH6MtMN1O7b5gE+LJpCsRFzAn4u8lbIxHh3w=
 github.com/getlantern/lantern-box v0.0.111 h1:1DNrhaxpn9mRE7qMX/efi1I4wYx4FoBh7stVFIEPcYU=
 github.com/getlantern/lantern-box v0.0.111/go.mod h1:avZOnXNHLNT/d/Mrkjqn8i02HB1C805Dk7EtcWYq9lw=
+github.com/getlantern/lantern-box v0.0.112 h1:GuXFs4ZFFszGkw2jX6OfC4nV6PwHlMLxJG48I931pjk=
+github.com/getlantern/lantern-box v0.0.112/go.mod h1:b+gDOk1Wgd/cEL4Q0cSQJAfZuNQPCqIDwNhxXwLPg8g=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395/go.mod h1:3JpJgwi4KEI6rS9loOAvcBp+F2jP65d0tTg2GQcTPBU=
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 h1:3BwvWj0JZzFEvNNiMhCu4bf60nqcIuQpTYb00Ezm1ag=


### PR DESCRIPTION
Picks up getlantern/lantern-box#298 (merged) — freshness-filtered external probes with a bounded worker pool.

## Device measurement

Built with the PR and tested on an iPhone 16 / iOS 26.6, six connect/disconnect cycles per build, same phone and config, ~40 minutes apart:

| build | peak under cycling | steady |
|---|---|---|
| without #298 | **44.33 MB** | ~31 MB |
| **with #298** | **38.88 MB** | ~31 MB |

**5.45 MB off the peak (~12%)**, moving headroom from ~5.7 MB to ~11 MB against the extension's fatal 50 MB jetsam cap. Steady state was already healthy and is unchanged — the win is in the churn case, which is exactly where the jetsam kills happened.

Verified the pinned module carries the change (`v0.0.112` points at the #298 merge commit `1c72b13ce99e`, and `protocol/group/mutableautoselect.go` has the freshness/worker-pool markers).

Caveat worth stating: single run per build, and peak varies run to run — I have seen 37.9–46.1 MB on unchanged code. The direction matches what the change does, but a repeat run would firm it up.

## Note

The client still receives **120 outbounds** (engineering#3816, radiance#599), so this measurement is against that. The two changes address different halves of the same problem and should compound rather than overlap.

`go build -tags with_clash_api ./vpn/... ./backend/... ./kindling/...` and `go test ./vpn/ ./backend/` clean. `cmd/lantern` does not compile, but that is **pre-existing on main** — identical `ipc.NewClient` signature failure with and without this bump, worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkKS8hGeHM5g4BDPvxcamg