### PR TITLE
backend: park AMP off everywhere, and wait for a config before connecting

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -1157,6 +1157,9 @@ func (r *LocalBackend) ConnectVPN(ctx context.Context, tag string) error {
 	if tag == "" {
 		tag = vpn.AutoSelectTag
 	}
+	if err := r.awaitConnectable(ctx, tag); err != nil {
+		return err
+	}
 	if tag != vpn.AutoSelectTag {
 		if _, found := r.srvManager.GetServerByTag(tag); !found {
 			return fmt.Errorf("no server found with tag %s", tag)
@@ -1169,6 +1172,44 @@ func (r *LocalBackend) ConnectVPN(ctx context.Context, tag string) error {
 	}
 	r.persistSelection(tag)
 	return nil
+}
+
+// awaitConnectable blocks until the connect has something to dial, or ctx is
+// done. Connecting with neither a config nor a server of the user's own
+// produces "no outbounds or endpoints found", and on mobile the process that
+// reports that failure is the one hosting the config fetch it needed
+// (getlantern/engineering#3814), so failing fast deadlocks the first run.
+func (r *LocalBackend) awaitConnectable(ctx context.Context, tag string) error {
+	if r.connectable(tag) {
+		return nil
+	}
+	slog.Info("Waiting for a config before connecting", "tag", tag)
+	ready := make(chan struct{})
+	sub := events.SubscribeOnce(func(config.NewConfigEvent) { close(ready) })
+	defer sub.Unsubscribe()
+	// A config can land between the check above and the subscription.
+	if r.connectable(tag) {
+		return nil
+	}
+	select {
+	case <-ready:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("no config to connect with: %w", ctx.Err())
+	}
+}
+
+// connectable reports whether a connect can proceed right now: either a config
+// has been loaded, or the user has a server of their own to dial without one.
+func (r *LocalBackend) connectable(tag string) bool {
+	if _, err := r.confHandler.GetConfig(); err == nil {
+		return true
+	}
+	if tag != vpn.AutoSelectTag {
+		_, found := r.srvManager.GetServerByTag(tag)
+		return found
+	}
+	return len(r.srvManager.AllServers()) > 0
 }
 
 func (r *LocalBackend) getBoxOptions() vpn.BoxOptions {

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -1185,7 +1185,16 @@ func (r *LocalBackend) awaitConnectable(ctx context.Context, tag string) error {
 	}
 	slog.Info("Waiting for a config before connecting", "tag", tag)
 	ready := make(chan struct{})
-	sub := events.SubscribeOnce(func(config.NewConfigEvent) { close(ready) })
+	// Subscribe, not SubscribeOnce: this unsubscribes on return anyway, and
+	// SubscribeUntil's self-referential `sub` capture is read from the callback
+	// goroutine without synchronization (events.go:78 vs :85).
+	//
+	// Emit runs each callback on its own goroutine, so configs landing together
+	// can both reach this. Closing twice would panic.
+	var closeOnce sync.Once
+	sub := events.Subscribe(func(config.NewConfigEvent) {
+		closeOnce.Do(func() { close(ready) })
+	})
 	defer sub.Unsubscribe()
 	// A config can land between the check above and the subscription.
 	if r.connectable(tag) {

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -233,6 +233,11 @@ func NewLocalBackend(ctx context.Context, opts Options) (*LocalBackend, error) {
 }
 
 func (r *LocalBackend) Start() {
+	// Settle the country's transport policy before the first build. The country
+	// is already in settings from the previous session, so correcting it
+	// afterwards means discarding a finished transport bootstrap and paying for
+	// a second one — ~6.6s on a censored network (getlantern/engineering#3822).
+	setTransportPolicy()
 	// eagerly start kindling so it's ready by the time we need to make network requests
 	kindling.Init()
 	go func() {
@@ -365,15 +370,23 @@ func ampEnabledForCountry(country string) bool {
 	return !strings.EqualFold(country, "CN")
 }
 
-// applyTransportPolicy enables or disables the AMP transport based on the
-// user's country and rebuilds kindling when that changes the enabled set. The
-// env override takes precedence over the config-derived country in settings.
-func applyTransportPolicy() {
+// setTransportPolicy enables or disables the AMP transport based on the user's
+// country and reports whether that changed the enabled set. The env override
+// takes precedence over the config-derived country in settings. Callers that
+// run before the first kindling.Init use this directly; there is nothing built
+// yet to rebuild.
+func setTransportPolicy() bool {
 	country := settings.GetString(settings.CountryCodeKey)
 	if override := env.GetString(env.Country); override != "" {
 		country = override
 	}
-	if kindling.EnableTransport(kindling.TransportAMP, ampEnabledForCountry(country)) {
+	return kindling.EnableTransport(kindling.TransportAMP, ampEnabledForCountry(country))
+}
+
+// applyTransportPolicy applies the country's transport policy, rebuilding
+// kindling when that changes the enabled set.
+func applyTransportPolicy() {
+	if setTransportPolicy() {
 		kindling.Close()
 		kindling.Init()
 	}

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
-	"strings"
 	"sync"
 
 	"time"
@@ -233,11 +232,6 @@ func NewLocalBackend(ctx context.Context, opts Options) (*LocalBackend, error) {
 }
 
 func (r *LocalBackend) Start() {
-	// Settle the country's transport policy before the first build. The country
-	// is already in settings from the previous session, so correcting it
-	// afterwards means discarding a finished transport bootstrap and paying for
-	// a second one — ~6.6s on a censored network (getlantern/engineering#3822).
-	setTransportPolicy()
 	// eagerly start kindling so it's ready by the time we need to make network requests
 	kindling.Init()
 	go func() {
@@ -284,11 +278,9 @@ func (r *LocalBackend) Start() {
 	unbounded.InitSubscription(cachedCfg)
 
 	// The server derives the country from the client IP, so it's stable for the
-	// session: react once to record it for issue reports and to apply the
-	// country-specific transport policy (AMP is disabled in China).
+	// session: react once to record it for issue reports.
 	events.SubscribeOnce(func(evt config.NewConfigEvent) {
 		setCountryCodeFromConfig(evt.New)
-		applyTransportPolicy()
 	})
 	// update VPN outbounds when new config is received
 	events.SubscribeContext(r.ctx, func(evt config.NewConfigEvent) {
@@ -309,7 +301,6 @@ func (r *LocalBackend) applyCurrentConfig() bool {
 		return false
 	}
 	setCountryCodeFromConfig(cfg)
-	applyTransportPolicy()
 	r.applyConfig(cfg)
 	return true
 }
@@ -362,34 +353,6 @@ func setCountryCodeFromConfig(cfg *config.Config) {
 		slog.Error("failed to set country code in settings", "error", err)
 	}
 	slog.Info("Set country code from config", "country_code", cfg.Country)
-}
-
-// ampEnabledForCountry reports whether the AMP transport works from the given
-// country. AMP fronts through Google domains that are unreachable from China.
-func ampEnabledForCountry(country string) bool {
-	return !strings.EqualFold(country, "CN")
-}
-
-// setTransportPolicy enables or disables the AMP transport based on the user's
-// country and reports whether that changed the enabled set. The env override
-// takes precedence over the config-derived country in settings. Callers that
-// run before the first kindling.Init use this directly; there is nothing built
-// yet to rebuild.
-func setTransportPolicy() bool {
-	country := settings.GetString(settings.CountryCodeKey)
-	if override := env.GetString(env.Country); override != "" {
-		country = override
-	}
-	return kindling.EnableTransport(kindling.TransportAMP, ampEnabledForCountry(country))
-}
-
-// applyTransportPolicy applies the country's transport policy, rebuilding
-// kindling when that changes the enabled set.
-func applyTransportPolicy() {
-	if setTransportPolicy() {
-		kindling.Close()
-		kindling.Init()
-	}
 }
 
 // serverListFromConfig converts config outbounds and endpoints into managed

--- a/backend/radiance_test.go
+++ b/backend/radiance_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/getlantern/radiance/common/settings"
 	"github.com/getlantern/radiance/config"
 	"github.com/getlantern/radiance/internal"
+	"github.com/getlantern/radiance/kindling"
 	"github.com/getlantern/radiance/log"
 	"github.com/getlantern/radiance/peer"
 	"github.com/getlantern/radiance/servers"
@@ -708,5 +709,65 @@ func TestLanternServerTags(t *testing.T) {
 
 	t.Run("nil config and managed yields no tags", func(t *testing.T) {
 		assert.Empty(t, lanternServerTags(nil, nil))
+	})
+}
+
+// A CN client must settle its transport policy before the first kindling build.
+// Correcting it afterwards costs a Close+Init rebuild that throws away a
+// finished transport bootstrap and pays for a second one — ~6.6s on a censored
+// network, which is what pushed the iOS tunnel past its start deadline in
+// getlantern/engineering#3822. applyTransportPolicy rebuilds exactly when
+// setTransportPolicy reports a change, so "reports no change" is "no rebuild".
+func TestSetTransportPolicy(t *testing.T) {
+	prevAMP := kindling.EnabledTransports[kindling.TransportAMP]
+	t.Cleanup(func() { kindling.EnabledTransports[kindling.TransportAMP] = prevAMP })
+
+	// withCountry gives the test a settings store holding just the country,
+	// plus kindling's default enabled set as NewKindling would see it.
+	withCountry := func(t *testing.T, country string) {
+		t.Helper()
+		settings.Reset()
+		t.Cleanup(settings.Reset)
+		require.NoError(t, settings.InitSettings(t.TempDir()))
+		if country != "" {
+			require.NoError(t, settings.Set(settings.CountryCodeKey, country))
+		}
+		kindling.EnabledTransports[kindling.TransportAMP] = true
+	}
+
+	t.Run("CN settles before the build and needs no rebuild afterwards", func(t *testing.T) {
+		withCountry(t, "CN")
+
+		require.True(t, setTransportPolicy(), "CN must disable AMP before the first build")
+		require.False(t, kindling.EnabledTransports[kindling.TransportAMP])
+
+		// The pass applyCurrentConfig makes once the cached config is read.
+		assert.False(t, setTransportPolicy(), "an already-settled policy must not trigger a rebuild")
+	})
+
+	t.Run("a country where AMP works never rebuilds", func(t *testing.T) {
+		withCountry(t, "US")
+
+		assert.False(t, setTransportPolicy(), "AMP is already enabled; nothing to change")
+		assert.True(t, kindling.EnabledTransports[kindling.TransportAMP])
+	})
+
+	t.Run("an unknown country keeps AMP and settles once the config names CN", func(t *testing.T) {
+		// First run: no country persisted yet, so the pre-build pass can only
+		// keep the default. The rebuild then happens off the start path, when
+		// the fetched config first names the country.
+		withCountry(t, "")
+		require.False(t, setTransportPolicy())
+
+		require.NoError(t, settings.Set(settings.CountryCodeKey, "CN"))
+		assert.True(t, setTransportPolicy(), "the config-time pass must correct the policy")
+	})
+
+	t.Run("the env override beats the country in settings", func(t *testing.T) {
+		withCountry(t, "US")
+		t.Setenv("RADIANCE_COUNTRY", "CN")
+
+		assert.True(t, setTransportPolicy(), "the override country must decide the policy")
+		assert.False(t, kindling.EnabledTransports[kindling.TransportAMP])
 	})
 }

--- a/backend/radiance_test.go
+++ b/backend/radiance_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/getlantern/radiance/config"
 	"github.com/getlantern/radiance/events"
 	"github.com/getlantern/radiance/internal"
-	"github.com/getlantern/radiance/kindling"
 	"github.com/getlantern/radiance/log"
 	"github.com/getlantern/radiance/peer"
 	"github.com/getlantern/radiance/servers"
@@ -710,69 +709,6 @@ func TestLanternServerTags(t *testing.T) {
 
 	t.Run("nil config and managed yields no tags", func(t *testing.T) {
 		assert.Empty(t, lanternServerTags(nil, nil))
-	})
-}
-
-// TestSetTransportPolicy pins the ordering that lets a CN client build kindling
-// once rather than twice.
-//
-// A CN client must settle its transport policy before the first kindling build.
-// Correcting it afterwards costs a Close+Init rebuild that throws away a
-// finished transport bootstrap and pays for a second one — ~6.6s on a censored
-// network, which is what pushed the iOS tunnel past its start deadline in
-// getlantern/engineering#3822. applyTransportPolicy rebuilds exactly when
-// setTransportPolicy reports a change, so "reports no change" is "no rebuild".
-func TestSetTransportPolicy(t *testing.T) {
-	prevAMP := kindling.EnabledTransports[kindling.TransportAMP]
-	t.Cleanup(func() { kindling.EnabledTransports[kindling.TransportAMP] = prevAMP })
-
-	// withCountry gives the test a settings store holding just the country,
-	// plus kindling's default enabled set as NewKindling would see it.
-	withCountry := func(t *testing.T, country string) {
-		t.Helper()
-		settings.Reset()
-		t.Cleanup(settings.Reset)
-		require.NoError(t, settings.InitSettings(t.TempDir()))
-		if country != "" {
-			require.NoError(t, settings.Set(settings.CountryCodeKey, country))
-		}
-		kindling.EnabledTransports[kindling.TransportAMP] = true
-	}
-
-	t.Run("CN settles before the build and needs no rebuild afterwards", func(t *testing.T) {
-		withCountry(t, "CN")
-
-		require.True(t, setTransportPolicy(), "CN must disable AMP before the first build")
-		require.False(t, kindling.EnabledTransports[kindling.TransportAMP])
-
-		// The pass applyCurrentConfig makes once the cached config is read.
-		assert.False(t, setTransportPolicy(), "an already-settled policy must not trigger a rebuild")
-	})
-
-	t.Run("a country where AMP works never rebuilds", func(t *testing.T) {
-		withCountry(t, "US")
-
-		assert.False(t, setTransportPolicy(), "AMP is already enabled; nothing to change")
-		assert.True(t, kindling.EnabledTransports[kindling.TransportAMP])
-	})
-
-	t.Run("an unknown country keeps AMP and settles once the config names CN", func(t *testing.T) {
-		// First run: no country persisted yet, so the pre-build pass can only
-		// keep the default. The rebuild then happens off the start path, when
-		// the fetched config first names the country.
-		withCountry(t, "")
-		require.False(t, setTransportPolicy())
-
-		require.NoError(t, settings.Set(settings.CountryCodeKey, "CN"))
-		assert.True(t, setTransportPolicy(), "the config-time pass must correct the policy")
-	})
-
-	t.Run("the env override beats the country in settings", func(t *testing.T) {
-		withCountry(t, "US")
-		t.Setenv("RADIANCE_COUNTRY", "CN")
-
-		assert.True(t, setTransportPolicy(), "the override country must decide the policy")
-		assert.False(t, kindling.EnabledTransports[kindling.TransportAMP])
 	})
 }
 

--- a/backend/radiance_test.go
+++ b/backend/radiance_test.go
@@ -824,6 +824,36 @@ func TestAwaitConnectable(t *testing.T) {
 		assert.Less(t, time.Since(start), 3*time.Second, "must return on the config, not on the deadline")
 	})
 
+	// events.Emit runs each callback on its own goroutine and SubscribeOnce gates
+	// on a plain atomic load, not a CAS, so simultaneous configs can both reach
+	// the subscription. Closing the ready channel twice would panic the process.
+	t.Run("survives several configs landing at once", func(t *testing.T) {
+		r := newBackend(t, false)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		var emitters sync.WaitGroup
+		emitters.Add(1)
+		go func() {
+			defer emitters.Done()
+			// Ordering, not a timing assertion: the emits have to land after
+			// awaitConnectable has subscribed.
+			time.Sleep(150 * time.Millisecond)
+			var burst sync.WaitGroup
+			for range 8 {
+				burst.Add(1)
+				go func() {
+					defer burst.Done()
+					events.Emit(config.NewConfigEvent{New: cachedConfig()})
+				}()
+			}
+			burst.Wait()
+		}()
+		t.Cleanup(emitters.Wait)
+
+		require.NoError(t, r.awaitConnectable(ctx, vpn.AutoSelectTag))
+	})
+
 	t.Run("gives up on the caller's deadline rather than blocking forever", func(t *testing.T) {
 		r := newBackend(t, false)
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)

--- a/backend/radiance_test.go
+++ b/backend/radiance_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/getlantern/radiance/common/settings"
 	"github.com/getlantern/radiance/config"
+	"github.com/getlantern/radiance/events"
 	"github.com/getlantern/radiance/internal"
 	"github.com/getlantern/radiance/kindling"
 	"github.com/getlantern/radiance/log"
@@ -769,5 +770,92 @@ func TestSetTransportPolicy(t *testing.T) {
 
 		assert.True(t, setTransportPolicy(), "the override country must decide the policy")
 		assert.False(t, kindling.EnabledTransports[kindling.TransportAMP])
+	})
+}
+
+// A connect that arrives before the first config must wait for one instead of
+// failing. On iOS the process that reports "no outbounds" is the same process
+// hosting the config fetch, and its failure handler tears that process down —
+// a first-run deadlock on any slow network (getlantern/engineering#3814).
+func TestAwaitConnectable(t *testing.T) {
+	// newBackend builds a backend with only what awaitConnectable reads. A
+	// cached config on disk is how a returning user already has one at connect.
+	newBackend := func(t *testing.T, cached bool) *LocalBackend {
+		t.Helper()
+		dataDir := t.TempDir()
+		if cached {
+			buf, err := singjson.Marshal(cachedConfig())
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(filepath.Join(dataDir, internal.ConfigFileName), buf, 0o600))
+		}
+		settings.Reset()
+		t.Cleanup(settings.Reset)
+		require.NoError(t, settings.InitSettings(dataDir))
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		srvMgr, err := servers.NewManager(dataDir, log.NoOpLogger())
+		require.NoError(t, err)
+		return &LocalBackend{
+			ctx:         ctx,
+			confHandler: config.NewConfigHandler(ctx, config.Options{DataPath: dataDir, Logger: log.NoOpLogger()}),
+			srvManager:  srvMgr,
+		}
+	}
+
+	// The censored-network shape: the fetch completes, just not instantly.
+	t.Run("returns as soon as a config lands", func(t *testing.T) {
+		r := newBackend(t, false)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		go func() {
+			time.Sleep(150 * time.Millisecond)
+			events.Emit(config.NewConfigEvent{New: cachedConfig()})
+		}()
+
+		start := time.Now()
+		require.NoError(t, r.awaitConnectable(ctx, vpn.AutoSelectTag))
+		assert.Less(t, time.Since(start), 3*time.Second, "must return on the config, not on the deadline")
+	})
+
+	t.Run("gives up on the caller's deadline rather than blocking forever", func(t *testing.T) {
+		r := newBackend(t, false)
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		err := r.awaitConnectable(ctx, vpn.AutoSelectTag)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	// A cached config on disk is enough to connect: NewConfigHandler loads it
+	// synchronously, so a returning user's tunnel comes up on it without waiting
+	// for any fetch. The already-expired context proves nothing waited, and the
+	// box options prove the tunnel actually gets the cached outbounds.
+	t.Run("connects straight off the cached config on disk", func(t *testing.T) {
+		r := newBackend(t, true)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		require.NoError(t, r.awaitConnectable(ctx, vpn.AutoSelectTag))
+
+		tags := make([]string, 0, len(r.getBoxOptions().Options.Outbounds))
+		for _, out := range r.getBoxOptions().Options.Outbounds {
+			tags = append(tags, out.Tag)
+		}
+		assert.Contains(t, tags, "cached-out", "the tunnel must be built from the cached config")
+	})
+
+	// A user with their own server can dial it without a Lantern config, so the
+	// gate must not hold that connect hostage to a fetch it does not need.
+	t.Run("does not wait when the user has a server of their own", func(t *testing.T) {
+		r := newBackend(t, false)
+		require.NoError(t, r.srvManager.AddServers(
+			servers.ServerList{Servers: []*servers.Server{{Tag: "mine", Type: "shadowsocks"}}}, true))
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		assert.NoError(t, r.awaitConnectable(ctx, vpn.AutoSelectTag), "auto-select can use the managed server")
+		assert.NoError(t, r.awaitConnectable(ctx, "mine"), "an explicit tag resolves without a config")
 	})
 }

--- a/backend/radiance_test.go
+++ b/backend/radiance_test.go
@@ -713,6 +713,9 @@ func TestLanternServerTags(t *testing.T) {
 	})
 }
 
+// TestSetTransportPolicy pins the ordering that lets a CN client build kindling
+// once rather than twice.
+//
 // A CN client must settle its transport policy before the first kindling build.
 // Correcting it afterwards costs a Close+Init rebuild that throws away a
 // finished transport bootstrap and pays for a second one — ~6.6s on a censored
@@ -773,6 +776,9 @@ func TestSetTransportPolicy(t *testing.T) {
 	})
 }
 
+// TestAwaitConnectable covers the gate that holds a too-early connect until
+// there is something to dial.
+//
 // A connect that arrives before the first config must wait for one instead of
 // failing. On iOS the process that reports "no outbounds" is the same process
 // hosting the config fetch, and its failure handler tears that process down —

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac
 	github.com/getlantern/domainfront v0.0.0-20260722204513-8c1f8acfa715
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3
-	github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464
+	github.com/getlantern/kindling v0.0.0-20260818164234-358648d63068
 	github.com/getlantern/lantern-box v0.0.113
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,8 @@ github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 h1:cSrD9ryDfTV2y
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770/go.mod h1:GOQsoDnEHl6ZmNIL+5uVo+JWRFWozMEp18Izcb++H+A=
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvdWv+YvXDqADVwjxM0DyABg2x4UgLVKU9McKI=
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
-github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464 h1:vZtMtKDsGO0ccBr+aQRRDKgcwFTg4psy13HtMttuBVQ=
-github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464/go.mod h1:ZEPFiB6rH6MtMN1O7b5gE+LJpCsRFzAn4u8lbIxHh3w=
+github.com/getlantern/kindling v0.0.0-20260818164234-358648d63068 h1:ufd2dx1TDu6oQvesBsXvtnlfpEq3wb2dbRXa5L+BU7g=
+github.com/getlantern/kindling v0.0.0-20260818164234-358648d63068/go.mod h1:ZEPFiB6rH6MtMN1O7b5gE+LJpCsRFzAn4u8lbIxHh3w=
 github.com/getlantern/lantern-box v0.0.113 h1:G48dLWe1SQo8Ec7PC2vDn2FLbwCmlzwztKc7zT10pgI=
 github.com/getlantern/lantern-box v0.0.113/go.mod h1:b+gDOk1Wgd/cEL4Q0cSQJAfZuNQPCqIDwNhxXwLPg8g=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=

--- a/kindling/client.go
+++ b/kindling/client.go
@@ -44,9 +44,13 @@ var (
 	k           *Client
 	// EnabledTransports gates which transports NewKindling wires up. Toggle it
 	// through EnableTransport, then rebuild via Close+Init to apply the change.
+	//
+	// AMP and DNS tunneling are parked off for every country. Their builders
+	// stay wired behind these flags so turning either back on is a one-line
+	// change.
 	EnabledTransports = map[kindling.TransportName]bool{
 		kindling.TransportDNSTunnel:   false,
-		kindling.TransportAMP:         true,
+		kindling.TransportAMP:         false,
 		kindling.TransportSmart:       true,
 		kindling.TransportDomainfront: true,
 	}

--- a/kindling/client.go
+++ b/kindling/client.go
@@ -26,7 +26,7 @@ import (
 	"github.com/getlantern/radiance/traces"
 )
 
-// TransportName identifies a transport that can be toggled via EnableTransport.
+// TransportName identifies a transport in EnabledTransports.
 type TransportName = kindling.TransportName
 
 // Transport names re-exported so callers configure transports through this
@@ -42,12 +42,13 @@ var (
 	mu          sync.Mutex
 	initialized bool
 	k           *Client
-	// EnabledTransports gates which transports NewKindling wires up. Toggle it
-	// through EnableTransport, then rebuild via Close+Init to apply the change.
+	// EnabledTransports gates which transports NewKindling wires up. AMP and DNS
+	// tunneling are parked off for every country; their builders stay wired
+	// behind these flags so turning either back on is a one-line change.
 	//
-	// AMP and DNS tunneling are parked off for every country. Their builders
-	// stay wired behind these flags so turning either back on is a one-line
-	// change.
+	// A var rather than constants because cmd/kindling-tester rewrites it to
+	// isolate a single transport, as does TestNewClient. Production code sets
+	// it once, here: nothing toggles a transport at runtime.
 	EnabledTransports = map[kindling.TransportName]bool{
 		kindling.TransportDNSTunnel:   false,
 		kindling.TransportAMP:         false,
@@ -58,18 +59,6 @@ var (
 
 	transport http.RoundTripper
 )
-
-// EnableTransport sets whether NewKindling wires up the given transport and
-// reports whether that changed the current setting. The change takes effect on
-// the next rebuild (Close then Init). Call it before rebuilding, not
-// concurrently with one.
-func EnableTransport(transport TransportName, enable bool) bool {
-	if EnabledTransports[transport] == enable {
-		return false
-	}
-	EnabledTransports[transport] = enable
-	return true
-}
 
 func initKindling() {
 	newK, err := NewKindling(settings.GetString(settings.DataPathKey))

--- a/kindling/client_test.go
+++ b/kindling/client_test.go
@@ -9,16 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEnableTransport(t *testing.T) {
-	prev := EnabledTransports[kindling.TransportAMP]
-	t.Cleanup(func() { EnabledTransports[kindling.TransportAMP] = prev })
-
-	EnabledTransports[kindling.TransportAMP] = true
-	assert.True(t, EnableTransport(kindling.TransportAMP, false), "flipping the value reports a change")
-	assert.False(t, EnabledTransports[kindling.TransportAMP])
-	assert.False(t, EnableTransport(kindling.TransportAMP, false), "setting the same value reports no change")
-}
-
 func TestNewClient(t *testing.T) {
 	transports := []kindling.TransportName{
 		kindling.TransportDomainfront,


### PR DESCRIPTION
## Why

Two defects on the tunnel-start path, both surfaced by getlantern/engineering#3822 and #3814 — CN users on iOS 9.1.18 who could never connect.

### 1. CN clients built kindling, threw it away, and built it again

`LocalBackend.Start` called `kindling.Init()` first and applied the country's transport policy afterwards, from `applyCurrentConfig`. Because `ampEnabledForCountry("CN")` was false, `applyTransportPolicy` ran `kindling.Close()` + `Init()` — and `Close()` blocks on the same package mutex `ensureInit` holds for the *entire* first bootstrap. Measured in the ticket session: **6.57s**, all of it inside `Start()`.

**Resolved by deleting the policy rather than reordering it.** AMP is now parked off for every country, so the enabled set is constant, `EnableTransport` can never report a change, and there is no second build to sequence around. `ampEnabledForCountry`, `setTransportPolicy`, and `applyTransportPolicy` are gone.

AMP is parked the same way DNS tunneling already was in #562: the builder stays wired behind its flag in `EnabledTransports`, so turning it back on is a one-line change. `setCountryCodeFromConfig` stays — the country is still recorded for issue reports.

Note that `kindling.EnableTransport` now has no production callers (only its own test). Left in place as the documented toggle for the two parked transports.

### 2. Connecting before the first config failed instead of waiting

`ConnectVPN` went straight to `getBoxOptions`, which silently tolerates a missing config. `buildOptions` then reports `no outbounds or endpoints found` in ~3ms. On iOS the caller that handles that failure is the network extension, and it responds with `cancelTunnelWithError` — killing the very process hosting the config fetch it was waiting on. First run on any slow network deadlocks (#3814).

`awaitConnectable` now waits for the first config, bounded by the caller's context. Two paths deliberately skip the wait:

- **A cached config on disk.** `NewConfigHandler` loads it synchronously at construction (`config/config.go:119`), so a returning user's tunnel comes up on the cache with no fetch and no wait.
- **A server of the user's own.** A private server does not need a Lantern config to dial.

It subscribes with `Subscribe` rather than `SubscribeOnce`, and guards the channel close with `sync.Once`. Both matter: `Emit` runs every callback on its own goroutine and `SubscribeUntil` gates on a plain load rather than a CAS, so concurrent configs would otherwise close an already-closed channel and panic. `SubscribeUntil` also races on its own `sub` handle — filed separately as getlantern/engineering#3832, since fixing it properly changes semantics for every caller.

## Tests

`TestAwaitConnectable` — returns as soon as a late config lands (the censored-network shape), gives up on the caller's deadline, survives a burst of simultaneous configs (the panic above, reliably reproduced under `-race`), connects straight off a cached config on disk *and asserts the box options carry the cached outbound*, and does not wait when the user has their own server.

`backend`, `config`, `kindling`, `kindling/fronted`, `kindling/smart` all pass under `-race`. (`kindling/dnstt` races, but identically on `origin/main` — pre-existing and unrelated.)

## Dependency

~~getlantern/kindling#48~~ — **merged**, pinned here as of 083449e (`kindling@358648d`). It takes the Outline strategy search off `NewKindling`'s critical path, removing the cost of the *first* build the way this PR removes the second. CI here exercises the pair.

## Ships with

getlantern/lantern#8993, which takes the whole bootstrap off iOS's `startTunnel` deadline.

Refs getlantern/engineering#3822, getlantern/engineering#3814

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkKS8hGeHM5g4BDPvxcamg

---

**Stack:** getlantern/kindling#48 (merged) → getlantern/radiance#607 → getlantern/lantern#8993 (merge in that order, `go mod tidy` at each bump).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - VPN connection attempts now wait until configuration or a managed server is available.
  - Connections return a clear cancellation error when readiness is not reached in time.

- **Changes**
  - AMP transport is now disabled by default.
  - Transport availability is controlled through configuration rather than runtime toggling.
  - Removed country-based transport policy application during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->