### PR TITLE
peer: give Start failures one honest line instead of four nested wraps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac
 	github.com/getlantern/domainfront v0.0.0-20260722204513-8c1f8acfa715
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3
-	github.com/getlantern/kindling v0.0.0-20260818164234-358648d63068
+	github.com/getlantern/kindling v0.0.0-20260818180827-1583458ab9b7
 	github.com/getlantern/lantern-box v0.0.113
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,8 @@ github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 h1:cSrD9ryDfTV2y
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770/go.mod h1:GOQsoDnEHl6ZmNIL+5uVo+JWRFWozMEp18Izcb++H+A=
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvdWv+YvXDqADVwjxM0DyABg2x4UgLVKU9McKI=
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
-github.com/getlantern/kindling v0.0.0-20260818164234-358648d63068 h1:ufd2dx1TDu6oQvesBsXvtnlfpEq3wb2dbRXa5L+BU7g=
-github.com/getlantern/kindling v0.0.0-20260818164234-358648d63068/go.mod h1:ZEPFiB6rH6MtMN1O7b5gE+LJpCsRFzAn4u8lbIxHh3w=
+github.com/getlantern/kindling v0.0.0-20260818180827-1583458ab9b7 h1:uQWqnkaLL5n4BmTly7a+xjySH9bQnz3vB+Gvgs1Bwgw=
+github.com/getlantern/kindling v0.0.0-20260818180827-1583458ab9b7/go.mod h1:ZEPFiB6rH6MtMN1O7b5gE+LJpCsRFzAn4u8lbIxHh3w=
 github.com/getlantern/lantern-box v0.0.113 h1:G48dLWe1SQo8Ec7PC2vDn2FLbwCmlzwztKc7zT10pgI=
 github.com/getlantern/lantern-box v0.0.113/go.mod h1:b+gDOk1Wgd/cEL4Q0cSQJAfZuNQPCqIDwNhxXwLPg8g=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=

--- a/peer/failure.go
+++ b/peer/failure.go
@@ -63,12 +63,13 @@ func (e *StartError) Unwrap() error { return e.cause }
 // enough to stay sound.
 //
 // It deliberately has no catch-all "something network-ish went wrong at this
