### PR TITLE
build: bump lantern-box to v0.0.114 for samizdat dial retry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/getlantern/domainfront v0.0.0-20260722204513-8c1f8acfa715
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3
 	github.com/getlantern/kindling v0.0.0-20260818180827-1583458ab9b7
-	github.com/getlantern/lantern-box v0.0.113
+	github.com/getlantern/lantern-box v0.0.114
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb
@@ -118,7 +118,7 @@ require (
 	github.com/gaukas/wazerofs v0.1.0 // indirect
 	github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52 // indirect
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 // indirect
-	github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 // indirect
+	github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064 // indirect
 	github.com/go-chi/chi/v5 v5.2.2 // indirect
 	github.com/go-json-experiment/json v0.0.0-20250103232110-6a9a0fde9288 // indirect
 	github.com/go-llsqlite/adapter v0.0.0-20230927005056-7f5ce7f0c916 // indirect

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvd
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260818180827-1583458ab9b7 h1:uQWqnkaLL5n4BmTly7a+xjySH9bQnz3vB+Gvgs1Bwgw=
 github.com/getlantern/kindling v0.0.0-20260818180827-1583458ab9b7/go.mod h1:ZEPFiB6rH6MtMN1O7b5gE+LJpCsRFzAn4u8lbIxHh3w=
-github.com/getlantern/lantern-box v0.0.113 h1:G48dLWe1SQo8Ec7PC2vDn2FLbwCmlzwztKc7zT10pgI=
-github.com/getlantern/lantern-box v0.0.113/go.mod h1:b+gDOk1Wgd/cEL4Q0cSQJAfZuNQPCqIDwNhxXwLPg8g=
+github.com/getlantern/lantern-box v0.0.114 h1:KlguJNuj3QdEyVTAVZoGN2i880dgzrR1w+n8KgdzTMM=
+github.com/getlantern/lantern-box v0.0.114/go.mod h1:8pVq9ECh1OCZRMSOn5YfLxHwS2OE2BAaXdIKY62y2x4=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395/go.mod h1:3JpJgwi4KEI6rS9loOAvcBp+F2jP65d0tTg2GQcTPBU=
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 h1:3BwvWj0JZzFEvNNiMhCu4bf60nqcIuQpTYb00Ezm1ag=
@@ -258,8 +258,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 h1:RZd3CELOtQUEzIE5kPdEO9HYg+7JYbR3OTdC+3P/wng=
-github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
+github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064 h1:NhCyQAWGEWjok/jg4gRD6fzCZvyOQy/4dVSFYhzU5xk=
+github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb/go.mod h1:GkPT5P9JoOTIRXRmFWxYgu1hhXgTFFTNc2hoG7WQc3g=
 github.com/getlantern/sing v0.7.18-lantern h1:QKGgIUA3LwmKYP/7JlQTRkxj9jnP4cX2Q/B+nd8XEjo=


### PR DESCRIPTION
## What

Bumps `github.com/getlantern/lantern-box` `v0.0.113` → `v0.0.114`, which carries `samizdat` `v0.0.3-0.20260724223841-a5ee9ab56830` → `v0.0.3-0.20260819153658-ebc74116a064`.

Dependency bump only — no radiance code changes.

## Why

Second link in the chain for [getlantern/samizdat#15](https://github.com/getlantern/samizdat/pull/15), pulled into lantern-box by [getlantern/lantern-box#308](https://github.com/getlantern/lantern-box/pull/308) (see that PR for the failure sequence).

Short version: on adversarial ISPs, DPI resets the shared TLS+H2 conn to a Samizdat server. `connPool.getTransport` could return a pooled transport whose conn was already dead but not yet marked closed; `openTunnel` then failed conn-fatally and retired it, but `Client.DialContext` surfaced that as a hard dial failure even though the next `getTransport` would have produced a working transport. It now retries on a fresh transport, bounded at 3 attempts. Caller cancellation and non-200 CONNECT responses still fail immediately.

Note that `samizdat` moves as an **indirect** dep here — radiance has no direct import, so the version has to arrive through lantern-box's `go.mod` rather than a direct `go get`.

## Verification

```
go build ./...                    # see caveat below
go mod tidy                       # no incidental churn; diff is lantern-box + samizdat lines only
go test ./backend/... ./bypass/... ./config/... ./servers/... \
        ./unbounded/... ./vpn/... ./peer/...   # 8/8 ok
```

Test selection is every package that references `lantern-box` or `samizdat`.

⚠️ **Pre-existing build break on `main`, not from this PR:** `cmd/lantern/lantern.go:170` fails with

```
not enough arguments in call to ipc.NewClient
    have ()
    want (context.Context, "github.com/getlantern/radiance/backend".Options)
```

Reproduced on unmodified `origin/main` (`git stash` + `go build ./...`), so it predates this bump and is unrelated (radiance-internal `ipc`/`backend` signature drift). Everything else builds clean: `go build $(go list ./... | grep -v '/cmd/lantern$')` exits 0. Worth a separate fix.

## Follow-ups

`lantern` bump lands next, once this merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying module dependencies to newer versions.
  * No user-facing features or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->