### PR TITLE
fix(vpn): attribute datacap usage for startup config servers

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -1177,6 +1177,7 @@ func (r *LocalBackend) getBoxOptions() vpn.BoxOptions {
 	}
 	managedServers := r.srvManager.AllServers()
 	appendManagedServerOptions(&bOptions.Options, managedServers)
+	bOptions.LanternServerTags = lanternServerTags(cfg, managedServers)
 
 	seed := make(map[string]lbA.TagHistory)
 	for _, srv := range managedServers {
@@ -1188,6 +1189,39 @@ func (r *LocalBackend) getBoxOptions() vpn.BoxOptions {
 		bOptions.SelectionHistorySeed = seed
 	}
 	return bOptions
+}
+
+// lanternServerTags collects the tags of the Lantern servers in cfg and
+// managed, to seed the client-context injector's match bounds. Every cfg
+// outbound and endpoint is a Lantern server; managed servers carry the flag
+// explicitly.
+func lanternServerTags(cfg *config.Config, managed []*servers.Server) []string {
+	seen := make(map[string]struct{})
+	var tags []string
+	add := func(tag string) {
+		if tag == "" {
+			return
+		}
+		if _, ok := seen[tag]; ok {
+			return
+		}
+		seen[tag] = struct{}{}
+		tags = append(tags, tag)
+	}
+	if cfg != nil {
+		for _, out := range cfg.Options.Outbounds {
+			add(out.Tag)
+		}
+		for _, ep := range cfg.Options.Endpoints {
+			add(ep.Tag)
+		}
+	}
+	for _, srv := range managed {
+		if srv.IsLantern {
+			add(srv.Tag)
+		}
+	}
+	return tags
 }
 
 // appendManagedServerOptions adds server-manager options that are missing from

--- a/backend/radiance_test.go
+++ b/backend/radiance_test.go
@@ -669,3 +669,44 @@ func TestBuildIssueReportMetadataFallsBackToSettings(t *testing.T) {
 	assert.True(t, meta.splitTunnelEnabled, "split-tunnel state must survive a backendless report")
 	assert.NotNil(t, meta.reporter, "a reporter is always needed to upload the report")
 }
