### PR TITLE
fix(issue): assemble mobile issue reports in the calling process

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -437,7 +437,9 @@ type issueReportMetadata struct {
 // report. It is safe to call with a nil or partially initialized backend.
 func (r *LocalBackend) buildIssueReportMetadata() issueReportMetadata {
 	meta := issueReportMetadata{
-		country: settings.GetString(settings.CountryCodeKey),
+		country:            settings.GetString(settings.CountryCodeKey),
+		deviceID:           settings.GetString(settings.DeviceIDKey),
+		splitTunnelEnabled: settings.GetBool(settings.SplitTunnelKey),
 	}
 
 	if r == nil {
@@ -449,9 +451,10 @@ func (r *LocalBackend) buildIssueReportMetadata() issueReportMetadata {
 	} else {
 		meta.reporter = issue.NewIssueReporter(kindling.HTTPClient())
 	}
-	meta.deviceID = r.deviceID
+	if r.deviceID != "" {
+		meta.deviceID = r.deviceID
+	}
 
-	// get country from the config returned by the backend
 	if r.confHandler != nil {
 		if cfg, err := r.confHandler.GetConfig(); err != nil {
 			slog.Warn("failed to get config", "error", err)
@@ -469,13 +472,17 @@ func (r *LocalBackend) buildIssueReportMetadata() issueReportMetadata {
 	return meta
 }
 
-// ReportIssue allows the user to report an issue with the application. It collects relevant
-// information about the user's environment such as country, device ID, user ID, subscription level,
-// and locale, and log files to include in the report.
+// ReportIssue sends an issue report with current metadata and diagnostic attachments.
 //
-// ReportIssue is safe to call with a nil receiver.
-func (r *LocalBackend) ReportIssue(issueType issue.IssueType, description, email string, additionalAttachments []string, attachments []*issue.Attachment) error {
-	ctx, span := otel.Tracer(tracerName).Start(context.Background(), "report_issue")
+// ReportIssue is safe to call with a nil receiver; in that case it uses settings-backed metadata.
+func (r *LocalBackend) ReportIssue(
+	ctx context.Context,
+	issueType issue.IssueType,
+	description, email string,
+	additionalAttachments []string,
+	attachments []*issue.Attachment,
+) error {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "report_issue")
 	defer span.End()
 
 	meta := r.buildIssueReportMetadata()

--- a/backend/radiance_test.go
+++ b/backend/radiance_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/getlantern/radiance/common/settings"
 	"github.com/getlantern/radiance/config"
 	"github.com/getlantern/radiance/internal"
 	"github.com/getlantern/radiance/log"
@@ -334,4 +335,20 @@ func TestConnectVPN_ShedsConcurrentCalls(t *testing.T) {
 	// The reject path must not release the guard; only the holder unlocks it.
 	r.connectMu.Unlock()
 	assert.True(t, r.connectMu.TryLock())
+}
+
+func TestBuildIssueReportMetadataFallsBackToSettings(t *testing.T) {
+	settings.Reset()
+	t.Cleanup(settings.Reset)
+	require.NoError(t, settings.InitSettings(t.TempDir()))
+	require.NoError(t, settings.Set(settings.CountryCodeKey, "IR"))
+	require.NoError(t, settings.Set(settings.DeviceIDKey, "device-123"))
+	require.NoError(t, settings.Set(settings.SplitTunnelKey, true))
+
+	meta := (*LocalBackend)(nil).buildIssueReportMetadata()
+
+	assert.Equal(t, "IR", meta.country)
+	assert.Equal(t, "device-123", meta.deviceID, "device ID must survive a backendless report")
+	assert.True(t, meta.splitTunnelEnabled, "split-tunnel state must survive a backendless report")
+	assert.NotNil(t, meta.reporter, "a reporter is always needed to upload the report")
 }

--- a/common/settings/settings.go
+++ b/common/settings/settings.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -267,16 +268,29 @@ func userLevelInJSON(contents []byte) string {
 	return s.UserLevel
 }
 
-func loadSettings(path string) error {
+// loadSettings applies the file to the in-memory settings.
+//
+// Koanf parses before taking its write lock, so malformed files leave the live settings untouched.
+// Without opts the file merges over current settings; pass replaceAll when omitted keys must be
+// dropped.
+func loadSettings(path string, opts ...koanf.Option) error {
 	contents, err := atomicfile.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("loading settings: %w", err)
 	}
-	kk := koanf.New(".")
-	if err := kk.Load(rawbytes.Provider(contents), json.Parser()); err != nil {
+	if err := k.k.Load(rawbytes.Provider(contents), json.Parser(), opts...); err != nil {
 		return fmt.Errorf("parsing settings: %w", errors.Join(errParseSettings, err))
 	}
-	k.k = kk
+	return nil
+}
+
+// replaceAll makes a koanf load overwrite rather than merge, so keys the source omits are dropped.
+//
+// Koanf re-flattens dest after this returns, so dest must be mutated in place; replacing the map
+// header would silently lose the load.
+func replaceAll(src, dest map[string]any) error {
+	clear(dest)
+	maps.Copy(dest, src)
 	return nil
 }
 
@@ -436,6 +450,27 @@ func Reset() {
 	defer k.mu.Unlock()
 	k.k = koanf.New(".")
 	k.initialized = false
+}
+
+// Reload re-reads the settings file, adopting values written by another process.
+//
+// Mobile keeps the tunnel in a separate process that persists to the same file, so long-lived
+// callers must reload before using cross-process metadata. The file supersedes memory rather than
+// merging over it, so keys removed by another process do not linger. A missing file is not an
+// error, and failed reloads leave the current settings untouched.
+func Reload() error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if !k.initialized {
+		return errors.New("settings not initialized")
+	}
+	switch err := loadSettings(k.filePath, koanf.WithMergeFunc(replaceAll)); {
+	case errors.Is(err, fs.ErrNotExist):
+		return nil
+	case err != nil:
+		return fmt.Errorf("reloading settings: %w", err)
+	}
+	return nil
 }
 
 func IsPro() bool {

--- a/common/settings/settings_test.go
+++ b/common/settings/settings_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -501,4 +502,103 @@ Token: tok
 		assert.Equal(t, `{"user_level": "expired"}`, string(got),
 			"canonical with non-ENOENT read error should be left alone")
 	})
+}
+
+func TestReload(t *testing.T) {
+	initSettingsAt := func(t *testing.T, contents string) string {
+		t.Helper()
+		Reset()
+		t.Cleanup(Reset)
+		dir := t.TempDir()
+		path := filepath.Join(dir, settingsFileName)
+		require.NoError(t, os.WriteFile(path, []byte(contents), 0644))
+		require.NoError(t, InitSettings(dir))
+		return path
+	}
+
+	t.Run("adopts values written by another process", func(t *testing.T) {
+		path := initSettingsAt(t, `{"country_code": "US", "device_id": "old-device"}`)
+		require.Equal(t, "US", GetString(CountryCodeKey))
+
+		require.NoError(t, os.WriteFile(path, []byte(`{"country_code": "IR", "device_id": "new-device"}`), 0644))
+		require.Equal(t, "US", GetString(CountryCodeKey), "cached value is served until a reload")
+
+		require.NoError(t, Reload())
+		assert.Equal(t, "IR", GetString(CountryCodeKey))
+		assert.Equal(t, "new-device", GetString(DeviceIDKey))
+	})
+
+	t.Run("keeps this process's own writes", func(t *testing.T) {
+		initSettingsAt(t, `{"country_code": "US"}`)
+		require.NoError(t, Set(DeviceIDKey, "written-here"))
+
+		require.NoError(t, Reload())
+		assert.Equal(t, "written-here", GetString(DeviceIDKey), "Set persists before returning, so a reload reads it back")
+	})
+
+	t.Run("leaves settings intact when the file is unreadable", func(t *testing.T) {
+		path := initSettingsAt(t, `{"country_code": "US"}`)
+		require.NoError(t, os.WriteFile(path, []byte(`{invalid json}`), 0644))
+
+		assert.Error(t, Reload())
+		assert.Equal(t, "US", GetString(CountryCodeKey), "a failed reload must not wipe live settings")
+	})
+
+	t.Run("adopts deletions", func(t *testing.T) {
+		path := initSettingsAt(t, `{"country_code": "US", "user_id": "user-1"}`)
+		require.Equal(t, "user-1", GetString(UserIDKey))
+
+		require.NoError(t, os.WriteFile(path, []byte(`{"country_code": "IR"}`), 0644))
+		require.NoError(t, Reload())
+
+		assert.Equal(t, "IR", GetString(CountryCodeKey), "changed values are adopted")
+		assert.Empty(t, GetString(UserIDKey), "a removed key is dropped, not kept")
+		assert.False(t, Exists(UserIDKey))
+	})
+
+	t.Run("missing file is not an error", func(t *testing.T) {
+		path := initSettingsAt(t, `{"country_code": "US"}`)
+		require.NoError(t, os.Remove(path))
+
+		assert.NoError(t, Reload())
+		assert.Equal(t, "US", GetString(CountryCodeKey))
+	})
+
+	t.Run("errors when uninitialized", func(t *testing.T) {
+		Reset()
+		t.Cleanup(Reset)
+		assert.Error(t, Reload())
+	})
+}
+
+func TestReloadRacesNothing(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+	dir := t.TempDir()
+	path := filepath.Join(dir, settingsFileName)
+	require.NoError(t, os.WriteFile(path, []byte(`{"country_code": "US"}`), 0644))
+	require.NoError(t, InitSettings(dir))
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = GetString(CountryCodeKey)
+					_ = GetBool(SplitTunnelKey)
+				}
+			}
+		}()
+	}
+	for range 50 {
+		require.NoError(t, Reload())
+	}
+	close(stop)
+	wg.Wait()
 }

