### PR TITLE
portforward: log why UPnP failed, and stop leaking a mapping when the gateway never answers

### DIFF
--- a/portforward/portforward.go
+++ b/portforward/portforward.go
@@ -74,7 +74,16 @@ type Forwarder struct {
 // without coordination.
 func ProbeUPnP(ctx context.Context) bool {
 	_, err := NewForwarder(ctx)
-	return err == nil
+	if err != nil {
+		// NewForwarder logs the specifics; this line exists so the probe's own
+		// verdict is greppable. A bare bool at the call site cannot say whether
+		// the answer was "no gateway" or "we ran out of time", and the UI that
+		// consumes it shows the same thing either way.
+		slog.Info("portforward: UPnP probe says this network cannot host a peer", "err", err)
+		return false
+	}
+	slog.Info("portforward: UPnP probe succeeded")
+	return true
 }
 
 // NewForwarder discovers the local gateway and returns a Forwarder bound to
@@ -86,16 +95,48 @@ func ProbeUPnP(ctx context.Context) bool {
 // discovery, the ctx error is returned verbatim so callers can distinguish
 // "this network can't host a peer" from "we ran out of time, retry later".
 func NewForwarder(ctx context.Context) (*Forwarder, error) {
-	if c, err := discoverIGDv2(ctx); err == nil && c != nil {
-		return &Forwarder{client: c, method: "upnp-igd2"}, nil
+	// Both discovery errors were previously discarded by the `err == nil &&
+	// c != nil` guards, which made a failure indistinguishable from "this
+	// network has no gateway" — and the success path logs the method it chose
+	// while the failure path logged nothing at all. Whether IGDv2 was refused
+	// or simply absent is the first thing anyone asks when a peer turns out to
+	// be unreachable.
+	c2, err2 := discoverIGDv2(ctx)
+	if err2 == nil && c2 != nil {
+		slog.Info("portforward: gateway discovered", "method", "upnp-igd2")
+		return &Forwarder{client: c2, method: "upnp-igd2"}, nil
 	}
-	if c, err := discoverIGDv1(ctx); err == nil && c != nil {
-		return &Forwarder{client: c, method: "upnp-igd1"}, nil
+	c1, err1 := discoverIGDv1(ctx)
+	if err1 == nil && c1 != nil {
+		slog.Info("portforward: gateway discovered", "method", "upnp-igd1",
+			// Worth knowing: a router that answers v1 but not v2 is common, and
+			// it is also the shape of a gateway with a partial UPnP stack.
+			"igd2_err", errOrAbsent(err2, c2))
+		return &Forwarder{client: c1, method: "upnp-igd1"}, nil
 	}
+
 	if err := ctx.Err(); err != nil {
+		slog.Warn("portforward: gateway discovery ran out of time",
+			"err", err, "igd2_err", errOrAbsent(err2, c2), "igd1_err", errOrAbsent(err1, c1))
 		return nil, err
 	}
+	slog.Warn("portforward: no UPnP gateway found; this network cannot host a peer",
+		"igd2_err", errOrAbsent(err2, c2), "igd1_err", errOrAbsent(err1, c1))
 	return nil, ErrNoPortForwarding
+}
+
+// errOrAbsent renders a discovery outcome for a log field. A nil error with a
+// nil client is not a failure — it means discovery completed and the network
+// simply has no gateway of that flavour — and reporting that as "<nil>" reads
+// as though nothing was attempted.
+func errOrAbsent(err error, c igdClient) string {
+	if err != nil {
+		return err.Error()
+	}
+	if c == nil {
+		return "no gateway responded"
+	}
+	return "ok"
 }
 
 // MapPort asks the gateway to forward externalPort → (LocalIP():internalPort)
@@ -119,6 +160,7 @@ func (f *Forwarder) MapPort(ctx context.Context, internalPort uint16, descriptio
 
 	internalIP, err := localIP()
 	if err != nil {
+		slog.Warn("portforward: could not determine the local address to map to", "err", err)
 		return nil, fmt.Errorf("determine local ip: %w", err)
 	}
 
@@ -150,6 +192,8 @@ func (f *Forwarder) MapPort(ctx context.Context, internalPort uint16, descriptio
 	if ctxErr := ctx.Err(); ctxErr != nil && addLanded {
 		// The caller gave up but the gateway accepted the mapping. Remove it —
 		// otherwise it survives with no Forwarder tracking it.
+		slog.Warn("portforward: caller gave up while the gateway was accepting the mapping; removing it",
+			"external_port", externalPort, "internal_port", internalPort, "err", ctxErr)
 		f.deleteRacedMapping(&Mapping{ExternalPort: externalPort, Protocol: "TCP"}, client)
 		return nil, fmt.Errorf("add port mapping: %w", ctxErr)
 	}
@@ -157,8 +201,14 @@ func (f *Forwarder) MapPort(ctx context.Context, internalPort uint16, descriptio
 		// Propagate ctx cancellation/deadline verbatim so callers can retry
 		// rather than treating it as a permanent "this network won't work".
 		if ctxErr := ctx.Err(); ctxErr != nil {
+			slog.Warn("portforward: ran out of time adding the mapping",
+				"external_port", externalPort, "internal_port", internalPort,
+				"internal_ip", internalIP, "method", f.method, "err", ctxErr)
 			return nil, fmt.Errorf("add port mapping: %w", ctxErr)
 		}
+		slog.Warn("portforward: gateway refused the mapping",
+			"external_port", externalPort, "internal_port", internalPort,
+			"internal_ip", internalIP, "method", f.method, "err", err)
 		// Per the ErrNoPortForwarding docstring, a gateway refusing to map a
 		// port is the "this network can't host a peer" case. Join the
 		// sentinel so callers can detect it via errors.Is while still
@@ -174,6 +224,16 @@ func (f *Forwarder) MapPort(ctx context.Context, internalPort uint16, descriptio
 		LeaseDuration: time.Duration(requestedLease) * time.Second,
 		Method:        f.method,
 	}
+	// Logged here rather than only by the caller on full success. A mapping that
+	// the gateway accepts and then does not honour is invisible otherwise: the
+	// caller's success line never runs because verification fails afterwards, so
+	// the port and address we asked for — the two facts needed to check the
+	// router's own table — were nowhere in the log. That is exactly the shape of
+	// a 422 "could not connect to peer port".
+	slog.Info("portforward: mapping added",
+		"external_port", externalPort, "internal_port", internalPort,
+		"internal_ip", internalIP, "method", f.method,
+		"requested_lease_s", requestedLease)
 	return f.mapping, nil
 }
 
@@ -354,9 +414,12 @@ func (f *Forwarder) ExternalIP(ctx context.Context) (string, error) {
 		return nil
 	})
 	if err != nil {
+		slog.Warn("portforward: gateway would not report its external address",
+			"method", f.method, "err", err)
 		return "", fmt.Errorf("get external ip: %w", err)
 	}
 	if ip == "" {
+		slog.Warn("portforward: gateway reported an empty external address", "method", f.method)
 		return "", fmt.Errorf("gateway returned empty external ip")
 	}
 	return ip, nil

--- a/portforward/portforward.go
+++ b/portforward/portforward.go
@@ -85,7 +85,7 @@ func ProbeUPnP(ctx context.Context) bool {
 		// peer" states a capability verdict the probe did not reach — which is
 		// the kind of thing an operator acts on once and does not revisit.
 		if ctx.Err() != nil {
-			slog.Info("portforward: UPnP probe ran out of time; capability unknown", "err", err)
+			slog.Info("portforward: UPnP probe was canceled or timed out; capability unknown", "err", err)
 		} else {
 			slog.Info("portforward: UPnP probe found no gateway; this network cannot host a peer", "err", err)
 		}
@@ -125,7 +125,7 @@ func NewForwarder(ctx context.Context) (*Forwarder, error) {
 	}
 
 	if err := ctx.Err(); err != nil {
-		slog.Warn("portforward: gateway discovery ran out of time",
+		slog.Warn("portforward: gateway discovery was canceled or timed out",
 			"err", err, "igd2_err", errOrAbsent(err2, c2), "igd1_err", errOrAbsent(err1, c1))
 		return nil, err
 	}
@@ -204,14 +204,15 @@ func (f *Forwarder) MapPort(ctx context.Context, internalPort uint16, descriptio
 		// otherwise it survives with no Forwarder tracking it.
 		slog.Warn("portforward: caller gave up while the gateway was accepting the mapping; removing it",
 			"external_port", externalPort, "internal_port", internalPort, "err", ctxErr)
-		f.deleteRacedMapping(&Mapping{ExternalPort: externalPort, Protocol: "TCP"}, client)
+		f.deleteRacedMapping(&Mapping{ExternalPort: externalPort, Protocol: "TCP"}, client,
+			"caller gave up while the gateway was accepting it")
 		return nil, fmt.Errorf("add port mapping: %w", ctxErr)
 	}
 	if err != nil {
 		// Propagate ctx cancellation/deadline verbatim so callers can retry
 		// rather than treating it as a permanent "this network won't work".
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			slog.Warn("portforward: ran out of time adding the mapping",
+			slog.Warn("portforward: adding the mapping was canceled or timed out",
 				"external_port", externalPort, "internal_port", internalPort,
 				"internal_ip", internalIP, "method", f.method, "err", ctxErr)
 			return nil, fmt.Errorf("add port mapping: %w", ctxErr)
@@ -227,7 +228,8 @@ func (f *Forwarder) MapPort(ctx context.Context, internalPort uint16, descriptio
 			slog.Warn("portforward: gateway did not answer in time; removing any mapping it may have created",
 				"external_port", externalPort, "internal_port", internalPort,
 				"internal_ip", internalIP, "method", f.method, "err", err)
-			f.deleteRacedMapping(&Mapping{ExternalPort: externalPort, Protocol: "TCP"}, client)
+			f.deleteRacedMapping(&Mapping{ExternalPort: externalPort, Protocol: "TCP"}, client,
+				"gateway never answered the add")
 			return nil, fmt.Errorf("add port mapping: %w", errors.Join(ErrNoPortForwarding, err))
 		}
 		slog.Warn("portforward: gateway refused the mapping",
@@ -323,9 +325,10 @@ const (
 )
 
 // addCallTimeout is the same bound as renewCallTimeout for the initial MapPort
-// call. A var rather than a const only so tests can shorten it; nothing outside
-// this package writes it.
-var addCallTimeout = 30 * time.Second
+// call. Derived from it rather than repeating the literal, so the two cannot
+// drift. A var rather than a const only so tests can shorten it; nothing
+// outside this package writes it.
+var addCallTimeout = renewCallTimeout
 
 func (f *Forwarder) StartRenewal(ctx context.Context) {
 	f.mu.Lock()
@@ -345,22 +348,28 @@ func (f *Forwarder) StartRenewal(ctx context.Context) {
 	go f.renewLoop(renewCtx, interval)
 }
 
-// deleteRacedMapping removes a mapping that an in-flight renewal re-added
-// after UnmapPort had already deleted it. The renewal ctx is cancelled by
-// then, so this takes its own short deadline; best effort, since the only
-// remaining recourse is the router's own lease expiry.
-func (f *Forwarder) deleteRacedMapping(m *Mapping, client igdClient) {
+// deleteRacedMapping removes a mapping the Forwarder is not tracking and so
+// would never renew or delete: one an in-flight renewal re-added after
+// UnmapPort had already deleted it, or one the gateway may have created for an
+// add that was abandoned or never answered. why says which, because that is
+// the only place the three are distinguishable and they are diagnosed
+// differently.
+//
+// The calling ctx is typically already cancelled, so this takes its own short
+// deadline; best effort, since the only remaining recourse is the router's own
+// lease expiry.
+func (f *Forwarder) deleteRacedMapping(m *Mapping, client igdClient, why string) {
 	ctx, cancel := context.WithTimeout(context.Background(), racedUnmapTimeout)
 	defer cancel()
 	if err := runWithCtx(ctx, func() error {
 		return client.DeletePortMapping("", m.ExternalPort, m.Protocol)
 	}); err != nil {
-		slog.Warn("portforward: could not remove mapping re-added by an in-flight renewal",
-			"err", err, "external_port", m.ExternalPort)
+		slog.Warn("portforward: could not remove an untracked mapping",
+			"err", err, "external_port", m.ExternalPort, "why", why)
 		return
 	}
-	slog.Info("portforward: removed mapping re-added by an in-flight renewal",
-		"external_port", m.ExternalPort)
+	slog.Info("portforward: removed an untracked mapping",
+		"external_port", m.ExternalPort, "why", why)
 }
 
 func (f *Forwarder) renewLoop(ctx context.Context, interval time.Duration) {
@@ -417,7 +426,7 @@ func (f *Forwarder) renewLoop(ctx context.Context, interval time.Duration) {
 			f.mu.Unlock()
 			if teardownRaced {
 				if landed {
-					f.deleteRacedMapping(m, client)
+					f.deleteRacedMapping(m, client, "re-added by an in-flight renewal")
 				}
 				return
 			}

--- a/portforward/portforward.go
+++ b/portforward/portforward.go
@@ -75,11 +75,20 @@ type Forwarder struct {
 func ProbeUPnP(ctx context.Context) bool {
 	_, err := NewForwarder(ctx)
 	if err != nil {
-		// NewForwarder logs the specifics; this line exists so the probe's own
+		// NewForwarder logs the specifics; these lines exist so the probe's own
 		// verdict is greppable. A bare bool at the call site cannot say whether
 		// the answer was "no gateway" or "we ran out of time", and the UI that
 		// consumes it shows the same thing either way.
-		slog.Info("portforward: UPnP probe says this network cannot host a peer", "err", err)
+		//
+		// The two are kept apart deliberately. The docstring above promises that
+		// false covers both, and calling a timeout "this network cannot host a
+		// peer" states a capability verdict the probe did not reach — which is
+		// the kind of thing an operator acts on once and does not revisit.
+		if ctx.Err() != nil {
+			slog.Info("portforward: UPnP probe ran out of time; capability unknown", "err", err)
+		} else {
+			slog.Info("portforward: UPnP probe found no gateway; this network cannot host a peer", "err", err)
+		}
 		return false
 	}
 	slog.Info("portforward: UPnP probe succeeded")
@@ -180,13 +189,14 @@ func (f *Forwarder) MapPort(ctx context.Context, internalPort uint16, descriptio
 	go func() {
 		addErrCh <- client.AddPortMapping("", externalPort, "TCP", internalPort, internalIP, true, description, requestedLease)
 	}()
-	var addLanded bool
+	var addLanded, addTimedOut bool
 	select {
 	case err = <-addErrCh:
 		addLanded = err == nil
 	case <-time.After(addCallTimeout):
 		// Outcome unknowable; assume it landed so the cleanup below removes it.
 		addLanded = true
+		addTimedOut = true
 		err = fmt.Errorf("add port mapping timed out after %s", addCallTimeout)
 	}
 	if ctxErr := ctx.Err(); ctxErr != nil && addLanded {
@@ -205,6 +215,20 @@ func (f *Forwarder) MapPort(ctx context.Context, internalPort uint16, descriptio
 				"external_port", externalPort, "internal_port", internalPort,
 				"internal_ip", internalIP, "method", f.method, "err", ctxErr)
 			return nil, fmt.Errorf("add port mapping: %w", ctxErr)
+		}
+		if addTimedOut {
+			// The call never returned, so the gateway may well have created the
+			// mapping — which is what the comment on the timeout branch above
+			// promises to clean up. It did not: that cleanup is gated on
+			// ctx.Err(), so a local timeout with a live context fell straight
+			// through to here and left an untracked forward on the router,
+			// possibly permanent, with no Forwarder holding it. Same leak
+			// renewLoop already defends against on its own timeouts.
+			slog.Warn("portforward: gateway did not answer in time; removing any mapping it may have created",
+				"external_port", externalPort, "internal_port", internalPort,
+				"internal_ip", internalIP, "method", f.method, "err", err)
+			f.deleteRacedMapping(&Mapping{ExternalPort: externalPort, Protocol: "TCP"}, client)
+			return nil, fmt.Errorf("add port mapping: %w", errors.Join(ErrNoPortForwarding, err))
 		}
 		slog.Warn("portforward: gateway refused the mapping",
 			"external_port", externalPort, "internal_port", internalPort,
@@ -296,9 +320,12 @@ const (
 	// giving up on learning whether the mapping was re-added. SOAP to a LAN
 	// gateway normally answers in milliseconds.
 	renewCallTimeout = 30 * time.Second
-	// addCallTimeout is the same bound for the initial MapPort call.
-	addCallTimeout = 30 * time.Second
 )
+
+// addCallTimeout is the same bound as renewCallTimeout for the initial MapPort
+// call. A var rather than a const only so tests can shorten it; nothing outside
+// this package writes it.
+var addCallTimeout = 30 * time.Second
 
 func (f *Forwarder) StartRenewal(ctx context.Context) {
 	f.mu.Lock()

--- a/portforward/portforward_test.go
+++ b/portforward/portforward_test.go
@@ -3,8 +3,6 @@ package portforward
 import (
 	"context"
 	"errors"
-	"log/slog"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -382,69 +380,51 @@ func TestForwarder_MapPort_CancelledMidCall_RemovesAcceptedMapping(t *testing.T)
 	assert.Equal(t, uint16(15100), c.lastDelete.externalPort)
 }
 
-// captureLogs redirects the default slog destination for one test and returns
-// the accumulated output.
-func captureLogs(t *testing.T) *strings.Builder {
-	t.Helper()
-	var buf strings.Builder
-	prev := slog.Default()
-	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
-	t.Cleanup(func() { slog.SetDefault(prev) })
-	return &buf
-}
-
-// A mapping the gateway accepts and then does not honour is invisible without
-// this: the caller's success line never runs, because verification fails
-// afterwards, so the port and address we asked for — the two facts needed to
-// check the router's own table — appeared nowhere. That is the exact shape of
-// the "422 could not connect to peer port" reports this was added for.
-func TestForwarder_MapPort_LogsTheMappingOnSuccess(t *testing.T) {
-	buf := captureLogs(t)
-	f := newTestForwarder(t, &fakeIGD{})
-
-	m, err := f.MapPort(context.Background(), 41234, "test")
-	require.NoError(t, err)
-	require.NotNil(t, m)
-
-	out := buf.String()
-	assert.Contains(t, out, "mapping added")
-	assert.Contains(t, out, "external_port=41234", "the mapped port must be recoverable from the log")
-	assert.Contains(t, out, "internal_port=41234")
-	assert.Contains(t, out, "method=fake")
-	assert.Contains(t, out, "internal_ip=", "the address the gateway was told to forward to")
-}
-
-// A refusal previously returned a wrapped error and logged nothing, so a failed
-// share left no record of which port was even attempted.
-func TestForwarder_MapPort_LogsGatewayRefusal(t *testing.T) {
-	buf := captureLogs(t)
-	f := newTestForwarder(t, &fakeIGD{addErr: errors.New("ConflictInMappingEntry")})
-
-	_, err := f.MapPort(context.Background(), 41235, "test")
-	require.Error(t, err)
-
-	out := buf.String()
-	assert.Contains(t, out, "gateway refused the mapping")
-	assert.Contains(t, out, "external_port=41235")
-	assert.Contains(t, out, "ConflictInMappingEntry", "the router's own reason is the actionable part")
-}
-
-// ExternalIP failing is the difference between "no gateway" and "a gateway that
-// will not say who it is", and the caller only ever saw a wrapped error.
-func TestForwarder_ExternalIP_LogsFailure(t *testing.T) {
-	buf := captureLogs(t)
-	f := &Forwarder{client: &fakeIGD{extIPErr: errors.New("SpecifiedArrayIndexInvalid")}, method: "fake"}
-
-	_, err := f.ExternalIP(context.Background())
-	require.Error(t, err)
-	assert.Contains(t, buf.String(), "would not report its external address")
-	assert.Contains(t, buf.String(), "SpecifiedArrayIndexInvalid")
-}
-
 // errOrAbsent keeps "discovery completed, nothing answered" from rendering as
 // "<nil>", which reads as though no attempt was made.
 func TestErrOrAbsent(t *testing.T) {
 	assert.Equal(t, "boom", errOrAbsent(errors.New("boom"), nil))
 	assert.Equal(t, "no gateway responded", errOrAbsent(nil, nil))
 	assert.Equal(t, "ok", errOrAbsent(nil, &fakeIGD{}))
+}
+
+// A local timeout waiting for AddPortMapping is not a gateway refusing the
+// mapping. The call never returned, so the router may well have created the
+// forward — and nothing then tracks it: no Forwarder renews it, no UnmapPort
+// removes it, and it can outlive the process entirely. Orphans accumulate
+// across runs, which is a plausible mechanism for a gateway that later accepts
+// AddPortMapping without honouring it once its table is full.
+//
+// The timeout branch has always claimed to handle this ("assume it landed so
+// the cleanup below removes it"), but that cleanup is gated on ctx.Err(), so a
+// timeout with a live context fell straight through to the generic error return
+// and deleted nothing. renewLoop already defends against exactly this on its
+// own timeouts.
+func TestForwarder_MapPort_RemovesTheMappingWhenTheGatewayNeverAnswers(t *testing.T) {
+	prev := addCallTimeout
+	addCallTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { addCallTimeout = prev })
+
+	// Unblocked only after the assertions, so AddPortMapping is still in flight
+	// for the whole test — the case where the outcome is genuinely unknowable.
+	block := make(chan struct{})
+	t.Cleanup(func() { close(block) })
+	c := &fakeIGD{addBlock: block}
+	f := newTestForwarder(t, c)
+
+	_, err := f.MapPort(context.Background(), 30001, "test")
+	require.Error(t, err)
+	// Still the "this network can't host a peer" sentinel: the caller has no
+	// mapping either way, and the retry decision is the same.
+	assert.ErrorIs(t, err, ErrNoPortForwarding)
+	assert.ErrorContains(t, err, "timed out")
+
+	assert.Eventually(t, func() bool { return c.deleteCalls.Load() == 1 }, time.Second, 10*time.Millisecond,
+		"a mapping the gateway may have created was left on the router")
+
+	// And no mapping is retained locally, so a later UnmapPort has nothing
+	// stale to delete and StartRenewal has nothing to renew.
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	assert.Nil(t, f.mapping)
 }

--- a/portforward/portforward_test.go
+++ b/portforward/portforward_test.go
@@ -3,6 +3,8 @@ package portforward
 import (
 	"context"
 	"errors"
+	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -378,4 +380,71 @@ func TestForwarder_MapPort_CancelledMidCall_RemovesAcceptedMapping(t *testing.T)
 	assert.Equal(t, int64(1), c.deleteCalls.Load(),
 		"the accepted-but-unreported mapping must be deleted, or it survives untracked")
 	assert.Equal(t, uint16(15100), c.lastDelete.externalPort)
+}
+
+// captureLogs redirects the default slog destination for one test and returns
+// the accumulated output.
+func captureLogs(t *testing.T) *strings.Builder {
+	t.Helper()
+	var buf strings.Builder
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+// A mapping the gateway accepts and then does not honour is invisible without
+// this: the caller's success line never runs, because verification fails
+// afterwards, so the port and address we asked for — the two facts needed to
+// check the router's own table — appeared nowhere. That is the exact shape of
+// the "422 could not connect to peer port" reports this was added for.
+func TestForwarder_MapPort_LogsTheMappingOnSuccess(t *testing.T) {
+	buf := captureLogs(t)
+	f := newTestForwarder(t, &fakeIGD{})
+
+	m, err := f.MapPort(context.Background(), 41234, "test")
+	require.NoError(t, err)
+	require.NotNil(t, m)
+
+	out := buf.String()
+	assert.Contains(t, out, "mapping added")
+	assert.Contains(t, out, "external_port=41234", "the mapped port must be recoverable from the log")
+	assert.Contains(t, out, "internal_port=41234")
+	assert.Contains(t, out, "method=fake")
+	assert.Contains(t, out, "internal_ip=", "the address the gateway was told to forward to")
+}
+
+// A refusal previously returned a wrapped error and logged nothing, so a failed
+// share left no record of which port was even attempted.
+func TestForwarder_MapPort_LogsGatewayRefusal(t *testing.T) {
+	buf := captureLogs(t)
+	f := newTestForwarder(t, &fakeIGD{addErr: errors.New("ConflictInMappingEntry")})
+
+	_, err := f.MapPort(context.Background(), 41235, "test")
+	require.Error(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "gateway refused the mapping")
+	assert.Contains(t, out, "external_port=41235")
+	assert.Contains(t, out, "ConflictInMappingEntry", "the router's own reason is the actionable part")
+}
+
+// ExternalIP failing is the difference between "no gateway" and "a gateway that
+// will not say who it is", and the caller only ever saw a wrapped error.
+func TestForwarder_ExternalIP_LogsFailure(t *testing.T) {
+	buf := captureLogs(t)
+	f := &Forwarder{client: &fakeIGD{extIPErr: errors.New("SpecifiedArrayIndexInvalid")}, method: "fake"}
+
+	_, err := f.ExternalIP(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, buf.String(), "would not report its external address")
+	assert.Contains(t, buf.String(), "SpecifiedArrayIndexInvalid")
+}
+
+// errOrAbsent keeps "discovery completed, nothing answered" from rendering as
+// "<nil>", which reads as though no attempt was made.
+func TestErrOrAbsent(t *testing.T) {
+	assert.Equal(t, "boom", errOrAbsent(errors.New("boom"), nil))
+	assert.Equal(t, "no gateway responded", errOrAbsent(nil, nil))
+	assert.Equal(t, "ok", errOrAbsent(nil, &fakeIGD{}))
 }


### PR DESCRIPTION
The logging here was exactly inverted: **success logged everything, failure logged nothing.**

On success the caller emits one good line — external IP, both ports, IGD version:

```
peer client started external_ip=68.82.145.138 external_port=35826 internal_port=35826 method=upnp-igd1
```

On failure, `portforward` emitted nothing at all. Its only four `slog` calls were in the *renewal and teardown* paths; `ProbeUPnP`, `NewForwarder`, `MapPort`, `ExternalIP` and both discovery functions were silent.

## Two field reports made it concrete

**A machine hit `422 could not connect to peer port` three times in a row.** Its 24 MB log contains no port, no external address, and no indication UPnP was even attempted — because `MapPort` logged only via the caller's full-success line, and verification fails *before* that runs. Comparing against a working run from the day before, the only observable difference was the absence of the success line:

```
15:50:29.990  tcp server started at [::]:38190     ← local listener up
              (no inbound connection — dial-back never arrived)
15:50:31.813  verify: status=422 could not connect to peer port
```

**Another returned a four-deep wrapped error** whose innermost cause was a DNS timeout, with no way to tell whether the gateway had been reached at all.

## What changed

**`NewForwarder` was discarding both discovery errors.** The `err == nil && c != nil` guards meant a gateway that *refused* IGDv2 was indistinguishable from a network with no gateway. Both are logged now, and a successful v1 discovery records why v2 didn't answer — a router that answers v1 but not v2 is common, and also the shape of a partial UPnP stack.

**`MapPort` logs the mapping the moment the gateway accepts it**, rather than leaving that to the caller. A mapping that is accepted and then not honoured is otherwise invisible, and the port plus internal address are precisely the two facts needed to check the router's own table.

**Every failure now says so** — refusal, timeout, unresolvable local address, gateway that won't report its external IP — carrying the router's own error text, which is the actionable part rather than our wrapping of it.

**`ProbeUPnP`'s bare `bool`** now leaves a reason behind it. The call site can't distinguish "no gateway" from "ran out of time", and the UI shows the same thing either way.

## Found in review: a mapping leak on the add timeout

Copilot noticed that my new log line called a *local* timeout "gateway refused the mapping", and pulling that thread turned up a real bug underneath it.

`MapPort`'s timeout branch has always carried this comment:

```go
case <-time.After(addCallTimeout):
    // Outcome unknowable; assume it landed so the cleanup below removes it.
    addLanded = true
```

The cleanup it refers to is gated on `ctx.Err() != nil`. So a local timeout with a still-live context fell straight through to the generic error return and deleted nothing — the comment described an intent the code never implemented. The gateway may well have created the forward, and once `MapPort` returns an error nothing tracks it: no `Forwarder` renews it, no `UnmapPort` removes it, and it can outlive the process. `renewLoop` already defends against exactly this on its own timeouts.

That may not be incidental to the 422s above. Orphaned mappings accumulating across runs — crashes skip `UnmapPort` too — is a plausible mechanism for a router that later accepts `AddPortMapping` without honouring it.

`MapPort` now issues the compensating delete on that path, and reports it as a timeout rather than a refusal. It still joins `ErrNoPortForwarding`: the caller has no mapping either way and the retry decision is unchanged.

## Tests

`errOrAbsent` keeps its test — it stops "discovery completed, nothing answered" from rendering as `<nil>`, which reads as though no attempt was made.

The leak has a regression test that fails against the previous code:

```
--- FAIL: TestForwarder_MapPort_RemovesTheMappingWhenTheGatewayNeverAnswers
    Condition never satisfied
    Messages: a mapping the gateway may have created was left on the router
```

**The three log-assertion tests are gone.** They asserted on captured output via `slog.SetDefault`, which `.github/workflows/go.yml` fails the build for, and there is no injectable-logger or capture convention anywhere in radiance to follow instead. Rather than invent one in this PR, the log lines are verified by inspection. Worth knowing that they are therefore unguarded against future edits.

## Scope

**This is no longer logging-only.** The leak fix above changes behaviour, and it is easy to split out if a reviewer prefers that — it is here because the new log line is what surfaced it, and shipping a line that reports the leak without fixing it seemed worse than the extra scope.

Still untouched: error classification, and the port-selection strategy. `pickInternalPort()` returning a fresh random port each run remains a plausible contributor to the 422s and deserves its own PR.

## Note on the build

An earlier version of this description claimed `cmd/lantern` "does not build on `main` (`ipc.NewClient` signature drift)". That was wrong, and worth correcting rather than deleting: there is no drift.

`ipc` selects `NewClient` by build tag — `client_mobile.go` is `android || ios || (darwin && !standalone)`, `client_nonmobile.go` is the complement. On macOS without `-tags standalone` the mobile variant wins, and `cmd/lantern`'s no-arg call doesn't match it. `go build -tags standalone,with_clash_api ./cmd/lantern/` succeeds, and CI builds on Linux where the nonmobile variant is selected — which is why CI is green here and on `main`.

Nothing to fix, and nothing in this PR is affected.

## Scope

**This is no longer logging-only.** The leak fix above changes behaviour, and it is easy to split out if a reviewer prefers that — it is here because the new log line is what surfaced it, and shipping a line that reports the leak without fixing it seemed worse than the extra scope.

Still untouched: error classification, and the port-selection strategy. `pickInternalPort()` returning a fresh random port each run remains a plausible contributor to the 422s and deserves its own PR.

## Note on the build

`cmd/lantern` does not build on `main` (`ipc.NewClient` signature drift). That predates this change and is untouched here — confirmed in a clean worktree of `origin/main`. `portforward` builds and its tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MYMwy9Pu5Ji3xpYK8Nzj3


