### PR TITLE
events: deliver events to a subscriber in the order they were emitted

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -218,9 +218,9 @@ func (e *Subscription[T]) Unsubscribe() {
 // own callbacks are serialized.
 func Emit[T Event](evt T) {
 	key := reflect.TypeFor[T]()
-	// Snapshot the callbacks into a slice under the RLock, then drop
+	// Snapshot the subscribers into a slice under the RLock, then drop
 	// the lock before doing anything that could block (the diagnostic
-	// log, the per-callback goroutine spawn). Iterating the underlying
+	// log, the enqueue to each one). Iterating the underlying
 	// map after releasing the lock would race against Unsubscribe's
 	// write lock — `concurrent map iteration and map write` panic
 	// territory under load.

--- a/events/events.go
+++ b/events/events.go
@@ -50,18 +50,10 @@ var (
 // so reaching it means the callback is wedged, not busy.
 const queueDepth = 256
 
-// subscriber owns one subscription's delivery. Each has a single goroutine
-// draining a FIFO queue, which is what makes delivery ordered: Emit used to
-// spawn a fresh goroutine per event per callback, so two Emits raced and the
-// one that landed last was decided by the scheduler.
-//
-// That is not a rare interleaving. Emitting eight events to one subscriber
-// delivered them out of order in 200 of 200 runs, e.g. [0 3 1 2 7 6 5 4] —
-// so the *last* event a consumer saw was routinely not the last one sent.
-// Consumers that render the newest state (the share card renders the phase
-// from whichever frame arrived last) therefore settled on an arbitrary one,
-// which is how a peer that had finished registering kept reading
-// "discovering public IP".
+// subscriber owns one subscription's delivery: a single goroutine draining a
+// FIFO queue, which is what orders it. Emit previously spawned a goroutine per
+// event per callback, leaving the delivery order to the scheduler, so a
+// consumer that renders the newest event received an arbitrary one.
 type subscriber struct {
 	deliver func(any)
 	queue   chan any

--- a/events/events.go
+++ b/events/events.go
@@ -63,9 +63,14 @@ const queueDepth = 256
 // which is how a peer that had finished registering kept reading
 // "discovering public IP".
 type subscriber struct {
-	deliver  func(any)
-	queue    chan any
-	stopped  chan struct{}
+	deliver func(any)
+	queue   chan any
+	stopped chan struct{}
+	// exited is closed when the delivery goroutine returns. Distinct from
+	// stopped, which only records that it was asked to: an in-flight callback
+	// still has to finish first, so the two are not the same moment and only
+	// this one means the goroutine is gone.
+	exited   chan struct{}
 	stopOnce sync.Once
 }
 
@@ -74,12 +79,14 @@ func newSubscriber(key reflect.Type, deliver func(any)) *subscriber {
 		deliver: deliver,
 		queue:   make(chan any, queueDepth),
 		stopped: make(chan struct{}),
+		exited:  make(chan struct{}),
 	}
 	go s.run(key)
 	return s
 }
 
 func (s *subscriber) run(key reflect.Type) {
+	defer close(s.exited)
 	for {
 		select {
 		case <-s.stopped:

--- a/events/events.go
+++ b/events/events.go
@@ -85,6 +85,18 @@ func (s *subscriber) run(key reflect.Type) {
 		case <-s.stopped:
 			return
 		case evt := <-s.queue:
+			// Re-checked, because reaching here does not mean the
+			// subscription is still live: once stopped is closed both cases
+			// are ready and select picks at random. Without this, up to a
+			// full queue of callbacks could still run after Unsubscribe had
+			// returned. SubscribeUntil only looks immune to that — it
+			// carries its own done flag, which swallows the late delivery
+			// rather than preventing it.
+			select {
+			case <-s.stopped:
+				return
+			default:
+			}
 			s.invoke(key, evt)
 		}
 	}

--- a/events/events.go
+++ b/events/events.go
@@ -40,9 +40,87 @@ type Event interface {
 }
 
 var (
-	subscriptions   = make(map[reflect.Type]map[*Subscription[Event]]func(any))
+	subscriptions   = make(map[reflect.Type]map[*Subscription[Event]]*subscriber)
 	subscriptionsMu sync.RWMutex
 )
+
+// queueDepth bounds how many events can be waiting for one subscriber. Deep
+// enough that it is never reached by a subscriber that is merely slow — the
+// event types here fire a handful of times per user action, not per packet —
+// so reaching it means the callback is wedged, not busy.
+const queueDepth = 256
+
+// subscriber owns one subscription's delivery. Each has a single goroutine
+// draining a FIFO queue, which is what makes delivery ordered: Emit used to
+// spawn a fresh goroutine per event per callback, so two Emits raced and the
+// one that landed last was decided by the scheduler.
+//
+// That is not a rare interleaving. Emitting eight events to one subscriber
+// delivered them out of order in 200 of 200 runs, e.g. [0 3 1 2 7 6 5 4] —
+// so the *last* event a consumer saw was routinely not the last one sent.
+// Consumers that render the newest state (the share card renders the phase
+// from whichever frame arrived last) therefore settled on an arbitrary one,
+// which is how a peer that had finished registering kept reading
+// "discovering public IP".
+type subscriber struct {
+	deliver  func(any)
+	queue    chan any
+	stopped  chan struct{}
+	stopOnce sync.Once
+}
+
+func newSubscriber(key reflect.Type, deliver func(any)) *subscriber {
+	s := &subscriber{
+		deliver: deliver,
+		queue:   make(chan any, queueDepth),
+		stopped: make(chan struct{}),
+	}
+	go s.run(key)
+	return s
+}
+
+func (s *subscriber) run(key reflect.Type) {
+	for {
+		select {
+		case <-s.stopped:
+			return
+		case evt := <-s.queue:
+			s.invoke(key, evt)
+		}
+	}
+}
+
+// invoke keeps the per-callback recover that Emit used to hold. Without it one
+// panicking subscriber would now take down the delivery goroutine, silently
+// ending that subscription rather than just losing one event.
+func (s *subscriber) invoke(key reflect.Type, evt any) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("Panic in event callback", "error", r, "event", key.String())
+		}
+	}()
+	s.deliver(evt)
+}
+
+// enqueue never blocks. Emit has always returned without waiting on
+// subscribers, and callers depend on that — peer.Client emits lifecycle
+// phases from the same goroutine that is bringing the session up. A full
+// queue is therefore dropped rather than waited on, loudly, because by then
+// the subscriber has ignored 256 events and waiting would only spread its
+// problem to the emitter.
+func (s *subscriber) enqueue(key reflect.Type, evt any) {
+	select {
+	case s.queue <- evt:
+	case <-s.stopped:
+	default:
+		slog.Error("Dropped event: subscriber is not draining its queue",
+			"event", key.String(), "queue_depth", queueDepth)
+	}
+}
+
+func (s *subscriber) stop() {
+	s.stopOnce.Do(func() { close(s.stopped) })
+}
 
 // Subscription allows unsubscribing from an event.
 type Subscription[T Event] struct {
@@ -56,10 +134,10 @@ func Subscribe[T Event](callback func(evt T)) *Subscription[T] {
 	defer subscriptionsMu.Unlock()
 	key := reflect.TypeFor[T]()
 	if subscriptions[key] == nil {
-		subscriptions[key] = make(map[*Subscription[Event]]func(any))
+		subscriptions[key] = make(map[*Subscription[Event]]*subscriber)
 	}
 	sub := &Subscription[T]{}
-	subscriptions[key][(*Subscription[Event])(sub)] = func(e any) { callback(e.(T)) }
+	subscriptions[key][(*Subscription[Event])(sub)] = newSubscriber(key, func(e any) { callback(e.(T)) })
 	return sub
 }
 
@@ -105,6 +183,12 @@ func Unsubscribe[T Event](sub *Subscription[T]) {
 	defer subscriptionsMu.Unlock()
 	key := reflect.TypeFor[T]()
 	if subs, ok := subscriptions[key]; ok {
+		if s, found := subs[(*Subscription[Event])(sub)]; found {
+			// Non-blocking, so a callback may unsubscribe itself —
+			// SubscribeUntil does exactly that, from the delivery goroutine
+			// this stops.
+			s.stop()
+		}
 		delete(subs, (*Subscription[Event])(sub))
 		if len(subs) == 0 {
 			delete(subscriptions, key)
@@ -116,8 +200,11 @@ func (e *Subscription[T]) Unsubscribe() {
 	Unsubscribe(e)
 }
 
-// Emit notifies all subscribers of the event, passing event data. Callbacks are invoked
-// asynchronously in separate goroutines.
+// Emit notifies all subscribers of the event, passing event data. It does not wait for them.
+//
+// Each subscriber receives events in the order they were emitted. Different
+// subscribers still run concurrently with each other; only one subscriber's
+// own callbacks are serialized.
 func Emit[T Event](evt T) {
 	key := reflect.TypeFor[T]()
 	// Snapshot the callbacks into a slice under the RLock, then drop
@@ -128,26 +215,19 @@ func Emit[T Event](evt T) {
 	// territory under load.
 	subscriptionsMu.RLock()
 	subsMap := subscriptions[key]
-	cbs := make([]func(any), 0, len(subsMap))
-	for _, cb := range subsMap {
-		cbs = append(cbs, cb)
+	subs := make([]*subscriber, 0, len(subsMap))
+	for _, s := range subsMap {
+		subs = append(subs, s)
 	}
 	subscriptionsMu.RUnlock()
 	// Diagnostic hook; default no-op so high-frequency event types
 	// don't flood logs in prod. Tests / debugging swap in a real
 	// logger via SetEmitDebugLogger.
 	if fn := emitDebugLogger.Load(); fn != nil {
-		(*fn)(key, len(cbs))
+		(*fn)(key, len(subs))
 	}
-	for _, cb := range cbs {
-		go func() {
-			defer func() {
-				if r := recover(); r != nil {
-					slog.Error("Panic in event callback", "error", r, "event", key.String())
-				}
-			}()
-			cb(evt)
-		}()
+	for _, s := range subs {
+		s.enqueue(key, evt)
 	}
 }
 

--- a/events/ordering_test.go
+++ b/events/ordering_test.go
@@ -145,10 +145,11 @@ func TestSubscribeUntil_CanUnsubscribeFromInsideItsOwnCallback(t *testing.T) {
 	}
 }
 
-// Unsubscribe must stop delivery goroutines. Without this the package leaks
-// one goroutine per subscription for the process lifetime, which it did not
-// before ordering required a goroutine to exist at all.
-func TestUnsubscribe_StopsTheDeliveryGoroutine(t *testing.T) {
+// Unsubscribe must end the delivery goroutine, not merely signal it. Ordering
+// required a goroutine per subscription where the package previously held
+// none, so anything short of it actually returning is a leak for the process
+// lifetime — and observing the stop signal alone would not have shown that.
+func TestUnsubscribe_EndsTheDeliveryGoroutine(t *testing.T) {
 	sub := Subscribe(func(orderedEvt) {})
 	subscriptionsMu.RLock()
 	s := subscriptions[reflect.TypeFor[orderedEvt]()][(*Subscription[Event])(sub)]
@@ -158,9 +159,9 @@ func TestUnsubscribe_StopsTheDeliveryGoroutine(t *testing.T) {
 	}
 	sub.Unsubscribe()
 	select {
-	case <-s.stopped:
+	case <-s.exited:
 	case <-time.After(5 * time.Second):
-		t.Fatal("delivery goroutine was never signalled to stop")
+		t.Fatal("delivery goroutine never returned")
 	}
 }
 

--- a/events/ordering_test.go
+++ b/events/ordering_test.go
@@ -163,3 +163,51 @@ func TestUnsubscribe_StopsTheDeliveryGoroutine(t *testing.T) {
 		t.Fatal("delivery goroutine was never signalled to stop")
 	}
 }
+
+// Unsubscribe must stop delivery of events already sitting in the queue, not
+// just future ones. Once stopped is closed, it and a queued event are both
+// ready select cases and the choice is random — so without a second check
+// after dequeuing, a caller that unsubscribed could still be called back up to
+// a full queue's worth of times.
+//
+// SubscribeUntil does not expose this: it carries its own done flag, which
+// swallows the late delivery instead of preventing it. Only a plain Subscribe
+// shows the behaviour.
+//
+// Looped, because a single round can survive the random choice by luck.
+func TestUnsubscribe_DropsEventsAlreadyQueued(t *testing.T) {
+	for r := 0; r < 20; r++ {
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		var mu sync.Mutex
+		var got []int
+
+		sub := Subscribe(func(e orderedEvt) {
+			mu.Lock()
+			got = append(got, e.n)
+			first := len(got) == 1
+			mu.Unlock()
+			if first {
+				close(entered)
+				<-release // hold the goroutine inside the first delivery
+			}
+		})
+
+		// Emit never blocks, so all four are queued before the callback for
+		// the first one has finished.
+		for i := 0; i < 4; i++ {
+			Emit(orderedEvt{n: i})
+		}
+		<-entered
+		sub.Unsubscribe()
+		close(release)
+
+		time.Sleep(20 * time.Millisecond)
+		mu.Lock()
+		delivered := append([]int(nil), got...)
+		mu.Unlock()
+		if len(delivered) != 1 {
+			t.Fatalf("round %d: delivered %v after Unsubscribe; want only [0]", r, delivered)
+		}
+	}
+}

--- a/events/ordering_test.go
+++ b/events/ordering_test.go
@@ -193,6 +193,9 @@ func TestUnsubscribe_DropsEventsAlreadyQueued(t *testing.T) {
 				<-release // hold the goroutine inside the first delivery
 			}
 		})
+		subscriptionsMu.RLock()
+		s := subscriptions[reflect.TypeFor[orderedEvt]()][(*Subscription[Event])(sub)]
+		subscriptionsMu.RUnlock()
 
 		// Emit never blocks, so all four are queued before the callback for
 		// the first one has finished.
@@ -203,7 +206,14 @@ func TestUnsubscribe_DropsEventsAlreadyQueued(t *testing.T) {
 		sub.Unsubscribe()
 		close(release)
 
-		time.Sleep(20 * time.Millisecond)
+		// Waiting for the goroutine to return is exact, where a sleep would
+		// only be probably-long-enough — and it cannot pass by finishing
+		// before a late delivery that was still coming.
+		select {
+		case <-s.exited:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("round %d: delivery goroutine never returned", r)
+		}
 		mu.Lock()
 		delivered := append([]int(nil), got...)
 		mu.Unlock()

--- a/events/ordering_test.go
+++ b/events/ordering_test.go
@@ -1,0 +1,165 @@
+package events
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+type orderedEvt struct{ n int }
+
+func (orderedEvt) IsEvent() {}
+
+// The bug this package shipped with: Emit spawned a goroutine per callback per
+// event, so nothing ordered two Emits against each other. Consumers that
+// render the newest state — the share card takes the phase from whichever
+// frame arrived last — settled on an arbitrary one, which is how a peer that
+// had already registered kept reading "discovering public IP".
+//
+// Written as a loop because a single round can come out ordered by luck. The
+// pre-fix implementation failed all 200.
+func TestEmit_DeliversInOrderToASubscriber(t *testing.T) {
+	const rounds, perRound = 200, 8
+
+	for r := 0; r < rounds; r++ {
+		var mu sync.Mutex
+		got := make([]int, 0, perRound)
+		done := make(chan struct{})
+		sub := Subscribe(func(e orderedEvt) {
+			mu.Lock()
+			got = append(got, e.n)
+			full := len(got) == perRound
+			mu.Unlock()
+			if full {
+				close(done)
+			}
+		})
+
+		for i := 0; i < perRound; i++ {
+			Emit(orderedEvt{n: i})
+		}
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			sub.Unsubscribe()
+			t.Fatalf("round %d: only %d of %d events delivered", r, len(got), perRound)
+		}
+		sub.Unsubscribe()
+
+		mu.Lock()
+		for i, n := range got {
+			if n != i {
+				mu.Unlock()
+				t.Fatalf("round %d: delivered out of order: %v", r, got)
+			}
+		}
+		mu.Unlock()
+	}
+}
+
+// Ordering is per subscriber, not global: two subscribers must still run
+// concurrently, or one slow consumer would stall every other one. A callback
+// that blocks until the other side has finished can only pass if they do.
+func TestEmit_SubscribersDoNotBlockEachOther(t *testing.T) {
+	first := make(chan struct{})
+	second := make(chan struct{})
+
+	subA := Subscribe(func(orderedEvt) {
+		close(first)
+		<-second // held until B runs; deadlocks if delivery is serialized
+	})
+	defer subA.Unsubscribe()
+	subB := Subscribe(func(orderedEvt) {
+		<-first
+		close(second)
+	})
+	defer subB.Unsubscribe()
+
+	Emit(orderedEvt{})
+	select {
+	case <-second:
+	case <-time.After(5 * time.Second):
+		t.Fatal("subscribers were serialized against each other")
+	}
+}
+
+// Emit must not wait for subscribers. peer.Client emits lifecycle phases from
+// the goroutine bringing the session up, so an Emit that blocked on a wedged
+// consumer would stall the thing being reported on.
+func TestEmit_DoesNotWaitForASubscriber(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+	sub := Subscribe(func(orderedEvt) { <-release })
+	defer sub.Unsubscribe()
+
+	returned := make(chan struct{})
+	go func() {
+		// More than the queue depth, so this also covers the drop path
+		// rather than merely filling the buffer.
+		for i := 0; i < queueDepth+16; i++ {
+			Emit(orderedEvt{n: i})
+		}
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Emit blocked on a subscriber that was not consuming")
+	}
+}
+
+// SubscribeUntil unsubscribes from inside the callback, which now runs on the
+// very goroutine Unsubscribe stops. If stopping ever waited for that goroutine
+// to finish, this would deadlock rather than fail.
+func TestSubscribeUntil_CanUnsubscribeFromInsideItsOwnCallback(t *testing.T) {
+	done := make(chan int, 4)
+	SubscribeUntil(func(e orderedEvt) { done <- e.n }, func(e orderedEvt) bool { return e.n == 1 })
+
+	Emit(orderedEvt{n: 0})
+	Emit(orderedEvt{n: 1})
+	Emit(orderedEvt{n: 2})
+
+	select {
+	case n := <-done:
+		if n != 0 {
+			t.Fatalf("first delivery was %d, want 0", n)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("no delivery; self-unsubscribe likely deadlocked")
+	}
+	select {
+	case n := <-done:
+		if n != 1 {
+			t.Fatalf("second delivery was %d, want 1", n)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("second delivery never arrived")
+	}
+	// The condition matched on 1, so 2 must not arrive.
+	select {
+	case n := <-done:
+		t.Fatalf("delivered %d after the subscription ended", n)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// Unsubscribe must stop delivery goroutines. Without this the package leaks
+// one goroutine per subscription for the process lifetime, which it did not
+// before ordering required a goroutine to exist at all.
+func TestUnsubscribe_StopsTheDeliveryGoroutine(t *testing.T) {
+	sub := Subscribe(func(orderedEvt) {})
+	subscriptionsMu.RLock()
+	s := subscriptions[reflect.TypeFor[orderedEvt]()][(*Subscription[Event])(sub)]
+	subscriptionsMu.RUnlock()
+	if s == nil {
+		t.Fatal("subscription not registered")
+	}
+	sub.Unsubscribe()
+	select {
+	case <-s.stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("delivery goroutine was never signalled to stop")
+	}
+}

--- a/ipc/client_events_mobile.go
+++ b/ipc/client_events_mobile.go
@@ -90,8 +90,11 @@ func (c *Client) DataCapStream(ctx context.Context, handler func(account.DataCap
 // → registering → verifying → serving on Start, stopping → idle on Stop,
 // error on failure). Each frame is a peer.StatusEvent JSON whose .Status
 // is the live snapshot at the moment the event fired — consumers SHOULD
-// re-render on every frame rather than diffing, since events.Emit's
-// per-callback goroutine can land Start phases out of order. Mobile builds
+// re-render on every frame rather than diffing. Frames arrive in the order
+// they were emitted, so the last one seen is the current phase; that was not
+// true before the event bus serialized delivery per subscriber, and a
+// consumer rendering the newest frame could settle on a stale phase.
+// Mobile builds
 // may share a process with radiance (localOnly), in which case
 // events.SubscribeContext delivers directly; otherwise the SSE retry loop
 // is used. Blocks until ctx is cancelled.

--- a/ipc/client_events_mobile.go
+++ b/ipc/client_events_mobile.go
@@ -90,10 +90,14 @@ func (c *Client) DataCapStream(ctx context.Context, handler func(account.DataCap
 // → registering → verifying → serving on Start, stopping → idle on Stop,
 // error on failure). Each frame is a peer.StatusEvent JSON whose .Status
 // is the live snapshot at the moment the event fired — consumers SHOULD
-// re-render on every frame rather than diffing. Frames arrive in the order
-// they were emitted, so the last one seen is the current phase; that was not
-// true before the event bus serialized delivery per subscriber, and a
-// consumer rendering the newest frame could settle on a stale phase.
+// re-render on every frame rather than diffing.
+//
+// Frames from the event bus arrive in the order they were emitted, which was
+// not true before it serialized delivery per subscriber: a consumer rendering
+// the newest frame could settle on a stale phase. That guarantee covers the
+// bus only. This method can feed handler from two independent sources at once
+// (below), and nothing orders them against each other, so a delayed SSE frame
+// can still follow a newer local one.
 // Mobile builds
 // may share a process with radiance (localOnly), in which case
 // events.SubscribeContext delivers directly; otherwise the SSE retry loop

--- a/ipc/client_events_nonmobile.go
+++ b/ipc/client_events_nonmobile.go
@@ -59,9 +59,8 @@ func (c *Client) DataCapStream(ctx context.Context, handler func(account.DataCap
 // → registering → verifying → serving on Start, stopping → idle on Stop,
 // error on failure). Each frame is a peer.StatusEvent JSON whose .Status
 // is the live snapshot at the moment the event fired — consumers SHOULD
-// re-render on every frame rather than diffing, since events.Emit's
-// per-callback goroutine can land Start phases out of order. Blocks until
-// ctx is cancelled.
+// re-render on every frame rather than diffing. Frames arrive in order, so
+// the last one seen is the current phase. Blocks until ctx is cancelled.
 func (c *Client) PeerStatusEvents(ctx context.Context, handler func(peer.StatusEvent)) error {
 	return c.sseRetryLoop(ctx, peerStatusEventsEndpoint, func(data []byte) {
 		var evt peer.StatusEvent

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -496,10 +496,10 @@ func (s *localapi) peerStatusHandler(w http.ResponseWriter, r *http.Request) {
 
 // peerStatusEventsHandler streams peer.StatusEvent over SSE. The wire
 // payload is always the live snapshot from PeerStatus(), not the event's
-// captured value: events.Emit dispatches each callback on its own goroutine
-// so a quick start→stop pair can land out of order, and we'd send a stale
-// "active" after a "inactive". Reading the live snapshot when the trigger
-// fires guarantees the SSE consumer's last message reflects current state.
+// captured value: the trigger below coalesces, so a burst of phases becomes
+// one wakeup and the captured value could be one the consumer never needed.
+// Reading the live snapshot when the trigger fires guarantees the SSE
+// consumer's last message reflects current state.
 func (s *localapi) peerStatusEventsHandler(w http.ResponseWriter, r *http.Request) {
 	flusher := sseWriter(w)
 	if flusher == nil {
@@ -538,9 +538,7 @@ func (s *localapi) peerStatusEventsHandler(w http.ResponseWriter, r *http.Reques
 // each accept/close on the local samizdat-in. Unlike peerStatusEventsHandler
 // (which always sends the live snapshot), each emit's captured value is
 // what the consumer needs here — the Source IP and +1/-1 state ARE the
-// payload, not a periodic poll. Out-of-order +1/-1 from events.Emit's
-// per-callback goroutine is fine: the consumer (lantern-core's globe-arc
-// renderer) keys arcs by source, so it handles re-orderings naturally.
+// payload, not a periodic poll, so none may be collapsed into a wakeup.
 //
 // The events package lives in this process (lanternd); cross-process
 // consumers in Liblantern can only receive these via this SSE stream,

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -562,7 +562,8 @@ func (s *localapi) peerConnectionEventsHandler(w http.ResponseWriter, r *http.Re
 		case queue <- evt:
 		default:
 			// queue full — drop. SSE consumer is too slow; better to
-			// lose this event than to back up the events.Emit goroutine.
+			// lose this event here than to stall this subscription's
+			// delivery goroutine and have the bus drop from further back.
 		}
 	})
 	defer sub.Unsubscribe()

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -551,10 +551,11 @@ func (s *localapi) peerConnectionEventsHandler(w http.ResponseWriter, r *http.Re
 	if flusher == nil {
 		return
 	}
-	// Buffered channel so a slow SSE consumer doesn't apply backpressure
-	// to events.Emit (which spawns a goroutine per subscriber but blocks
-	// nothing). 64 holds ~one second of accept/close pairs under heavy
-	// load; beyond that we drop to avoid unbounded memory growth.
+	// Buffered channel so a slow SSE consumer doesn't stall this
+	// subscription's delivery goroutine, which would eventually fill the
+	// bus's own queue and start dropping. 64 holds ~one second of
+	// accept/close pairs under heavy load; beyond that we drop here to
+	// avoid unbounded memory growth.
 	queue := make(chan peer.ConnectionEvent, 64)
 	sub := events.Subscribe(func(evt peer.ConnectionEvent) {
 		select {

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -164,7 +164,7 @@ type Client struct {
 	// before invoking it, so SetListener(nil) alone races against in-flight
 	// Notify calls — under load (real client traffic), Close fires N disconnect
 	// callbacks from N goroutines that have already snapshotted the listener,
-	// each then events.Emit spawns one more goroutine per subscriber. The
+	// each then emitting an event to every subscriber. The
 	// Flutter-side subscriber posts main-thread tasks per event, and a
 	// hundred-task flood against a Flutter engine that's simultaneously
 	// processing the SmC-off state change is the Flutter mutex crash we hit.

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -880,10 +880,11 @@ func TestClient_StatusEventEmittedOnStartAndStop(t *testing.T) {
 }
 
 // drainPhases reads up to n StatusEvents from got and returns them
-// keyed by Phase (last event per phase wins). Used by tests that need
-// set-membership semantics rather than strict ordering because
-// events.Emit's per-callback goroutines deliver out of order under
-// the runtime's scheduling.
+// keyed by Phase (last event per phase wins). Used by tests that care
+// which phases occurred rather than in what order. The bus does deliver
+// them in order now, so those tests could assert the sequence instead;
+// they do not, because the phase a given step emits is not what they are
+// pinning.
 func drainPhases(t *testing.T, got <-chan StatusEvent, n int) map[Phase]StatusEvent {
 	t.Helper()
 	out := make(map[Phase]StatusEvent, n)

--- a/unbounded/unbounded_test.go
+++ b/unbounded/unbounded_test.go
@@ -664,8 +664,8 @@ func TestConnectionEventBridge(t *testing.T) {
 	cb := *captured.Load()
 	require.NotNil(t, cb, "OnConnectionChangeFunc must be installed on bfOpt")
 
-	// Buffered enough that events.Emit's per-callback goroutines
-	// can deposit before the test reads.
+	// Buffered so the subscription's delivery goroutine can deposit
+	// without blocking before the test reads.
 	ch := make(chan ConnectionEvent, 4)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
The share card sat on **"discovering public IP"** while the peer had long since moved past it. The phase text was not stale because a phase event was lost — it was stale because the events arrived in the wrong order, and the card renders whichever frame landed last.

`Emit` spawned a goroutine per callback *per event*, so nothing ordered two `Emit` calls against each other:

```go
for _, cb := range cbs {
    go func() { ... cb(evt) }()
}
```

## This is the normal case, not a rare race

Emitting eight events to one subscriber, 200 times:

```
first reordered delivery: [0 3 1 2 7 6 5 4]
RESULT: 200/200 rounds delivered out of emit order
```

Every single round. The last event a consumer saw was routinely not the last one sent — in that sample the final delivery was `4`, not `7`. Any consumer that renders the newest frame was rendering an arbitrary one.

The package's own docs already recorded the symptom without connecting it to the cause. From `ipc/client_events_mobile.go`:

> consumers SHOULD re-render on every frame rather than diffing, since `events.Emit`'s per-callback goroutine can land Start phases out of order

That comment is updated here, since it now describes a hazard that no longer exists.

## What changed

Each subscription owns a FIFO queue drained by a single goroutine. Ordering is **per subscriber**, not global — different subscribers still run concurrently, so one slow consumer cannot stall the others.

`Emit` still never blocks. Callers depend on that: `peer.Client` emits lifecycle phases from the same goroutine that is bringing the session up, so an `Emit` that waited on a wedged consumer would stall the very thing it is reporting on. A full queue is dropped and logged loudly rather than waited on — at 256 deep, for event types that fire a handful of times per user action, reaching it means the callback is wedged, not busy.

`Unsubscribe` stops the delivery goroutine and does so *without waiting for it*, because `SubscribeUntil` unsubscribes from inside its own callback — which now runs on the very goroutine being stopped. That would deadlock under the obvious implementation, so there is a test for it.

## Why this is in the bus rather than in the UI

On macOS the NE path builds a `LocalBackend` in-process, so `PeerStatusEvents` delivers through `events.SubscribeContext` directly — the Dart handler is fed straight off this bus with nothing in between to re-serialize. The SSE path in `ipc/server.go` happens to be insulated (it coalesces to a trigger and re-reads the current snapshot), but the in-process path is not, and it is the one desktop uses.

Fixing it in one consumer would leave the same hazard for the other 30-odd subscription sites, every one of which assumes ordered delivery today.

## Also fixed in review: delivery after Unsubscribe

Both reviewers independently caught that the delivery goroutine could keep invoking a callback *after* `Unsubscribe` returned: once `stopped` is closed, it and a queued event are both ready `select` cases and the choice is random.

Pre-existing in kind — `Emit` always snapshotted callbacks before firing — but serializing widened the window from one in-flight event to a full queue of 256, turning a rare race into a reliable one. The run loop now re-checks after dequeuing.

My own test missed it, and would have kept missing it: it exercised `SubscribeUntil`, which carries its own `done` flag that *swallows* a late delivery rather than preventing it. It passed against the bug. Replaced with one driving a plain `Subscribe`.

## Tests

Six. Each was checked against the implementation it guards, not just run green:

| Test | Fails against |
|---|---|
| `DeliversInOrderToASubscriber` | old fan-out — `round 0: delivered out of order: [7 4 5 6 1 0 2 3]` |
| `DropsEventsAlreadyQueued` | missing post-dequeue check — `delivered [0 1 2 3] after Unsubscribe` |
| `EndsTheDeliveryGoroutine` | a stop that signals but never returns — `delivery goroutine never returned` |
| `SubscribersDoNotBlockEachOther` | any globally-serialized delivery |
| `DoesNotWaitForASubscriber` | an `Emit` that blocks (driven past queue depth, so it covers the drop path) |
| `SubscribeUntil_CanUnsubscribeFromInsideItsOwnCallback` | a stop that waits on its own goroutine |

Two of these exist because a reviewer showed the earlier version proved nothing — the unsubscribe test asserted only that the stop *signal* had been sent, so `subscriber` now closes an `exited` channel when `run` returns and the test waits on that.

## Risk

This is a core primitive with ~34 subscription sites. Two things worth a reviewer's attention:

1. **`Subscribe` now holds a goroutine** until `Unsubscribe`, where before it held none. I audited every site: the per-request SSE handlers all `defer sub.Unsubscribe()`, and the rest are process-lifetime listeners. No subscribe-in-a-loop.
2. **Events can now be dropped** under a wedged consumer, where previously they would pile up as goroutines instead. That is a deliberate trade — unbounded goroutine growth is the failure mode that is harder to see — and it is logged at `Error`.

Full suite passes (`go build -tags standalone,with_clash_api ./...` clean, `-race` clean on `events` and `peer`).

`gofmt` reports pre-existing drift in `ipc/middlewares.go`; untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MYMwy9Pu5Ji3xpYK8Nzj3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Event notifications now preserve order for each subscriber.
  * Subscribers can receive events concurrently without blocking one another.
  * Event emission remains responsive when subscribers are slow; excess events may be dropped.
  * Callback failures no longer stop ongoing event delivery.
  * Unsubscribing safely stops further notifications, including during callback execution.
  * Peer status event documentation now reflects ordered delivery and current-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