+
+func TestLanternServerTags(t *testing.T) {
+	cfg := &config.Config{
+		Options: option.Options{
+			Outbounds: []option.Outbound{{Tag: "out-1"}, {Tag: "out-2"}},
+			Endpoints: []option.Endpoint{{Tag: "ep-1"}},
+		},
+	}
+
+	t.Run("config outbounds and endpoints are all lantern", func(t *testing.T) {
+		assert.ElementsMatch(t, []string{"out-1", "out-2", "ep-1"}, lanternServerTags(cfg, nil))
+	})
+
+	t.Run("managed servers included only when lantern", func(t *testing.T) {
+		managed := []*servers.Server{
+			{Tag: "lan-1", IsLantern: true},
+			{Tag: "user-1", IsLantern: false},
+		}
+		assert.Equal(t, []string{"lan-1"}, lanternServerTags(nil, managed))
+	})
+
+	t.Run("config and managed lantern tags are unioned and deduped", func(t *testing.T) {
+		managed := []*servers.Server{
+			{Tag: "out-1", IsLantern: true}, // duplicate of a config tag
+			{Tag: "lan-2", IsLantern: true},
+			{Tag: "user-1", IsLantern: false},
+		}
+		got := lanternServerTags(cfg, managed)
+		assert.ElementsMatch(t, []string{"out-1", "out-2", "ep-1", "lan-2"}, got)
+		assert.Len(t, got, 4, "the tag shared by config and managed must appear once")
+	})
+
+	t.Run("empty tags are skipped", func(t *testing.T) {
+		emptyCfg := &config.Config{Options: option.Options{Outbounds: []option.Outbound{{Tag: ""}}}}
+		assert.Empty(t, lanternServerTags(emptyCfg, []*servers.Server{{Tag: "", IsLantern: true}}))
+	})
+
+	t.Run("nil config and managed yields no tags", func(t *testing.T) {
+		assert.Empty(t, lanternServerTags(nil, nil))
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/getlantern/domainfront v0.0.0-20260722204513-8c1f8acfa715
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3
 	github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464
-	github.com/getlantern/lantern-box v0.0.112
+	github.com/getlantern/lantern-box v0.0.113
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb

--- a/go.sum
+++ b/go.sum
@@ -246,10 +246,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvd
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464 h1:vZtMtKDsGO0ccBr+aQRRDKgcwFTg4psy13HtMttuBVQ=
 github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464/go.mod h1:ZEPFiB6rH6MtMN1O7b5gE+LJpCsRFzAn4u8lbIxHh3w=
-github.com/getlantern/lantern-box v0.0.111 h1:1DNrhaxpn9mRE7qMX/efi1I4wYx4FoBh7stVFIEPcYU=
-github.com/getlantern/lantern-box v0.0.111/go.mod h1:avZOnXNHLNT/d/Mrkjqn8i02HB1C805Dk7EtcWYq9lw=
-github.com/getlantern/lantern-box v0.0.112 h1:GuXFs4ZFFszGkw2jX6OfC4nV6PwHlMLxJG48I931pjk=
-github.com/getlantern/lantern-box v0.0.112/go.mod h1:b+gDOk1Wgd/cEL4Q0cSQJAfZuNQPCqIDwNhxXwLPg8g=
+github.com/getlantern/lantern-box v0.0.113 h1:G48dLWe1SQo8Ec7PC2vDn2FLbwCmlzwztKc7zT10pgI=
+github.com/getlantern/lantern-box v0.0.113/go.mod h1:b+gDOk1Wgd/cEL4Q0cSQJAfZuNQPCqIDwNhxXwLPg8g=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395/go.mod h1:3JpJgwi4KEI6rS9loOAvcBp+F2jP65d0tTg2GQcTPBU=
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 h1:3BwvWj0JZzFEvNNiMhCu4bf60nqcIuQpTYb00Ezm1ag=

--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -79,6 +79,12 @@ type BoxOptions struct {
 	// SelectionHistorySeed seeds the tunnel's AutoSelectHistoryStorage
 	// at startup with the latest persisted snapshot per tag.
 	SelectionHistorySeed map[string]lbA.TagHistory `json:"tag_history"`
+	// LanternServerTags lists the outbound/endpoint tags in Options that are
+	// Lantern servers. Only Lantern servers receive injected client info, so
+	// these seed the client-context injector's match bounds at construction —
+	// otherwise servers baked into the initial config get no data-usage
+	// attribution until a config refresh adds them.
+	LanternServerTags []string `json:"lantern_server_tags,omitempty"`
 }
 
 // isGlobalIPv6 reports whether ip is in 2000::/3. Not net.IP.IsGlobalUnicast,

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -466,7 +466,7 @@ func (t *tunnel) addOutboundsLocked(list servers.ServerList) (err error) {
 		// Outbound.
 		lanternTags := make([]string, 0, len(list.Servers))
 		for _, srv := range list.Servers {
-			if srv.IsLantern {
+			if srv.IsLantern && srv.Tag != "" {
 				lanternTags = append(lanternTags, srv.Tag)
 			}
 		}

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -60,6 +60,8 @@ type tunnel struct {
 
 	clientContextTracker *clientcontext.ClientContextInjector
 
+	initialLanternTags []string
+
 	// memoryMonitor starts during tunnel init in visibility-only mode.
 	// On iOS, its executor is installed later, after the clash server exists.
 	memoryMonitor *memmon.Monitor
@@ -202,7 +204,7 @@ func (t *tunnel) init(ctx context.Context, options string, platformIfce libbox.P
 
 	// setup client info tracker
 	outboundMgr := service.FromContext[adapter.OutboundManager](t.ctx)
-	clientContextInjector := newClientContextInjector(outboundMgr, dataPath)
+	clientContextInjector := newClientContextInjector(outboundMgr, dataPath, t.initialLanternTags)
 	service.MustRegisterPtr[clientcontext.ClientContextInjector](t.ctx, clientContextInjector)
 	t.clientContextTracker = clientContextInjector
 	router := service.FromContext[adapter.Router](t.ctx)
@@ -233,7 +235,7 @@ func setMobileMemoryLimits() {
 	runtimeDebug.SetMemoryLimit(mobileMemoryLimit)
 }
 
-func newClientContextInjector(outboundMgr adapter.OutboundManager, dataPath string) *clientcontext.ClientContextInjector {
+func newClientContextInjector(outboundMgr adapter.OutboundManager, dataPath string, lanternTags []string) *clientcontext.ClientContextInjector {
 	slog.Debug("Creating ClientContextInjector")
 	infoFn := func() clientcontext.ClientInfo {
 		return clientcontext.ClientInfo{
@@ -244,11 +246,11 @@ func newClientContextInjector(outboundMgr adapter.OutboundManager, dataPath stri
 			Version:     common.GetVersion(),
 		}
 	}
-	// Outbound match bounds start empty and are populated when lantern servers are added via
-	// addOutbounds. Only lantern servers support client context tracking.
+	// Only lantern servers support client context tracking, so only their tags
+	// belong in the match bounds.
 	matchBounds := clientcontext.MatchBounds{
 		Inbound:  []string{"any"},
-		Outbound: []string{},
+		Outbound: slices.Clone(lanternTags),
 	}
 	return clientcontext.NewClientContextInjector(infoFn, matchBounds)
 }
@@ -458,18 +460,24 @@ func (t *tunnel) addOutboundsLocked(list servers.ServerList) (err error) {
 
 	var errs []error
 	if t.clientContextTracker != nil {
-		// preemptively merge the new lantern tags into the clientContextInjector match bounds to
-		// capture any new connections before finished adding the servers.
-		lanternTags := make([]string, 0, len(newList.Servers))
-		for _, srv := range newList.Servers {
+		// Iterate the full list, not the deduped newList: removeDuplicates drops
+		// startup lantern servers that must stay bound, and the append-if-absent
+		// guard below re-adds any the construction seed missed without regrowing
+		// Outbound.
+		lanternTags := make([]string, 0, len(list.Servers))
+		for _, srv := range list.Servers {
 			if srv.IsLantern {
 				lanternTags = append(lanternTags, srv.Tag)
 			}
 		}
 		if len(lanternTags) > 0 {
-			slog.Log(nil, rlog.LevelTrace, "Temporarily merging new lantern tags into ClientContextInjector")
+			slog.Log(nil, rlog.LevelTrace, "Merging lantern tags into ClientContextInjector")
 			matchBounds := t.clientContextTracker.MatchBounds()
-			matchBounds.Outbound = append(matchBounds.Outbound, lanternTags...)
+			for _, tag := range lanternTags {
+				if !slices.Contains(matchBounds.Outbound, tag) {
+					matchBounds.Outbound = append(matchBounds.Outbound, tag)
+				}
+			}
 			t.clientContextTracker.SetBounds(matchBounds)
 		}
 		defer func() {

--- a/vpn/tunnel_test.go
+++ b/vpn/tunnel_test.go
@@ -144,3 +144,24 @@ func TestMobileMemoryLimitsOrdering(t *testing.T) {
 	assert.Less(t, mobileMemoryLimit, defaultIOSMemLimitBytes, "GOMEMLIMIT must be below the monitor budget")
 	assert.Less(t, defaultIOSMemLimitBytes, iOSFootprintCap, "monitor budget must be below the iOS cap")
 }
+
+func TestNewClientContextInjectorSeedsLanternTags(t *testing.T) {
+	t.Run("seeds outbound bounds with the given lantern tags", func(t *testing.T) {
+		inj := newClientContextInjector(nil, "", []string{"a", "b"})
+		bounds := inj.MatchBounds()
+		assert.Equal(t, []string{"a", "b"}, bounds.Outbound)
+		assert.Equal(t, []string{"any"}, bounds.Inbound)
+	})
+
+	t.Run("nil tags yield empty outbound bounds", func(t *testing.T) {
+		inj := newClientContextInjector(nil, "", nil)
+		assert.Empty(t, inj.MatchBounds().Outbound)
+	})
+
+	t.Run("clones input so later caller mutation does not alias the bounds", func(t *testing.T) {
+		tags := []string{"a", "b"}
+		inj := newClientContextInjector(nil, "", tags)
+		tags[0] = "mutated"
+		assert.Equal(t, []string{"a", "b"}, inj.MatchBounds().Outbound)
+	})
+}

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -179,6 +179,7 @@ func (c *VPNClient) start(ctx context.Context, boxOptions BoxOptions, options st
 	t := tunnel{
 		dataPath:             boxOptions.BasePath,
 		selectionHistorySeed: boxOptions.SelectionHistorySeed,
+		initialLanternTags:   boxOptions.LanternServerTags,
 		connObserver:         c.connObserver,
 	}
 	if err := t.start(ctx, options, c.platformIfce, isRestart); err != nil {


### PR DESCRIPTION
## Problem

The per-device datacap always showed **0 usage** on the client. Traffic through servers baked into the initial sing-box config was never attributed to the device.

Root cause chain:
- The `ClientContextInjector`'s outbound match bounds started **empty** and were only populated by `addOutbounds`. Only tags in those bounds get the client's `DeviceID` injected on their connections, which the server needs to attribute data usage.
- Startup-config servers are seeded into `t.optsMap` at tunnel start (`makeOutboundOptsMap`).
- On every later config refresh, `removeDuplicates` drops those tags (they match `optsMap`) **before** the lantern tags are built — so a server present at tunnel start never entered the match bounds for the life of the tunnel.
- Net effect: its traffic carried no `DeviceID`; the server attributed zero usage.

## Fix

**Construction-time seeding (primary):** a new `BoxOptions.LanternServerTags`, computed by the backend from `cfg.Options` (all Lantern) plus managed servers where `IsLantern`, is threaded into the tunnel and seeds `MatchBounds.Outbound` when the injector is built. Attribution now works from the moment the tunnel starts — even if no config refresh ever lands (e.g. config fetch fails).

**Refresh path (defense-in-depth):** `addOutboundsLocked` sources lantern tags from the pre-dedup `list.Servers` and appends only tags not already in the bounds, recovering any tag the seed missed without regrowing `Outbound`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Lantern server tag tracking for client context and data-usage attribution.
  * Tags are collected from configured connections and managed Lantern servers.
  * Duplicate and empty tags are automatically excluded.
  * Server tags are preserved when establishing a tunnel and updated as servers are added.

* **Bug Fixes**
  * Improved consistency of outbound server matching when duplicate server entries are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->