### PR TITLE
backend: never serve as a peer on iOS

### DIFF
--- a/backend/peer_share.go
+++ b/backend/peer_share.go
@@ -34,13 +34,12 @@ const peerToggleTimeout = 30 * time.Second
 // is a constant, so the real check cannot be faked at runtime.
 //
 // iOS is excluded because the backend runs inside the network extension
-// there — MobileStartIPCServer, the only caller of NewLocalBackend, is
-// invoked from the tunnel provider — where the memory budget is 48MB against
-// 512MB elsewhere and serving would add a second sing-box instance to it.
-// The memory monitor cannot absorb that: its sensor is process-wide, but its
-// reclaimer only sheds the VPN's own dialed connections, so peer load would
-// be relieved by evicting the user's traffic, and failing that the extension
-// is killed and the user loses the VPN.
+// there, on a memory budget roughly a tenth of every other platform's, and
+// serving adds a second sing-box instance to it. The memory monitor cannot
+// absorb the difference: it measures the whole process but can only reclaim
+// the VPN's own connections, so peer load would be relieved by evicting the
+// user's own traffic, and failing that the extension is killed and the VPN
+// goes down with it.
 var peerShareUnsupported = common.IsIOS
 
 // newPeerClient constructs the production peer.Client wired against the
@@ -71,7 +70,7 @@ func (r *LocalBackend) applyPeerShare(enabled bool) error {
 			if rbErr := settings.Patch(settings.Settings{settings.PeerShareEnabledKey: false}); rbErr != nil {
 				slog.Error("peer share rollback failed on unsupported platform", "error", rbErr)
 			}
-			return errors.New("peer share is not supported on this platform")
+			return fmt.Errorf("peer share is not supported on %s", common.Platform)
 		}
 		return nil
 	}