-// phase" rule. A phase spans more than one operation: validateAbuseRules and
-// ensurePeerOutboundsBypassVPN both run while the phase still reads
-// "registering", so a phase-keyed guess reported a launch_cfg that failed our
-// own safety check as "couldn't reach Lantern's servers" — pointing the user
-// at their network for a server-side config problem. Guessing from position
-// is how you get a confident wrong answer; an unnamed error at least stays
+// phase" rule. A phase spans more than one operation — validating the
+// server's launch config and patching it for the local VPN both happen after
+// registration has already succeeded, while the phase still reads
+// "registering" — so a phase-keyed guess reported a launch config that failed
+// our own safety check as "couldn't reach Lantern's servers", pointing the
+// user at their network for a server-side problem. Guessing from position is
+// how you get a confident wrong answer; an unnamed error at least stays
 // honest.
 func classifyStartFailure(phase Phase, err error) *StartError {
 	if err == nil {

--- a/peer/failure.go
+++ b/peer/failure.go
@@ -1,0 +1,178 @@
+package peer
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"syscall"
+
+	"github.com/getlantern/radiance/portforward"
+)
+
+// Start's failures reach the user as raw Go error text. The share card renders
+// whatever string comes back from setPeerProxy, so a peer that failed because
+// the machine was offline showed this:
+//
+//	register with lantern-cloud: send: all transports failed: transport
+//	smart: timed out, transport errors: transport proxyless: dial tcp:
+//	lookup api.iantem.io: no such host
+//
+// Four nested wraps naming four internals, and the one fact the user could act
+// on — the network was down — is the last clause of the innermost error. This
+// turns the tree into one line, and keeps the tree in the log.
+//
+// Only failures we can actually name are rewritten. Everything else keeps its
+// original error, because a vague-but-honest wrap beats a confident guess.
+
+// Reason is a stable, machine-readable classification of a Start failure. The
+// Flutter card currently renders Error verbatim, so these exist to let it
+// localize later without another radiance release — the message strings here
+// are English and cannot be translated in the UI.
+type Reason string
+
+const (
+	// ReasonNoInternet means every attempt failed the way a disconnected
+	// machine fails: name resolution or the route itself.
+	ReasonNoInternet Reason = "no_internet"
+	// ReasonNoPortForwarding means the router declined to map a port.
+	ReasonNoPortForwarding Reason = "no_port_forwarding"
+	// ReasonPortUnreachable means the router accepted the mapping and then
+	// did not honour it: lantern-cloud's dial-back never arrived.
+	ReasonPortUnreachable Reason = "port_unreachable"
+	// ReasonCanceled means the caller gave up — usually the user toggling
+	// sharing back off mid-start.
+	ReasonCanceled Reason = "canceled"
+)
+
+// StartError is a named Start failure. Error() is the one line the UI shows;
+// the original tree stays reachable through Unwrap for callers that want it,
+// and is logged in full at the point of classification either way.
+type StartError struct {
+	Reason Reason
+	msg    string
+	cause  error
+}
+
+func (e *StartError) Error() string { return e.msg }
+func (e *StartError) Unwrap() error { return e.cause }
+
+// classifyStartFailure names err if it can, and returns nil when it cannot —
+// in which case the caller keeps the raw error. Every rule below is justified
+// by the error's own identity, and the one that consults phase is narrow
+// enough to stay sound.
+//
+// It deliberately has no catch-all "something network-ish went wrong at this
+// phase" rule. A phase spans more than one operation: validateAbuseRules and
+// ensurePeerOutboundsBypassVPN both run while the phase still reads
+// "registering", so a phase-keyed guess reported a launch_cfg that failed our
+// own safety check as "couldn't reach Lantern's servers" — pointing the user
+// at their network for a server-side config problem. Guessing from position
+// is how you get a confident wrong answer; an unnamed error at least stays
+// honest.
+func classifyStartFailure(phase Phase, err error) *StartError {
+	if err == nil {
+		return nil
+	}
+	named := func(r Reason, msg string) *StartError {
+		return &StartError{Reason: r, msg: msg, cause: err}
+	}
+
+	// Cancellation gets its own branch so a user who toggles sharing back
+	// off mid-start reads a sentence about that rather than the raw wrap.
+	//
+	// It cannot collide with the offline check below, which is why the order
+	// here is defensive rather than load-bearing: offline() demands that
+	// every branch of the tree be an offline signal, and context.Canceled is
+	// not one, so a tree carrying it is never called offline whichever runs
+	// first.
+	if errors.Is(err, context.Canceled) {
+		return named(ReasonCanceled, "Sharing was stopped before it finished starting.")
+	}
+	if errors.Is(err, portforward.ErrNoPortForwarding) {
+		return named(ReasonNoPortForwarding,
+			"Your router won't open a port automatically. Check that UPnP is enabled in its settings.")
+	}
+	if offline(err) {
+		return named(ReasonNoInternet, "No internet connection.")
+	}
+
+	// A 422 from verify is the router lying: it accepted the mapping, so
+	// MapPort returned success, but lantern-cloud's dial-back never arrived.
+	// Distinguished from a plain unreachable server because the fix is
+	// entirely different — this one is the user's router, not our outage.
+	//
+	// Narrow to that one status on purpose. Any other failure at verify,
+	// 5xx especially, says nothing about the router and blaming it would
+	// send the user to reconfigure hardware that is working.
+	//
+	// Reading the operation off phase is safe here, unlike as a fallback:
+	// Verify is the only API call Start makes while the phase is
+	// PhaseVerifying (Register is a phase earlier, Heartbeat a phase later),
+	// so a 422 seen here came from the dial-back and nothing else.
+	var apiErr *APIError
+	if phase == PhaseVerifying && errors.As(err, &apiErr) &&
+		apiErr.Status == http.StatusUnprocessableEntity {
+		return named(ReasonPortUnreachable,
+			"Your router accepted the port mapping but isn't forwarding traffic to this computer.")
+	}
+	return nil
+}
+
+// offline reports whether every distinct failure in err's tree is one a
+// machine with no working network produces.
+//
+// Every, not any: kindling races several transports and joins their errors, so
+// a tree where one transport got an HTTP status back is proof the network
+// works, whatever the others say.
+//
+// Written as an explicit walk rather than errors.Is/As at the top, because
+// those traverse joined errors with "any" semantics — errors.As(tree,
+// &dnsErr) is true when a single transport hit DNS trouble, which is the
+// opposite of the question being asked here.
+//
+// A DNS failure counts, which is not universally safe: a poisoned resolver
+// looks the same and is a censorship signal rather than a local one. It is
+// safe here specifically. This path only runs for Share My Connection, whose
+// users are running an exit node in an uncensored network by definition; a
+// user whose DNS is being tampered with is not the person seeing this string.
+func offline(err error) bool {
+	for err != nil {
+		if joined, ok := err.(interface{ Unwrap() []error }); ok {
+			branches := joined.Unwrap()
+			if len(branches) == 0 {
+				return false
+			}
+			for _, branch := range branches {
+				if !offline(branch) {
+					return false
+				}
+			}
+			return true
+		}
+		if offlineNode(err) {
+			return true
+		}
+		unwrappable, ok := err.(interface{ Unwrap() error })
+		if !ok {
+			return false
+		}
+		err = unwrappable.Unwrap()
+	}
+	return false
+}
+
+// offlineNode tests one node with a type switch rather than errors.Is, so it
+// cannot accidentally traverse into a joined error and answer about a sibling.
+func offlineNode(err error) bool {
+	switch e := err.(type) {
+	case *net.DNSError:
+		return true
+	case syscall.Errno:
+		// ECONNREFUSED is deliberately absent: something answered, so the
+		// network works and the problem is at the other end.
+		return e == syscall.ENETUNREACH || e == syscall.EHOSTUNREACH ||
+			e == syscall.ENETDOWN || e == syscall.EHOSTDOWN || e == syscall.ENETRESET
+	}
+	return false
+}

--- a/peer/failure.go
+++ b/peer/failure.go
@@ -10,9 +10,9 @@ import (
 	"github.com/getlantern/radiance/portforward"
 )
 
-// Start's failures reach the user as raw Go error text. The share card renders
-// whatever string comes back from setPeerProxy, so a peer that failed because
-// the machine was offline showed this:
+// Start's failures reach the user as raw Go error text: the desktop share card
+// renders the returned error verbatim. A peer that failed because the machine
+// was offline showed this:
 //
 //	register with lantern-cloud: send: all transports failed: transport
 //	smart: timed out, transport errors: transport proxyless: dial tcp:
@@ -25,10 +25,10 @@ import (
 // Only failures we can actually name are rewritten. Everything else keeps its
 // original error, because a vague-but-honest wrap beats a confident guess.
 
-// Reason is a stable, machine-readable classification of a Start failure. The
-// Flutter card currently renders Error verbatim, so these exist to let it
-// localize later without another radiance release — the message strings here
-// are English and cannot be translated in the UI.
+// Reason is a stable, machine-readable classification of a Start failure. It
+// exists so the UI can localize these later without another radiance release:
+// the message strings below are English, and a UI that only has the string can
+// only display it.
 type Reason string
 
 const (

--- a/peer/failure.go
+++ b/peer/failure.go
@@ -38,7 +38,7 @@ const (
 	// ReasonNoPortForwarding means the router declined to map a port.
 	ReasonNoPortForwarding Reason = "no_port_forwarding"
 	// ReasonPortUnreachable means the router accepted the mapping and then
-	// did not honour it: lantern-cloud's dial-back never arrived.
+	// did not honor it: lantern-cloud's dial-back never arrived.
 	ReasonPortUnreachable Reason = "port_unreachable"
 	// ReasonCanceled means the caller gave up — usually the user toggling
 	// sharing back off mid-start.

--- a/peer/failure_test.go
+++ b/peer/failure_test.go
@@ -1,0 +1,207 @@
+package peer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/getlantern/radiance/events"
+	"github.com/getlantern/radiance/portforward"
+)
+
+// dnsFailure is what a dial looks like when nothing can be resolved.
+func dnsFailure(host string) error {
+	return &net.OpError{
+		Op:  "dial",
+		Net: "tcp",
+		Err: &net.DNSError{Err: "no such host", Name: host, IsNotFound: true},
+	}
+}
+
+// routeFailure is the other shape of offline: the name resolved (or was an IP)
+// and the kernel had nowhere to send the packet.
+func routeFailure() error {
+	return &net.OpError{
+		Op:  "dial",
+		Net: "tcp",
+		Err: os.NewSyscallError("connect", syscall.ENETUNREACH),
+	}
+}
+
+// kindlingTree reproduces the shape radiance actually receives from a failed
+// kindling round-trip: a per-tier errors.Join nested inside an outer
+// errors.Join, wrapped twice. Built by hand rather than by driving kindling so
+// the test states the shape it depends on — if kindling changes it, this
+// failing is the point.
+func kindlingTree(leaves ...error) error {
+	tier := make([]error, 0, len(leaves))
+	names := []string{"proxyless", "fronted", "dnstt"}
+	for i, leaf := range leaves {
+		tier = append(tier, fmt.Errorf("transport %s: %w", names[i%len(names)], leaf))
+	}
+	inner := fmt.Errorf("timed out, transport errors: %w", errors.Join(tier...))
+	return fmt.Errorf("send: %w", fmt.Errorf("all transports failed: %w",
+		errors.Join(fmt.Errorf("transport smart: %w", inner))))
+}
+
+// The failure from the field: every transport failed to resolve, and the user
+// saw four nested wraps ending in "lookup api.iantem.io: no such host".
+func TestClassifyStartFailure_OfflineKindlingTreeBecomesOneLine(t *testing.T) {
+	err := fmt.Errorf("register with lantern-cloud: %w",
+		kindlingTree(dnsFailure("api.iantem.io"), dnsFailure("api.iantem.io"), routeFailure()))
+
+	got := classifyStartFailure(PhaseRegistering, err)
+	require.NotNil(t, got)
+	assert.Equal(t, ReasonNoInternet, got.Reason)
+	assert.Equal(t, "No internet connection.", got.Error())
+	// One sentence, not a tree: the internals that leaked into the share card
+	// must not be in the message any more.
+	assert.NotContains(t, got.Error(), "transport")
+	assert.NotContains(t, got.Error(), "lookup")
+	// The tree is still reachable for anything that wants it.
+	assert.ErrorContains(t, errors.Unwrap(got), "all transports failed")
+}
+
+// The load-bearing property of offline(): every branch, not any. kindling
+// races transports, so one transport that got an HTTP response back is proof
+// the network works — no matter how many siblings failed to resolve.
+func TestClassifyStartFailure_OneReachableTransportIsNotOffline(t *testing.T) {
+	err := fmt.Errorf("register with lantern-cloud: %w", kindlingTree(
+		dnsFailure("api.iantem.io"),
+		dnsFailure("api.iantem.io"),
+		// No wrapped cause, exactly as kindling formats a status: proof a
+		// server answered.
+		errors.New("http status 503"),
+	))
+
+	assert.Nil(t, classifyStartFailure(PhaseRegistering, err),
+		"a tree containing a reachable transport must not be called offline")
+}
+
+// A user who toggles sharing off mid-start cancels the ctx, and the dials that
+// were in flight fail alongside it. What matters is that the result is never
+// "No internet connection." — blaming their network for their own click.
+//
+// This holds structurally rather than by check order: offline() requires every
+// branch to be an offline signal and context.Canceled is not one, so the tree
+// cannot be called offline regardless of which condition is tested first.
+func TestClassifyStartFailure_CancellationIsNeverReportedAsNoInternet(t *testing.T) {
+	err := fmt.Errorf("register with lantern-cloud: %w",
+		errors.Join(kindlingTree(dnsFailure("api.iantem.io")), context.Canceled))
+
+	got := classifyStartFailure(PhaseRegistering, err)
+	require.NotNil(t, got)
+	assert.Equal(t, ReasonCanceled, got.Reason)
+	assert.NotEqual(t, ReasonNoInternet, got.Reason)
+	assert.False(t, offline(err), "cancellation must not read as an offline tree")
+}
+
+func TestClassifyStartFailure_NoPortForwarding(t *testing.T) {
+	err := fmt.Errorf("map port 38190: %w",
+		fmt.Errorf("add port mapping: %w", portforward.ErrNoPortForwarding))
+
+	got := classifyStartFailure(PhaseMappingPort, err)
+	require.NotNil(t, got)
+	assert.Equal(t, ReasonNoPortForwarding, got.Reason)
+	assert.Contains(t, got.Error(), "UPnP")
+}
+
+// The 422 under investigation: MapPort succeeded, so the router accepted the
+// mapping, but lantern-cloud's dial-back never arrived.
+func TestClassifyStartFailure_VerifyUnprocessableMeansTheRouterLied(t *testing.T) {
+	err := fmt.Errorf("verify with lantern-cloud: %w",
+		fmt.Errorf("verify: %w", &APIError{
+			Status: http.StatusUnprocessableEntity,
+			Body:   "could not connect to peer port",
+		}))
+
+	got := classifyStartFailure(PhaseVerifying, err)
+	require.NotNil(t, got)
+	assert.Equal(t, ReasonPortUnreachable, got.Reason)
+	assert.Contains(t, got.Error(), "forwarding traffic")
+}
+
+// A 5xx at verify says nothing about the router. Blaming it would send the
+// user to reconfigure hardware that is working, so this stays unnamed and the
+// raw error survives.
+func TestClassifyStartFailure_ServerErrorAtVerifyIsNotTheRoutersFault(t *testing.T) {
+	err := fmt.Errorf("verify with lantern-cloud: %w",
+		fmt.Errorf("verify: %w", &APIError{Status: http.StatusInternalServerError}))
+
+	assert.Nil(t, classifyStartFailure(PhaseVerifying, err))
+}
+
+// Regression for a bug this classifier shipped with in review: a phase-keyed
+// fallback ("anything that fails while registering is a network problem")
+// reported a launch_cfg that failed our own abuse-rule check as "couldn't
+// reach Lantern's servers". validateAbuseRules runs after Register has already
+// succeeded, so the phase still reads registering — position is not evidence.
+func TestClassifyStartFailure_PhaseAloneNeverNamesAFailure(t *testing.T) {
+	for _, phase := range []Phase{PhaseMappingPort, PhaseDetectingIP, PhaseRegistering, PhaseVerifying, PhaseStartingBox} {
+		err := fmt.Errorf("launch_cfg failed abuse-rule sanity check: %w",
+			errors.New("inbound 0 is missing rule set"))
+		assert.Nil(t, classifyStartFailure(phase, err),
+			"phase %s must not be enough to name an unrelated failure", phase)
+	}
+}
+
+// An unnamed failure must keep its original text — a vague-but-honest wrap
+// beats a confident guess, and the raw error is all the user has left.
+func TestClient_Start_UnclassifiedFailureKeepsItsRawError(t *testing.T) {
+	fwd := &fakeForwarder{extIPErr: errors.New("gateway returned empty")}
+	c := newTestClient(t, fwd, &fakeBoxService{}, newStubServer(t))
+
+	err := c.Start(context.Background())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "gateway returned empty")
+	assert.Empty(t, c.status.Reason, "an unnamed failure must not claim a reason")
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// End to end: an offline Register makes Start return the one line the share
+// card renders, and the StatusEvent carries the machine-readable reason
+// alongside it.
+func TestClient_Start_OfflineRegisterSurfacesOneLineAndAReason(t *testing.T) {
+	srv := newStubServer(t)
+	offline := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, kindlingTree(dnsFailure("api.iantem.io"), routeFailure())
+	})}
+	c := newTestClient(t, &fakeForwarder{externalIP: "203.0.113.42"}, &fakeBoxService{}, srv,
+		func(cfg *Config) { cfg.API = NewAPI(offline, srv.server.URL+"/v1", "test-device") })
+
+	got := make(chan StatusEvent, 16)
+	sub := events.Subscribe(func(evt StatusEvent) { got <- evt })
+	defer sub.Unsubscribe()
+
+	err := c.Start(context.Background())
+	require.Error(t, err)
+	assert.Equal(t, "No internet connection.", err.Error())
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case evt := <-got:
+			if evt.Status.Phase != PhaseError {
+				assert.Empty(t, evt.Status.Reason, "progress events must carry no reason")
+				continue
+			}
+			assert.Equal(t, ReasonNoInternet, evt.Status.Reason)
+			assert.Equal(t, "No internet connection.", evt.Status.Error)
+			return
+		case <-deadline:
+			t.Fatal("no PhaseError status event within 1s")
+		}
+	}
+}

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -103,6 +103,10 @@ type Status struct {
 	// Empty for every other phase; consumers should render this only when
 	// the UI is in the error state.
 	Error string `json:"error,omitempty"`
+	// Reason classifies Error for consumers that need to branch on the cause
+	// or localize it. Empty when the failure could not be named, in which
+	// case Error is the raw Go error and is not worth translating.
+	Reason Reason `json:"reason,omitempty"`
 	// Active is true only when Phase == PhaseServing. Kept distinct from
 	// Phase so subscribers that just want a boolean "is sharing?" don't
 	// have to switch on the phase enum.
@@ -310,15 +314,32 @@ func (c *Client) Start(ctx context.Context) (retErr error) {
 		}
 		// Surface the failure to the UI. Emitted AFTER cleanup so the UI
 		// sees the error phase as the terminal state of this Start attempt,
-		// not as a transient between phases. retErr carries whichever
-		// fmt.Errorf the failing branch returned, which is the most
-		// human-readable diagnostic we have ("map port %d: ...",
-		// "register with lantern-cloud: ...", etc.).
+		// not as a transient between phases.
+		//
+		// This is the one place that sees both the failure and the phase it
+		// happened in, which is what makes the error nameable — so it is
+		// also the place that logs the full tree. Nothing downstream of here
+		// has the detail any more: the UI renders Error verbatim, and a
+		// named StartError's Error() is deliberately one sentence.
 		var errMsg string
+		var reason Reason
 		if retErr != nil {
+			failedPhase := c.currentPhase()
+			if named := classifyStartFailure(failedPhase, retErr); named != nil {
+				slog.Error("peer: start failed", "phase", failedPhase,
+					"reason", named.Reason, "err", retErr)
+				reason = named.Reason
+				retErr = named
+			} else {
+				// Unnamed, so the raw wrap is all the user gets — worth a
+				// log line of its own, since a reason we cannot classify is
+				// the signal that this list needs another entry.
+				slog.Error("peer: start failed with an unclassified error",
+					"phase", failedPhase, "err", retErr)
+			}
 			errMsg = retErr.Error()
 		}
-		c.emitPhase(PhaseError, errMsg)
+		c.emitError(reason, errMsg)
 	}()
 
 	c.emitPhase(PhaseMappingPort, "")