--- a/ipc/client.go
+++ b/ipc/client.go
@@ -673,16 +673,10 @@ func (c *Client) RestoreSubscription(ctx context.Context, service account.Subscr
 // not need to be specified. attachments contains screenshot files sent as first-class multipart
 // attachments; callers may include up to [issue.MaxFirstClassAttachmentCount] files with a
 // combined size of [issue.MaxFirstClassAttachmentBytes] bytes.
+//
+// On mobile the report is assembled in this process to avoid pressuring the tunnel process.
 func (c *Client) ReportIssue(ctx context.Context, issueType issue.IssueType, description, email string, additionalAttachments []string, attachments []*issue.Attachment) error {
-	_, err := c.do(ctx, http.MethodPost, issueEndpoint,
-		IssueReportRequest{
-			IssueType:             issueType,
-			Description:           description,
-			Email:                 email,
-			AdditionalAttachments: additionalAttachments,
-			Attachments:           attachments,
-		})
-	return err
+	return c.reportIssue(ctx, issueType, description, email, additionalAttachments, attachments)
 }
 
 /////////////

--- a/ipc/client_mobile.go
+++ b/ipc/client_mobile.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/getlantern/radiance/backend"
 	"github.com/getlantern/radiance/common/settings"
+	"github.com/getlantern/radiance/issue"
 	rlog "github.com/getlantern/radiance/log"
 )
 
