### PR TITLE
perf(vpn): reduce CPU and resident memory in connection paths

### DIFF
--- a/account/datacap.go
+++ b/account/datacap.go
@@ -92,8 +92,9 @@ func readSSE(ctx context.Context, body io.Reader) (<-chan sseEvent, func() error
 	go func() {
 		defer close(ch)
 		scanner := bufio.NewScanner(body)
-		buf := make([]byte, 0, 64*1024)
-		scanner.Buffer(buf, 1024*1024)
+		// Keep the long-lived scanner buffer near normal SSE event size
+		buf := make([]byte, 0, 4*1024)
+		scanner.Buffer(buf, 64*1024)
 
 		var evt sseEvent
 		for scanner.Scan() {

--- a/account/datacap.go
+++ b/account/datacap.go
@@ -92,9 +92,10 @@ func readSSE(ctx context.Context, body io.Reader) (<-chan sseEvent, func() error
 	go func() {
 		defer close(ch)
 		scanner := bufio.NewScanner(body)
-		// Keep the long-lived scanner buffer near normal SSE event size
+		// The initial buffer stays small to bound resident memory; the 1 MiB max still
+		// admits a rare oversized line rather than failing it.
 		buf := make([]byte, 0, 4*1024)
-		scanner.Buffer(buf, 64*1024)
+		scanner.Buffer(buf, 1024*1024)
 
 		var evt sseEvent
 		for scanner.Scan() {

--- a/telemetry/connections.go
+++ b/telemetry/connections.go
@@ -10,13 +10,22 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
+	"github.com/getlantern/radiance/common"
 	"github.com/getlantern/radiance/vpn"
 )
 
 // connEventBuffer sizes the channel used for buffered ConnClose events.
 // Sends are non-blocking; on overflow the event is dropped and counted rather than stalling
 // a connection close.
-const connEventBuffer = 4096
+//
+// Channel backing storage is allocated at make time; on mobile the smaller depth trades
+// counted drops for lower resident footprint.
+var connEventBuffer = func() int {
+	if common.IsMobile() {
+		return 256
+	}
+	return 4096
+}()
 
 // droppedFlushInterval is how often run folds the dropped-event count into its metric. The overflow
 // path only touches an atomic, so the metric trails by at most one interval.

--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -1,9 +1,7 @@
 package vpn
 
 import (
-	"bytes"
 	"context"
-	stdjson "encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -16,8 +14,6 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 
 	lcommon "github.com/getlantern/common"
 	box "github.com/getlantern/lantern-box"
@@ -476,32 +472,22 @@ func buildOptions(bOptions BoxOptions) (O.Options, error) {
 	// catch-all rule to ensure no fallthrough
 	opts.Route.Rules = append(opts.Route.Rules, catchAllBlockerRule())
 	slog.Debug("Finished building options", "env", common.Env())
-
-	span.AddEvent("finished building options", trace.WithAttributes(
-		attribute.String("options", string(writeBoxOptions(bOptions.BasePath, opts))),
-	))
+	writeBoxOptions(bOptions.BasePath, opts)
 	return opts, nil
 }
 
-// writeBoxOptions marshals the options as JSON and stores them in a file so we can debug them
-// we can ignore the errors here since the tunnel will error out anyway if something is wrong
-func writeBoxOptions(path string, opts O.Options) []byte {
+// writeBoxOptions marshals the options as JSON and writes them to a file. we can ignore
+// errors here since the tunnel will error out anyway if something is wrong
+func writeBoxOptions(path string, opts O.Options) {
 	buf, err := json.MarshalContext(box.BaseContext(), opts)
 	if err != nil {
-		slog.Warn("failed to marshal options while writing debug box options", slog.Any("error", err))
-		return nil
+		slog.Warn("failed to marshal options while writing debug box options", "error", err)
+		return
 	}
 
-	var b bytes.Buffer
-	if err := stdjson.Indent(&b, buf, "", "  "); err != nil {
-		slog.Warn("failed to indent marshaled options while writing debug box options", slog.Any("error", err))
-		return buf
+	if err := atomicfile.WriteFile(filepath.Join(path, internal.DebugBoxOptionsFileName), buf, fileperm.File); err != nil {
+		slog.Warn("failed to write options file", "error", err)
 	}
-	if err := atomicfile.WriteFile(filepath.Join(path, internal.DebugBoxOptionsFileName), b.Bytes(), fileperm.File); err != nil {
-		slog.Warn("failed to write options file", slog.Any("error", err))
-		return buf
-	}
-	return b.Bytes()
 }
 
 //////////////////////

--- a/vpn/clash.go
+++ b/vpn/clash.go
@@ -178,13 +178,14 @@ func (s *clashServer) newRecord(metadata A.InboundContext, matchedRule A.Rule, m
 	id, _ := uuid.NewV4()
 	outbound, outboundType, chain := s.resolveChain(matchOutbound)
 	return &record{
-		id:           id,
-		createdAt:    time.Now(),
-		outbound:     outbound,
-		outboundType: outboundType,
-		chain:        chain,
-		inboundType:  metadata.InboundType,
-		inboundName:  metadata.Inbound,
+		id:            id,
+		createdAt:     time.Now(),
+		outbound:      outbound,
+		outboundType:  outboundType,
+		chain:         chain,
+		outboundLabel: outboundType + "/" + outbound,
+		inboundLabel:  metadata.InboundType + "/" + metadata.Inbound,
+
 		ipVersion:    metadata.IPVersion,
 		network:      metadata.Network,
 		source:       metadata.Source.String(),

--- a/vpn/conntrack.go
+++ b/vpn/conntrack.go
@@ -36,8 +36,12 @@ type record struct {
 	outboundType string
 	chain        []string
 
-	inboundType  string
-	inboundName  string
+	// Labels are prejoined because IPC polling rebuilds Connection values for every live record.
+	// Keep outboundLabel aligned with outbound/outboundType so rendered labels and structured
+	// routing metadata describe the same path.
+	outboundLabel string
+	inboundLabel  string
+
 	ipVersion    uint8
 	network      string
 	source       string
@@ -51,10 +55,9 @@ type record struct {
 // attrs returns the telemetry attribute set for the connection.
 func (r *record) attrs() ConnAttrs {
 	return ConnAttrs{
-		ID:           r.id.String(),
 		FromOutbound: r.fromOutbound,
-		Outbound:     r.outboundType + "/" + r.outbound,
-		Inbound:      r.inboundType + "/" + r.inboundName,
+		Outbound:     r.outboundLabel,
+		Inbound:      r.inboundLabel,
 		Network:      r.network,
 		Protocol:     r.protocol,
 		IPVersion:    int(r.ipVersion),
@@ -81,7 +84,6 @@ func (r *record) trackerMetadata() trafficontrol.TrackerMetadata {
 
 // ConnAttrs is the attribute set describing a connection, carried on each ConnClose push.
 type ConnAttrs struct {
-	ID           string
 	FromOutbound string
 	Outbound     string
 	Inbound      string
@@ -182,7 +184,7 @@ func (m *connTracker) leave(r *record) {
 // Connections satisfies groups.ConnectionManager (github.com/getlantern/lantern-box/adapter/groups),
 // returning the active connections as synthesized trafficontrol.TrackerMetadata.
 func (m *connTracker) Connections() []trafficontrol.TrackerMetadata {
-	var out []trafficontrol.TrackerMetadata
+	out := make([]trafficontrol.TrackerMetadata, 0, m.activeCount.Load())
 	for _, r := range m.conns.Iter() {
 		out = append(out, r.trackerMetadata())
 	}
@@ -192,7 +194,7 @@ func (m *connTracker) Connections() []trafficontrol.TrackerMetadata {
 // activeConnections returns the current active connections as IPC Connection values. An empty
 // slice is returned if there are no active connections.
 func (m *connTracker) activeConnections() []Connection {
-	out := make([]Connection, 0)
+	out := make([]Connection, 0, m.activeCount.Load())
 	for _, r := range m.conns.Iter() {
 		out = append(out, newConnection(r))
 	}

--- a/vpn/conntrack_test.go
+++ b/vpn/conntrack_test.go
@@ -112,7 +112,8 @@ func TestConnTracker_ObserverOnClose(t *testing.T) {
 	r := newRec("vpn-a")
 	r.createdAt = time.Now().Add(-2 * time.Second)
 	r.outboundType = "vmess"
-	r.inboundType, r.inboundName = "tun", "tun-in"
+	r.outboundLabel = "vmess/vpn-a"
+	r.inboundLabel = "tun/tun-in"
 
 	ct.join(r)
 	addBytes(ct, r, 300, 120)

--- a/vpn/memmon.go
+++ b/vpn/memmon.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	runtimeDebug "runtime/debug"
 	"slices"
+	"time"
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/sagernet/sing-box/common/conntrack"
@@ -35,16 +36,27 @@ type memoryReclaimer struct {
 	tracker *connTracker
 }
 
-func (r *memoryReclaimer) ConnectionsOldestFirst() []memmon.ConnectionRef {
-	metadata := r.tracker.Connections()
-	refs := make([]memmon.ConnectionRef, len(metadata))
-	for i, conn := range metadata {
-		refs[i] = memmon.ConnectionRef{ID: conn.ID, CreatedAt: conn.CreatedAt}
+func (r *memoryReclaimer) OldestConnections(limit int) (oldest []memmon.ConnectionRef, total int) {
+	oldest = make([]memmon.ConnectionRef, 0, max(limit, 0))
+	for id, rec := range r.tracker.conns.Iter() {
+		total++
+		createdAt := rec.createdAt
+		// A candidate that can't join the oldest-limit window is skipped, but the loop
+		// continues so total still counts every connection.
+		if limit <= 0 || (len(oldest) == limit && !createdAt.Before(oldest[limit-1].CreatedAt)) {
+			continue
+		}
+		i, _ := slices.BinarySearchFunc(oldest, createdAt, func(ref memmon.ConnectionRef, t time.Time) int {
+			return ref.CreatedAt.Compare(t)
+		})
+		if len(oldest) < limit {
+			oldest = append(oldest, memmon.ConnectionRef{})
+		}
+		// At limit, this evicts the newest kept entry to make room.
+		copy(oldest[i+1:], oldest[i:])
+		oldest[i] = memmon.ConnectionRef{ID: id, CreatedAt: createdAt}
 	}
-	slices.SortFunc(refs, func(a, b memmon.ConnectionRef) int {
-		return a.CreatedAt.Compare(b.CreatedAt)
-	})
-	return refs
+	return oldest, total
 }
 
 func (r *memoryReclaimer) FreeOSMemory() {

--- a/vpn/memmon/executor.go
+++ b/vpn/memmon/executor.go
@@ -67,12 +67,13 @@ func (e *executor) Apply(decision Decision, now time.Time) {
 }
 
 func (e *executor) softEvict() (evicted, total int) {
-	refs := e.reclaimer.ConnectionsOldestFirst()
-	n := e.batchFor(len(refs))
-	for _, c := range refs[:n] {
+	// Request only the largest possible batch; batchFor may choose fewer after seeing total.
+	oldest, total := e.reclaimer.OldestConnections(e.cfg.SoftBatchMax)
+	n := min(e.batchFor(total), len(oldest))
+	for _, c := range oldest[:n] {
 		e.reclaimer.CloseConn(c.ID)
 	}
-	return n, len(refs)
+	return n, total
 }
 
 func (e *executor) batchFor(available int) int {

--- a/vpn/memmon/executor_test.go
+++ b/vpn/memmon/executor_test.go
@@ -18,12 +18,16 @@ type fakeReclaimer struct {
 	dialed    int
 }
 
-func (f *fakeReclaimer) ConnectionsOldestFirst() []ConnectionRef { return f.conns }
-func (f *fakeReclaimer) CloseConn(id uuid.UUID)                  { f.closed = append(f.closed, id) }
-func (f *fakeReclaimer) CloseAllConnections()                    { f.closeAllN++ }
-func (f *fakeReclaimer) FreeOSMemory()                           { f.freeOSCnt++ }
-func (f *fakeReclaimer) OpenConnectionCount() int                { return f.openCount }
-func (f *fakeReclaimer) TotalDialedConnections() int             { return f.dialed }
+// OldestConnections returns the fake's oldest-first prefix so limit handling exercises executor
+// behavior, not sorting.
+func (f *fakeReclaimer) OldestConnections(limit int) ([]ConnectionRef, int) {
+	return f.conns[:min(limit, len(f.conns))], len(f.conns)
+}
+func (f *fakeReclaimer) CloseConn(id uuid.UUID)      { f.closed = append(f.closed, id) }
+func (f *fakeReclaimer) CloseAllConnections()        { f.closeAllN++ }
+func (f *fakeReclaimer) FreeOSMemory()               { f.freeOSCnt++ }
+func (f *fakeReclaimer) OpenConnectionCount() int    { return f.openCount }
+func (f *fakeReclaimer) TotalDialedConnections() int { return f.dialed }
 
 func refs(n int) []ConnectionRef {
 	out := make([]ConnectionRef, n)

--- a/vpn/memmon/executor_test.go
+++ b/vpn/memmon/executor_test.go
@@ -21,6 +21,9 @@ type fakeReclaimer struct {
 // OldestConnections returns the fake's oldest-first prefix so limit handling exercises executor
 // behavior, not sorting.
 func (f *fakeReclaimer) OldestConnections(limit int) ([]ConnectionRef, int) {
+	if limit <= 0 {
+		return nil, len(f.conns)
+	}
 	return f.conns[:min(limit, len(f.conns))], len(f.conns)
 }
 func (f *fakeReclaimer) CloseConn(id uuid.UUID)      { f.closed = append(f.closed, id) }

--- a/vpn/memmon/reclaimer.go
+++ b/vpn/memmon/reclaimer.go
@@ -10,8 +10,9 @@ import (
 // be driven by a fake in tests — verifying eviction order, batch sizing, and the hard-close path
 // without a live tunnel — while production code can provide tracker-backed reclamation.
 type Reclaimer interface {
-	// ConnectionsOldestFirst returns the live routed connections sorted by creation time, oldest first.
-	ConnectionsOldestFirst() []ConnectionRef
+	// OldestConnections returns up to limit live routed connections ordered oldest-first, plus
+	// the total live count. A non-positive limit returns no refs but still reports total.
+	OldestConnections(limit int) (oldest []ConnectionRef, total int)
 	// CloseConn is a no-op when id is no longer live.
 	CloseConn(id uuid.UUID)
 	// CloseAllConnections closes every tracked connection for a hard reclaim.

--- a/vpn/memmon_test.go
+++ b/vpn/memmon_test.go
@@ -54,12 +54,23 @@ func TestMemmonReclaimer(t *testing.T) {
 	r := &memoryReclaimer{tracker: ct}
 	base := time.Unix(1_700_000_000, 0)
 
-	// Joined out of creation order; ConnectionsOldestFirst must return oldest-first.
+	// Joined out of creation order; OldestConnections must return oldest-first.
 	c2 := joinClosable(ct, "vpn-b", base.Add(2*time.Second))
 	c1 := joinClosable(ct, "vpn-a", base.Add(1*time.Second))
 	c3 := joinClosable(ct, "vpn-c", base.Add(3*time.Second))
 
-	assert.Equal(t, []uuid.UUID{c1.id, c2.id, c3.id}, refIDs(r.ConnectionsOldestFirst()), "oldest-first by CreatedAt")
+	oldest, total := r.OldestConnections(10)
+	assert.Equal(t, []uuid.UUID{c1.id, c2.id, c3.id}, refIDs(oldest), "oldest-first by CreatedAt")
+	assert.Equal(t, 3, total, "total counts every active connection, not just the returned ones")
+
+	oldest, total = r.OldestConnections(2)
+	assert.Equal(t, []uuid.UUID{c1.id, c2.id}, refIDs(oldest), "limit keeps the oldest, dropping newer")
+	assert.Equal(t, 3, total, "total is independent of the limit")
+
+	oldest, total = r.OldestConnections(0)
+	assert.Empty(t, oldest, "a non-positive limit selects nothing")
+	assert.Equal(t, 3, total)
+
 	require.Equal(t, 3, r.OpenConnectionCount())
 	// conntrack is compiled out in the default test build, so TotalDialedConnections
 	// and CloseAllConnections take the tracker fallback rather than the conntrack path.

--- a/vpn/session_history.go
+++ b/vpn/session_history.go
@@ -88,6 +88,8 @@ func NewSessionHistory(logger *slog.Logger, info SessionInfo) *SessionHistory {
 	h := &SessionHistory{
 		logger: logger,
 		info:   info,
+		// Preallocate the retention cap so finalizing a session can shift in place.
+		stored: make([]Session, 0, maxSessions),
 	}
 	h.sub = events.Subscribe(h.handleStatus)
 	h.startPruner()
@@ -194,10 +196,12 @@ func (h *SessionHistory) finalizeLocked(errMsg string) {
 	}
 	s := *h.current
 	h.current = nil
-	h.stored = append([]Session{s}, h.stored...)
-	if len(h.stored) > maxSessions {
-		h.stored = h.stored[:maxSessions]
+	// Avoid prepending onto a fresh slice while sessions may finalize under memory pressure.
+	if len(h.stored) < maxSessions {
+		h.stored = append(h.stored, Session{})
 	}
+	copy(h.stored[1:], h.stored[:len(h.stored)-1])
+	h.stored[0] = s
 	h.pruneLocked(now)
 }
 

--- a/vpn/types.go
+++ b/vpn/types.go
@@ -75,7 +75,7 @@ type Connection struct {
 func newConnection(r *record) Connection {
 	return Connection{
 		ID:           r.id.String(),
-		Inbound:      r.inboundType + "/" + r.inboundName,
+		Inbound:      r.inboundLabel,
 		IPVersion:    int(r.ipVersion),
 		Network:      r.network,
 		Source:       r.source,
@@ -87,7 +87,7 @@ func newConnection(r *record) Connection {
 		Uplink:       r.upload.Load(),
 		Downlink:     r.download.Load(),
 		Rule:         r.ruleStr,
-		Outbound:     r.outboundType + "/" + r.outbound,
+		Outbound:     r.outboundLabel,
 		ChainList:    r.chain,
 	}
 }


### PR DESCRIPTION
## Summary

CPU and resident-memory optimizations across the VPN connection and telemetry paths, favoring footprint wins on the memory-constrained mobile daemon. No behavioral change to routing or metrics semantics; drops on the telemetry buffer remain counted and surfaced.

## Changes

- **vpn/conntrack** — prejoin inbound/outbound labels once at record creation instead of rebuilding them on every IPC poll; drop the unused `ConnAttrs.ID` field; size `Connections`/`activeConnections` result slices from the live connection count.
- **vpn/memmon** — replace `ConnectionsOldestFirst` (full sort + full copy of all connections) with a bounded oldest-first top-k selection sized to the eviction batch max, returning the total live count alongside the selected refs.
- **vpn/session_history** — preallocate the retention window to its cap and shift in place on finalize rather than prepending onto a freshly allocated slice.
- **vpn/boxoptions** — drop the per-build span event that marshaled the full options into an attribute, and the debug-options indentation pass; the debug options file is still written for issue reports.
- **telemetry/connections** — size the buffered `ConnClose` channel smaller on mobile (256 vs 4096), trading counted overflow drops for lower resident footprint; desktop retains the larger buffer for burst absorption.
- **account/datacap** — shrink the long-lived SSE scanner's initial buffer to normal event size (the 1 MiB max-line cap is unchanged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced memory usage for mobile connection telemetry.
  * Improved connection tracking and cleanup efficiency, especially when managing large numbers of connections.
  * Optimized session history updates while preserving newest-first ordering.

* **Bug Fixes**
  * Added safer limits for processing incoming event data.
  * Improved connection labels shown in telemetry and connection details.
  * Streamlined diagnostic output handling for more reliable error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->