--- a/backend/peer_share.go
+++ b/backend/peer_share.go
@@ -29,6 +29,20 @@ type peerController interface {
 // shutdown.
 const peerToggleTimeout = 30 * time.Second
 
+// peerShareUnsupported reports platforms that must never serve as a peer. It
+// is a var solely so tests can reach the unsupported branch: common.Platform
+// is a constant, so the real check cannot be faked at runtime.
+//
+// iOS is excluded because the backend runs inside the network extension
+// there — MobileStartIPCServer, the only caller of NewLocalBackend, is
+// invoked from the tunnel provider — where the memory budget is 48MB against
+// 512MB elsewhere and serving would add a second sing-box instance to it.
+// The memory monitor cannot absorb that: its sensor is process-wide, but its
+// reclaimer only sheds the VPN's own dialed connections, so peer load would
+// be relieved by evicting the user's traffic, and failing that the extension
+// is killed and the user loses the VPN.
+var peerShareUnsupported = common.IsIOS
+
 // newPeerClient constructs the production peer.Client wired against the
 // shared kindling HTTP client and the platform device ID. Pulled out of
 // NewLocalBackend so the construction site is a one-liner.
@@ -50,6 +64,17 @@ func newPeerClient(platformDeviceID string) (*peer.Client, error) {
 // sequence could see the second call's "already active" rollback racing the
 // third call's Stop.
 func (r *LocalBackend) applyPeerShare(enabled bool) error {
+	if peerShareUnsupported() {
+		if enabled {
+			// Same reason as the nil-client path below: a persisted "on"
+			// would otherwise survive every restart with nothing behind it.
+			if rbErr := settings.Patch(settings.Settings{settings.PeerShareEnabledKey: false}); rbErr != nil {
+				slog.Error("peer share rollback failed on unsupported platform", "error", rbErr)
+			}
+			return errors.New("peer share is not supported on this platform")
+		}
+		return nil
+	}
 	// Construction degrades to a nil client rather than failing (the backend
 	// must always come up so a user can report an issue), so the toggle
 	// reports the outage instead of panicking. Roll the setting back, or a

--- a/backend/radiance_test.go
+++ b/backend/radiance_test.go
@@ -564,6 +564,57 @@ func TestApplyPeerShare_NilClientReportsUnavailableAndRollsBack(t *testing.T) {
 		"the setting must roll back so a persisted \"on\" doesn't survive with nothing behind it")
 }
 
+// withPeerShareUnsupported forces the platform gate on for one test. The real
+// predicate reads common.Platform, a constant, so the branch is unreachable on
+// the host that runs these tests.
+func withPeerShareUnsupported(t *testing.T) {
+	t.Helper()
+	prev := peerShareUnsupported
+	peerShareUnsupported = func() bool { return true }
+	t.Cleanup(func() { peerShareUnsupported = prev })
+}
+
+func TestApplyPeerShare_UnsupportedPlatformRefusesAndRollsBack(t *testing.T) {
+	withPeerShareUnsupported(t)
+	fake := &fakePeerController{}
+	r := newPeerTestBackend(t, fake)
+	require.NoError(t, settings.Patch(settings.Settings{settings.PeerShareEnabledKey: true}))
+
+	err := r.applyPeerShare(true)
+
+	require.Error(t, err, "enabling on an unsupported platform must report, not silently no-op")
+	assert.ErrorContains(t, err, "not supported")
+	assert.Zero(t, fake.startCalls.Load(), "the peer must never start on an unsupported platform")
+	assert.False(t, settings.GetBool(settings.PeerShareEnabledKey),
+		"the setting must roll back so a persisted \"on\" doesn't survive every restart")
+}
+
+func TestApplyPeerShare_UnsupportedPlatformDisableIsNoop(t *testing.T) {
+	withPeerShareUnsupported(t)
+	fake := &fakePeerController{}
+	r := newPeerTestBackend(t, fake)
+
+	assert.NoError(t, r.applyPeerShare(false), "turning it off where it never ran is not an error")
+	assert.Zero(t, fake.stopCalls.Load(), "nothing was started, so nothing needs stopping")
+}
+
+// The auto-resume path reaches Start through applyPeerShare, so the gate has to
+// hold there too: a setting persisted before the platform was excluded (or
+// synced from another device) would otherwise start a peer on every launch.
+func TestResumePeerShare_UnsupportedPlatformDoesNotStart(t *testing.T) {
+	withPeerShareUnsupported(t)
+	fake := &fakePeerController{}
+	r := newPeerTestBackend(t, fake)
+	require.NoError(t, settings.Patch(settings.Settings{settings.PeerShareEnabledKey: true}))
+
+	r.resumePeerShareIfEnabled()
+	r.peerWG.Wait()
+
+	assert.Zero(t, fake.startCalls.Load(), "auto-resume must not start a peer on an unsupported platform")
+	assert.False(t, settings.GetBool(settings.PeerShareEnabledKey),
+		"the stale setting is cleared on the way through")
+}
+
 func TestApplyPeerShare_NilClientDisableIsNoop(t *testing.T) {
 	r := newPeerTestBackend(t, nil)
 	r.peerClient = nil

--- a/backend/radiance_test.go
+++ b/backend/radiance_test.go
@@ -598,9 +598,10 @@ func TestApplyPeerShare_UnsupportedPlatformDisableIsNoop(t *testing.T) {
 	assert.Zero(t, fake.stopCalls.Load(), "nothing was started, so nothing needs stopping")
 }
 
-// The auto-resume path reaches Start through applyPeerShare, so the gate has to
-// hold there too: a setting persisted before the platform was excluded (or
-// synced from another device) would otherwise start a peer on every launch.
+// TestResumePeerShare_UnsupportedPlatformDoesNotStart covers the auto-resume
+// path, which reaches Start through applyPeerShare rather than directly: a
+// setting persisted before the platform was excluded, or synced from another
+// device, would otherwise start a peer on every launch.
 func TestResumePeerShare_UnsupportedPlatformDoesNotStart(t *testing.T) {
 	withPeerShareUnsupported(t)
 	fake := &fakePeerController{}


### PR DESCRIPTION
Peer serving had no platform gate at all. This adds one for iOS.

## What I found

`MobileStartIPCServer` is the only caller of `NewLocalBackend` (`lantern-core/mobile/ipc_lifecycle.go:184`), and therefore the only thing that constructs `peerClient`. It has exactly two call sites in the lantern repo:

```
ios/Tunnel/SingBox/ExtensionProvider.swift:35
macos/PacketTunnel/SingBox/ExtensionProvider.swift:35
```

The iOS app target never calls it. **So on iOS the peer proxy would run inside the network extension**, not the foreground app.

Nothing stopped it: no `IsIOS`/`IsAndroid` check anywhere in `peer/`, `portforward/`, or `applyPeerShare`, `peerClient` is constructed unconditionally, and the Unbounded tab is gated on the server-side `FeatureFlag.unbounded` plus a user setting — **not** on platform. Enabling that flag would have exposed it to iOS users.

## Why the extension is the wrong place for it

radiance already treats the extension as memory-starved — `vpn/memmon.go`:

```go
defaultIOSMemLimitBytes    = 48 * 1024 * 1024   // 48 MB
defaultNonIOSMemLimitBytes = 512 * 1024 * 1024  // 512 MB
```

Serving stands up a **second sing-box instance** (`c.cfg.BuildBoxService`) with a samizdat inbound inside that budget, alongside the tunnel.

The memory monitor can't absorb it, and the asymmetry is the real problem. The sensor is process-wide (`os_proc_available_memory`), so peer traffic counts toward pressure — but `memoryReclaimer` only sheds the VPN's own dialed connections (`connTracker`, `conntrack.Close`). The peer's accepted connections belong to a different box and aren't in that tracker. So:

> peer load raises pressure, and the only thing the system can evict in response is the user's own VPN traffic — and if that isn't enough, jetsam takes the extension and the user loses the VPN.

The per-peer client cap was just raised from 5 to 10 (lantern-cloud#3179), which doubles the ceiling on that load.

## The gate

At `applyPeerShare` rather than at construction, so the toggle and the auto-resume path both refuse through one check, and a persisted `on` is cleared on the way through — the same invariant the existing nil-client path maintains. Verified there is exactly one `peerClient.Start` call site and both `applyPeerShare` callers funnel through it.

`peerShareUnsupported` is a var purely as a test seam: `common.Platform` is a constant, so the branch is otherwise unreachable from a test on any host that can run one.

## Testing

Three new tests, and I confirmed they actually execute (`-run UnsupportedPlatform -v`) rather than trusting a bare `ok`:

- enabling refuses, never starts the peer, and rolls the setting back
- disabling is a no-op
- auto-resume does not start, and clears the stale setting

`TestApplyPeerShare_StartsOnEnable` still passes, which is what shows the gate is inert on supported platforms. Full `./backend/...` and `./peer/...` green, `go vet` clean on the changed package (worth running by hand — radiance CI runs no vet or lint at all).

## Not covered here

Hiding the toggle in the Flutter UI on iOS — this makes the attempt fail safely and audibly, but the control would still be visible. Worth a follow-up in lantern if the feature flag is ever turned on before that lands.

macOS is deliberately left alone: it also runs in an extension, but at the 512MB budget.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented peer sharing from starting on unsupported platforms.
  * Enabling peer sharing now reports an error and restores the previous setting if unsupported.
  * Disabling peer sharing remains safe, and automatic resume clears stale settings without starting the peer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->