@@ -132,6 +134,25 @@ func (c *Client) do(ctx context.Context, method, endpoint string, body any) ([]b
 		}
 	}
 	return respBody, nil
+}
+
+// reportIssue assembles and sends the report in this process rather than over IPC.
+//
+// Building the archive reads logs into memory. On iOS the IPC peer can be the network extension,
+// which the OS may kill for a footprint spike; the UI process has the roomier budget and can read
+// the shared logs and settings without starting a backend.
+func (c *Client) reportIssue(ctx context.Context, issueType issue.IssueType, description, email string, additionalAttachments []string, attachments []*issue.Attachment) error {
+	if err := settings.Reload(); err != nil {
+		slog.Warn("Reporting issue with possibly stale settings", "error", err)
+	}
+
+	var be *backend.LocalBackend
+	c.mu.RLock()
+	if c.localapi != nil {
+		be = c.localapi.be.Load()
+	}
+	c.mu.RUnlock()
+	return be.ReportIssue(ctx, issueType, description, email, additionalAttachments, attachments)
 }
 
 // doLocal serves the request through the given in-process handler.

--- a/ipc/client_nonmobile.go
+++ b/ipc/client_nonmobile.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/getlantern/radiance/issue"
 	rlog "github.com/getlantern/radiance/log"
 )
 
