### PR TITLE
bump lantern-box to v0.0.116 - rankedLock fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/getlantern/domainfront v0.0.0-20260722204513-8c1f8acfa715
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3
 	github.com/getlantern/kindling v0.0.0-20260818180827-1583458ab9b7
-	github.com/getlantern/lantern-box v0.0.115
+	github.com/getlantern/lantern-box v0.0.116
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb

--- a/go.sum
+++ b/go.sum
@@ -258,8 +258,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvd
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260818180827-1583458ab9b7 h1:uQWqnkaLL5n4BmTly7a+xjySH9bQnz3vB+Gvgs1Bwgw=
 github.com/getlantern/kindling v0.0.0-20260818180827-1583458ab9b7/go.mod h1:ZEPFiB6rH6MtMN1O7b5gE+LJpCsRFzAn4u8lbIxHh3w=
-github.com/getlantern/lantern-box v0.0.115 h1:B/ORP5XPaPGUrwZiFzN9Jqp67xdAMjkCM5kwZRWXhWY=
-github.com/getlantern/lantern-box v0.0.115/go.mod h1:ykxfn5L08D6Vk5PHEReI5WTyQ4IAsZJ6b31WVOwO9dE=
+github.com/getlantern/lantern-box v0.0.116 h1:ngCXXS/djiZZLSMbw6ZN0jb+07oJN52gMh1fFtwojP0=
+github.com/getlantern/lantern-box v0.0.116/go.mod h1:ykxfn5L08D6Vk5PHEReI5WTyQ4IAsZJ6b31WVOwO9dE=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395/go.mod h1:3JpJgwi4KEI6rS9loOAvcBp+F2jP65d0tTg2GQcTPBU=
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 h1:3BwvWj0JZzFEvNNiMhCu4bf60nqcIuQpTYb00Ezm1ag=


### PR DESCRIPTION
Pull in a fix for the ranking servers after running the ladder eval.

closes https://github.com/getlantern/engineering/issues/3821

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to the latest available version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->