@@ -595,13 +616,35 @@ func (c *Client) CurrentStatus() Status {
 // subscribers using just the Active flag don't see e.g. "active=true with
 // Phase=verifying" mid-Start.
 func (c *Client) emitPhase(p Phase, errMsg string) {
+	c.emitStatus(p, errMsg, "")
+}
+
+// emitError is emitPhase for the terminal failure, carrying the classification
+// alongside the message so consumers can branch on it.
+func (c *Client) emitError(reason Reason, errMsg string) {
+	c.emitStatus(PhaseError, errMsg, reason)
+}
+
+func (c *Client) emitStatus(p Phase, errMsg string, reason Reason) {
 	c.mu.Lock()
 	c.status.Phase = p
 	c.status.Error = errMsg
+	// Cleared on every non-error phase, so a stale classification from a
+	// previous failed Start cannot ride along on the next attempt's progress
+	// events.
+	c.status.Reason = reason
 	c.status.Active = (p == PhaseServing)
 	snapshot := c.status
 	c.mu.Unlock()
 	events.Emit(StatusEvent{Status: snapshot})
+}
+
+// currentPhase reports the phase Start had reached, which is the phase a
+// failure happened in — read before emitError overwrites it.
+func (c *Client) currentPhase() Phase {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.status.Phase
 }
 
 // heartbeatLoop closes done on exit so Stop can wait for the loop before

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -326,8 +326,17 @@ func (c *Client) Start(ctx context.Context) (retErr error) {
 		if retErr != nil {
 			failedPhase := c.currentPhase()
 			if named := classifyStartFailure(failedPhase, retErr); named != nil {
-				slog.Error("peer: start failed", "phase", failedPhase,
-					"reason", named.Reason, "err", retErr)
+				if named.Reason == ReasonCanceled {
+					// Not a failure: the user toggled sharing back off while
+					// it was still coming up. At Error this would put an
+					// expected click into the error rate, and the rate is
+					// only useful if everything in it is worth looking at.
+					slog.Info("peer: start canceled before it finished",
+						"phase", failedPhase, "err", retErr)
+				} else {
+					slog.Error("peer: start failed", "phase", failedPhase,
+						"reason", named.Reason, "err", retErr)
+				}
 				reason = named.Reason
 				retErr = named
 			} else {

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -619,8 +619,6 @@ func (c *Client) emitPhase(p Phase, errMsg string) {
 	c.emitStatus(p, errMsg, "")
 }
 
-// emitError is emitPhase for the terminal failure, carrying the classification
-// alongside the message so consumers can branch on it.
 func (c *Client) emitError(reason Reason, errMsg string) {
 	c.emitStatus(PhaseError, errMsg, reason)
 }


### PR DESCRIPTION
The share card renders whatever string `setPeerProxy` returns (`share_my_connection.dart:370`). So when a user's internet was down, this is what the UI showed them:

```
register with lantern-cloud: send: all transports failed: transport smart:
timed out, transport errors: transport proxyless: dial tcp: lookup
api.iantem.io: no such host
```

Four nested wraps naming four internals, and the one fact the user could act on — the network was down — is the last clause of the innermost error.

## What changed

`Start` now names the failures it can and returns a `StartError` whose `Error()` is one sentence:

```
No internet connection.
```

The tree is not discarded. It is logged in full at the boundary — the one place that sees both the failure and the phase it happened in — and stays reachable through `Unwrap` for anything programmatic.

`Status` gains a `reason` field carrying a stable code (`no_internet`, `no_port_forwarding`, `port_unreachable`, `canceled`). Nothing consumes it yet; it exists so the Flutter card can localize these later, since the strings here are English and the UI currently renders them verbatim.

## Four reasons, each earned from the error itself

| Reason | Evidence | Message |
|---|---|---|
| `no_internet` | every branch of the tree is a DNS failure or an unreachable-route errno | No internet connection. |
| `no_port_forwarding` | `portforward.ErrNoPortForwarding` | Your router won't open a port automatically… |
| `port_unreachable` | `APIError{422}` at `PhaseVerifying` | Your router accepted the port mapping but isn't forwarding traffic… |
| `canceled` | `context.Canceled` | Sharing was stopped before it finished starting. |

Anything else keeps its raw error. A vague-but-honest wrap beats a confident guess, and an error we cannot name is exactly the signal that this list needs another entry — so it gets its own log line.

`port_unreachable` is the **422 `could not connect to peer port`** currently under investigation: `MapPort` returned success, so the router accepted the mapping, but lantern-cloud's dial-back never arrived. Narrowed to that one status on purpose — a 5xx at verify says nothing about the router, and blaming it would send the user to reconfigure hardware that is working.

## `offline()` requires every branch, not any

kindling races several transports and joins their errors, so a tree where **one** transport got an HTTP status back is proof the network works, whatever its siblings say.

This is also why the walk is explicit instead of `errors.Is`/`errors.As` at the top: those traverse joined errors with *any* semantics. `errors.As(tree, &dnsErr)` is true when a single transport hit DNS trouble — the opposite of the question being asked. Verified by swapping in the naive version:

```
--- FAIL: TestClassifyStartFailure_OneReachableTransportIsNotOffline
    Expected nil, but got: &peer.StartError{Reason:"no_internet", ...}
    Messages: a tree containing a reachable transport must not be called offline
```

A DNS failure counting as offline is not universally safe — a poisoned resolver looks identical and is a censorship signal rather than a local one. It is safe *here*: this path only runs for Share My Connection, whose users are running an exit node in an uncensored network by definition.

## Requires the kindling bump

Before `errors.Join` (getlantern/kindling#47, merged) only the last tier error survived, so "did *every* transport fail this way?" was not an answerable question. This bumps kindling to `1583458`, which also picks up #48 (proxyless strategy search).

## No phase-keyed fallback — a bug worth recording

An earlier draft had one: "anything that fails while registering is a network problem." It reported a `launch_cfg` that failed our own abuse-rule sanity check as *"Couldn't reach Lantern's servers"* — pointing the user at their network for a server-side config problem. `validateAbuseRules` runs *after* `Register` has already succeeded, so the phase still reads `registering`.

Two existing tests caught it (`TestClient_Start_AbuseRuleValidationFailureUnwinds`, `TestClient_Start_VerifyFailureUnwinds`). A phase spans more than one operation, so position is not evidence. The fallback is gone; the one surviving use of phase is Verify-only, where `Verify` is the sole API call in that phase.

**The entire existing suite passes unmodified** — no test was edited to accommodate this change, which is the main reason to believe the boundary is in the right place.

## Tests

Eight added. The two that pin the subtle properties were both verified to fail against their naive alternatives, and one test's claim was corrected after it turned out to prove nothing: the cancellation test originally asserted that check *order* mattered, but it passes with the order swapped, because `offline()` demands every branch be an offline signal and `context.Canceled` is not one. The two conditions are mutually exclusive, so the ordering is defensive rather than load-bearing — the test and comment now say that instead.

## Not in scope

- **The UI still discards this in SmC mode.** `_handlePeerStatus` treats `phase=error` as a signal to fall back to Unbounded and never renders the text ("raw protocol error text never reaches the status card"). The synchronous `setPeerProxy` return path at `share_my_connection.dart:370` *is* rendered, which is the path this PR improves. The event-delivery side is the separate stale-phase bug.
- No localization wiring — `reason` is emitted, unconsumed.
- `go vet ./peer/` reports a pre-existing `cancelRun` context-leak warning on `main`; untouched here, and CI does not run vet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MYMwy9Pu5Ji3xpYK8Nzj3