@@ -28,6 +29,19 @@ func NewClient() *Client {
 // Close releases resources held by the client, including any local backend.
 func (c *Client) Close() {
 	c.http.CloseIdleConnections()
+}
+
+// reportIssue hands the report to the daemon, which owns the logs and live backend state.
+func (c *Client) reportIssue(ctx context.Context, issueType issue.IssueType, description, email string, additionalAttachments []string, attachments []*issue.Attachment) error {
+	_, err := c.do(ctx, http.MethodPost, issueEndpoint,
+		IssueReportRequest{
+			IssueType:             issueType,
+			Description:           description,
+			Email:                 email,
+			AdditionalAttachments: additionalAttachments,
+			Attachments:           attachments,
+		})
+	return err
 }
 
 // do executes an HTTP request with an optional JSON body and returns the raw response body. If

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -1192,7 +1192,7 @@ func (s *localapi) issueReportHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if err := s.backend(r.Context()).ReportIssue(req.IssueType, req.Description, req.Email, req.AdditionalAttachments, req.Attachments); err != nil {
+	if err := s.backend(r.Context()).ReportIssue(r.Context(), req.IssueType, req.Description, req.Email, req.AdditionalAttachments, req.Attachments); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
## Summary

Issue reports were being assembled inside the process running the tunnel. On mobile, `Client.do` tries the IPC socket first and only falls back in-process, so whenever the tunnel was up the archive was built by the tunnel process — on iOS a network extension, which the OS kills for a footprint spike. Building an archive reads whole log files into memory, and this happened exactly when a user is most likely to file a report ("the VPN isn't working").

Mobile now assembles and sends the report in the calling process, which is the only one with a UI to file from and already has everything the report needs. Desktop is unchanged — it still hands the report to the daemon, where there is no footprint ceiling.

## Changes

**`fix(issue): assemble mobile issue reports in the calling process`** (b8a6a83)

- `Client.ReportIssue` delegates to a build-tagged `reportIssue`. Mobile assembles locally; non-mobile keeps the existing IPC POST. The exported `ipc.Client.ReportIssue` signature is unchanged, so app callers are unaffected. The server's `issueEndpoint` handler is retained for desktop and the CLI.
- Issue metadata now defaults to persisted settings, so a report filed without a backend carries the same country, device ID and split-tunnel state as one filed with it. `LocalBackend.ReportIssue` is already documented nil-safe, so no backend is started just to file a report.
- New `settings.Reload`, so the calling process picks up what the tunnel process has written since startup. It replaces rather than merges (via `koanf.WithMergeFunc`), so a key removed with `Clear` — as logging out does — does not linger with a stale value. `InitSettings` still merges, which keeps in-memory defaults for keys an older settings file omits. A missing file is not an error, and a failed load leaves the current settings untouched.

## Bug Fixes

- **Cancellation was dropped on issue reports.** `LocalBackend.ReportIssue` rooted its own span at `context.Background()` and took no `ctx`, so the server path silently discarded the request context; moving mobile in-process would have extended that. `ctx` is now threaded through, which also makes the span a child of the caller's instead of a detached root. The report upload can be up to ~19.5 MB, so this is a real cancellation path.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added settings reload support so updated configuration can be applied without restarting.
  * Issue reports now include current country, device, and split-tunnel information when available.
  * Mobile issue reports are assembled using the current local configuration.

* **Bug Fixes**
  * Preserved existing settings when reloads fail and handled missing settings files safely.
  * Improved issue-report tracing by preserving the original request context.
  * Added safeguards for concurrent settings access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->