### PR TITLE
windows: restart daemon children without stopping LanternSvc

### DIFF
--- a/cmd/lanternd/lanternd.go
+++ b/cmd/lanternd/lanternd.go
@@ -240,6 +240,11 @@ type childProcess struct {
 	logger   *slog.Logger
 }
 
+const (
+	daemonRestartBackoffMax        = 60 * time.Second
+	daemonRestartBackoffResetAfter = 2 * time.Minute
+)
+
 // spawnChild creates and starts a daemon child process with piped I/O. The child's stdout and
 // stderr are merged and drained through the provided logger (or os.Stdout as fallback).
 func spawnChild(args []string, dataPath, logPath, logLevel string) (*childProcess, error) {
@@ -345,8 +350,7 @@ func babysit(args []string, dataPath, logPath, logLevel string) error {
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	stopping := false
 
-	const resetAfter = 2 * time.Minute // reset backoff if child ran longer than this
-	bo := common.NewBackoff(60 * time.Second)
+	bo := common.NewBackoff(daemonRestartBackoffMax)
 
 	for {
 		child, err := spawnChild(args, dataPath, logPath, logLevel)
@@ -384,7 +388,7 @@ func babysit(args []string, dataPath, logPath, logLevel string) error {
 		}
 
 		// Reset backoff if the child ran for a while (i.e. it wasn't a fast crash loop).
-		if time.Since(startedAt) > resetAfter {
+		if time.Since(startedAt) > daemonRestartBackoffResetAfter {
 			bo.Reset()
 		}
 

--- a/cmd/lanternd/lanternd.go
+++ b/cmd/lanternd/lanternd.go
@@ -241,7 +241,9 @@ type childProcess struct {
 }
 
 const (
-	daemonRestartBackoffMax        = 60 * time.Second
+	// daemonRestartBackoffMax keeps repeated crashes from delaying recovery by more than a minute.
+	daemonRestartBackoffMax = 60 * time.Second
+	// daemonRestartBackoffResetAfter marks a child as stable so a later failure restarts promptly.
 	daemonRestartBackoffResetAfter = 2 * time.Minute
 )
 
@@ -338,12 +340,10 @@ func (c *childProcess) HandleCrash(err error) {
 	vpn.AttemptFixNetState()
 }
 
-// babysit runs the daemon as a child process and monitors it. If the child exits unexpectedly
-// (crash, panic, etc.), the parent immediately cleans up any stale VPN network state and
-// automatically restarts the child process with quadratic backoff and jitter.
+// babysit keeps the parent alive across unexpected child exits, using the shared quadratic
+// backoff between restarts.
 //
-// Graceful shutdown is signaled by closing the child's stdin pipe — this works cross-platform,
-// including inside a Windows service where there is no console for signal delivery.
+// Graceful shutdown closes stdin because the Windows service has no console for signal delivery.
 func babysit(args []string, dataPath, logPath, logLevel string) error {
 	// On termination signal, request graceful shutdown of the current child.
 	sigCh := make(chan os.Signal, 1)

--- a/cmd/lanternd/lanternd.go
+++ b/cmd/lanternd/lanternd.go
@@ -340,7 +340,7 @@ func (c *childProcess) HandleCrash(err error) {
 
 // babysit runs the daemon as a child process and monitors it. If the child exits unexpectedly
 // (crash, panic, etc.), the parent immediately cleans up any stale VPN network state and
-// automatically restarts the child process with exponential backoff.
+// automatically restarts the child process with quadratic backoff and jitter.
 //
 // Graceful shutdown is signaled by closing the child's stdin pipe — this works cross-platform,
 // including inside a Windows service where there is no console for signal delivery.

--- a/cmd/lanternd/lanternd.go
+++ b/cmd/lanternd/lanternd.go
@@ -340,8 +340,7 @@ func (c *childProcess) HandleCrash(err error) {
 	vpn.AttemptFixNetState()
 }
 
-// babysit keeps the parent alive across unexpected child exits, using the shared quadratic
-// backoff between restarts.
+// babysit keeps the parent alive across unexpected child exits, using quadratic backoff between restarts.
 //
 // Graceful shutdown closes stdin because the Windows service has no console for signal delivery.
 func babysit(args []string, dataPath, logPath, logLevel string) error {

--- a/cmd/lanternd/lanternd_windows.go
+++ b/cmd/lanternd/lanternd_windows.go
@@ -75,7 +75,24 @@ func install(dataPath, logPath, logLevel string, environment daemonEnvironment) 
 	}
 	defer service.Close()
 
-	err = service.SetRecoveryActions([]mgr.RecoveryAction{
+	if err := configureWindowsServiceRecovery(service); err != nil {
+		return err
+	}
+	if err := service.Start(); err != nil {
+		return fmt.Errorf("failed to start service: %w", err)
+	}
+
+	slog.Info("Windows service installed successfully")
+	return nil
+}
+
+type windowsServiceRecoveryConfigurer interface {
+	SetRecoveryActions([]mgr.RecoveryAction, uint32) error
+	SetRecoveryActionsOnNonCrashFailures(bool) error
+}
+
+func configureWindowsServiceRecovery(service windowsServiceRecoveryConfigurer) error {
+	if err := service.SetRecoveryActions([]mgr.RecoveryAction{
 		{Type: mgr.ServiceRestart, Delay: 1 * time.Second},
 		{Type: mgr.ServiceRestart, Delay: 2 * time.Second},
 		{Type: mgr.ServiceRestart, Delay: 4 * time.Second},
@@ -83,15 +100,12 @@ func install(dataPath, logPath, logLevel string, environment daemonEnvironment) 
 		{Type: mgr.ServiceRestart, Delay: 16 * time.Second},
 		{Type: mgr.ServiceRestart, Delay: 32 * time.Second},
 		{Type: mgr.ServiceRestart, Delay: 64 * time.Second},
-	}, 60)
-	if err != nil {
+	}, 60); err != nil {
 		return fmt.Errorf("failed to set service recovery actions: %w", err)
 	}
-	if err := service.Start(); err != nil {
-		return fmt.Errorf("failed to start service: %w", err)
+	if err := service.SetRecoveryActionsOnNonCrashFailures(true); err != nil {
+		return fmt.Errorf("failed to enable recovery actions for non-crash failures: %w", err)
 	}
-
-	slog.Info("Windows service installed successfully")
 	return nil
 }
 
@@ -152,10 +166,51 @@ func maybePlatformService() bool {
 	return true
 }
 
-type service struct{}
+type windowsServiceChild interface {
+	Done() <-chan error
+	RequestShutdown()
+	WaitOrKill(time.Duration) error
+	HandleCrash(error)
+	info(string, ...any)
+}
+
+type windowsServiceChildProcess struct {
+	*childProcess
+}
+
+func (c *windowsServiceChildProcess) info(message string, args ...any) {
+	c.logger.Info(message, args...)
+}
+
+type windowsServiceBackoff interface {
+	Wait(context.Context)
+	Reset()
+}
+
+type service struct {
+	spawnChild func([]string, string, string, string) (windowsServiceChild, error)
+	newBackoff func() windowsServiceBackoff
+}
+
+// newWindowsService returns a production service handler. Its injected process and backoff
+// functions keep supervision tests independent of OS processes and wall-clock delays.
+func newWindowsService() *service {
+	return &service{
+		spawnChild: func(args []string, dataPath, logPath, logLevel string) (windowsServiceChild, error) {
+			child, err := spawnChild(args, dataPath, logPath, logLevel)
+			if err != nil {
+				return nil, err
+			}
+			return &windowsServiceChildProcess{childProcess: child}, nil
+		},
+		newBackoff: func() windowsServiceBackoff {
+			return common.NewBackoff(daemonRestartBackoffMax)
+		},
+	}
+}
 
 func startWindowsService() error {
-	return svc.Run(serviceName, &service{})
+	return svc.Run(serviceName, newWindowsService())
 }
 
 func (s *service) Execute(args []string, r <-chan svc.ChangeRequest, status chan<- svc.Status) (bool, uint32) {
@@ -170,33 +225,71 @@ func (s *service) Execute(args []string, r <-chan svc.ChangeRequest, status chan
 		slog.Error("Failed to parse service arguments", "error", err)
 		return true, 1
 	}
+	return s.run(config, r, status)
+}
 
-	// Run the daemon as a child process so we can clean up network state if it crashes,
-	// regardless of whether the SCM is configured to restart the service.
+// run supervises the daemon child so crash cleanup and restart do not depend on SCM recovery.
+func (s *service) run(config serviceRunConfig, r <-chan svc.ChangeRequest, status chan<- svc.Status) (bool, uint32) {
 	childArgs := config.args()
-	child, err := spawnChild(childArgs, config.dataPath, config.logPath, config.logLevel)
+	child, err := s.spawnChild(childArgs, config.dataPath, config.logPath, config.logLevel)
 	if err != nil {
 		slog.Error("Failed to start daemon", "error", err)
 		return true, 1
 	}
 
 	status <- svc.Status{State: svc.Running, Accepts: svc.AcceptStop | svc.AcceptShutdown}
-	child.logger.Info("Running as Windows service")
+	child.info("Running as Windows service")
+
+	backoff := s.newBackoff()
+	startedAt := time.Now()
+	childDone := child.Done()
+	var restartReady <-chan struct{}
+	serviceContext, cancelService := context.WithCancel(context.Background())
+	defer cancelService()
 
 	for {
 		select {
-		case err := <-child.Done():
+		case err := <-childDone:
 			if err != nil {
 				child.HandleCrash(err)
 			}
-			return true, 1
+			if time.Since(startedAt) > daemonRestartBackoffResetAfter {
+				backoff.Reset()
+			}
+			child.info("Restarting daemon process")
+			child = nil
+			childDone = nil
+
+			restartDone := make(chan struct{})
+			restartReady = restartDone
+			go func() {
+				backoff.Wait(serviceContext)
+				close(restartDone)
+			}()
+		case <-restartReady:
+			restartReady = nil
+
+			child, err = s.spawnChild(childArgs, config.dataPath, config.logPath, config.logLevel)
+			if err != nil {
+				slog.Error("Failed to restart daemon", "error", err)
+				return true, 1
+			}
+			startedAt = time.Now()
+			childDone = child.Done()
+			child.info("Running as Windows service")
 		case change := <-r:
 			switch change.Cmd {
 			case svc.Stop, svc.Shutdown:
 				status <- svc.Status{State: svc.StopPending}
-				child.logger.Info("Service stop requested")
-				child.RequestShutdown()
-				child.WaitOrKill(15 * time.Second)
+				cancelService()
+				if restartReady != nil {
+					<-restartReady
+				}
+				if child != nil {
+					child.info("Service stop requested")
+					child.RequestShutdown()
+					child.WaitOrKill(15 * time.Second)
+				}
 				return false, windows.NO_ERROR
 			case svc.Interrogate:
 				status <- change.CurrentStatus

--- a/cmd/lanternd/lanternd_windows.go
+++ b/cmd/lanternd/lanternd_windows.go
@@ -288,7 +288,9 @@ func (s *service) run(config serviceRunConfig, r <-chan svc.ChangeRequest, statu
 				if child != nil {
 					child.info("Service stop requested")
 					child.RequestShutdown()
-					child.WaitOrKill(15 * time.Second)
+					if err := child.WaitOrKill(15 * time.Second); err != nil {
+						slog.Warn("Daemon process did not stop cleanly", "error", err)
+					}
 				}
 				return false, windows.NO_ERROR
 			case svc.Interrogate:

--- a/cmd/lanternd/lanternd_windows.go
+++ b/cmd/lanternd/lanternd_windows.go
@@ -19,10 +19,15 @@ const (
 	serviceName = "LanternSvc"
 	binPath     = "C:\\Program Files\\Lantern\\" + serviceName + ".exe"
 
-	// windowsServiceChildShutdownTimeout bounds the child's graceful shutdown period.
 	windowsServiceChildShutdownTimeout = 15 * time.Second
-	// windowsServiceStopWaitHint includes headroom for forced termination after that period.
+	// windowsServiceStopWaitHint leaves SCM time for forced termination after graceful shutdown
+	// times out.
 	windowsServiceStopWaitHint = 20 * time.Second
+
+	windowsServiceRecoveryMaxDelay = 64 * time.Second
+	// windowsServiceRecoveryResetPeriod keeps the failure count through the longest delay so SCM
+	// advances to the next recovery action.
+	windowsServiceRecoveryResetPeriod = 2 * windowsServiceRecoveryMaxDelay
 )
 
 var isWindowsService bool
@@ -91,11 +96,14 @@ func install(dataPath, logPath, logLevel string, environment daemonEnvironment) 
 	return nil
 }
 
+// windowsServiceRecoveryConfigurer lets recovery setup be tested without connecting to SCM.
 type windowsServiceRecoveryConfigurer interface {
 	SetRecoveryActions([]mgr.RecoveryAction, uint32) error
 	SetRecoveryActionsOnNonCrashFailures(bool) error
 }
 
+// configureWindowsServiceRecovery keeps SCM restart as a fallback if the service host fails.
+// Non-crash failures are included because Execute reports an exit code instead of crashing.
 func configureWindowsServiceRecovery(service windowsServiceRecoveryConfigurer) error {
 	if err := service.SetRecoveryActions([]mgr.RecoveryAction{
 		{Type: mgr.ServiceRestart, Delay: 1 * time.Second},
@@ -104,8 +112,8 @@ func configureWindowsServiceRecovery(service windowsServiceRecoveryConfigurer) e
 		{Type: mgr.ServiceRestart, Delay: 8 * time.Second},
 		{Type: mgr.ServiceRestart, Delay: 16 * time.Second},
 		{Type: mgr.ServiceRestart, Delay: 32 * time.Second},
-		{Type: mgr.ServiceRestart, Delay: 64 * time.Second},
-	}, 60); err != nil {
+		{Type: mgr.ServiceRestart, Delay: windowsServiceRecoveryMaxDelay},
+	}, uint32(windowsServiceRecoveryResetPeriod/time.Second)); err != nil {
 		return fmt.Errorf("failed to set service recovery actions: %w", err)
 	}
 	if err := service.SetRecoveryActionsOnNonCrashFailures(true); err != nil {
@@ -171,6 +179,8 @@ func maybePlatformService() bool {
 	return true
 }
 
+// windowsServiceChild isolates supervision from OS process details so restart and shutdown paths
+// can be tested without launching a daemon.
 type windowsServiceChild interface {
 	Done() <-chan error
 	RequestShutdown()
@@ -187,20 +197,23 @@ func (c *windowsServiceChildProcess) info(message string, args ...any) {
 	c.logger.Info(message, args...)
 }
 
+// windowsServiceBackoff lets a service stop cancel a pending restart delay.
 type windowsServiceBackoff interface {
 	Wait(context.Context)
 	Reset()
 }
 
+// service runs the Windows SCM handler and supervises its daemon child. Dependencies are
+// injected to keep restart and shutdown tests isolated.
 type service struct {
+	logger     *slog.Logger
 	spawnChild func([]string, string, string, string) (windowsServiceChild, error)
 	newBackoff func() windowsServiceBackoff
 }
 
-// newWindowsService returns a production service handler. Its injected process and backoff
-// functions keep supervision tests independent of OS processes and wall-clock delays.
 func newWindowsService() *service {
 	return &service{
+		logger: slog.Default(),
 		spawnChild: func(args []string, dataPath, logPath, logLevel string) (windowsServiceChild, error) {
 			child, err := spawnChild(args, dataPath, logPath, logLevel)
 			if err != nil {
@@ -227,7 +240,7 @@ func (s *service) Execute(args []string, r <-chan svc.ChangeRequest, status chan
 	// falling back to defaults if not present.
 	config, err := parseServiceRunArgs(os.Args[1:])
 	if err != nil {
-		slog.Error("Failed to parse service arguments", "error", err)
+		s.logger.Error("Failed to parse service arguments", "error", err)
 		return true, 1
 	}
 	return s.run(config, r, status)
@@ -238,7 +251,7 @@ func (s *service) run(config serviceRunConfig, r <-chan svc.ChangeRequest, statu
 	childArgs := config.args()
 	child, err := s.spawnChild(childArgs, config.dataPath, config.logPath, config.logLevel)
 	if err != nil {
-		slog.Error("Failed to start daemon", "error", err)
+		s.logger.Error("Failed to start daemon", "error", err)
 		return true, 1
 	}
 
@@ -276,7 +289,7 @@ func (s *service) run(config serviceRunConfig, r <-chan svc.ChangeRequest, statu
 
 			child, err = s.spawnChild(childArgs, config.dataPath, config.logPath, config.logLevel)
 			if err != nil {
-				slog.Error("Failed to restart daemon", "error", err)
+				s.logger.Error("Failed to restart daemon", "error", err)
 				return true, 1
 			}
 			startedAt = time.Now()
@@ -298,7 +311,7 @@ func (s *service) run(config serviceRunConfig, r <-chan svc.ChangeRequest, statu
 					child.info("Service stop requested")
 					child.RequestShutdown()
 					if err := child.WaitOrKill(windowsServiceChildShutdownTimeout); err != nil {
-						slog.Warn("Daemon process did not stop cleanly", "error", err)
+						s.logger.Warn("Daemon process did not stop cleanly", "error", err)
 					}
 				}
 				return false, windows.NO_ERROR

--- a/cmd/lanternd/lanternd_windows.go
+++ b/cmd/lanternd/lanternd_windows.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
+	"math/rand/v2"
 	"os"
 	"time"
 
@@ -20,14 +21,18 @@ const (
 	binPath     = "C:\\Program Files\\Lantern\\" + serviceName + ".exe"
 
 	windowsServiceChildShutdownTimeout = 15 * time.Second
-	// windowsServiceStopWaitHint leaves SCM time for forced termination after graceful shutdown
-	// times out.
+	// windowsServiceStopWaitHint leaves SCM time for forced termination after graceful shutdown times out.
 	windowsServiceStopWaitHint = 20 * time.Second
 
+	// windowsServiceRecoveryMaxDelay caps how long SCM waits before retrying a failed service host.
 	windowsServiceRecoveryMaxDelay = 64 * time.Second
-	// windowsServiceRecoveryResetPeriod keeps the failure count through the longest delay so SCM
-	// advances to the next recovery action.
+	// windowsServiceRecoveryResetPeriod keeps the failure count through the longest delay so SCM advances to the next recovery action.
 	windowsServiceRecoveryResetPeriod = 2 * windowsServiceRecoveryMaxDelay
+
+	// windowsServiceRestartBackoffInitial allows quick recovery from an isolated child failure.
+	windowsServiceRestartBackoffInitial = time.Second
+	// windowsServiceRestartBackoffJitter spreads restart attempts after failures that affect many clients.
+	windowsServiceRestartBackoffJitter = 0.2
 )
 
 var isWindowsService bool
@@ -179,8 +184,7 @@ func maybePlatformService() bool {
 	return true
 }
 
-// windowsServiceChild isolates supervision from OS process details so restart and shutdown paths
-// can be tested without launching a daemon.
+// windowsServiceChild isolates supervision from OS process details so restart and shutdown paths can be tested without launching a daemon.
 type windowsServiceChild interface {
 	Done() <-chan error
 	RequestShutdown()
@@ -203,8 +207,44 @@ type windowsServiceBackoff interface {
 	Reset()
 }
 
-// service runs the Windows SCM handler and supervises its daemon child. Dependencies are
-// injected to keep restart and shutdown tests isolated.
+// windowsServiceExponentialBackoff slows crash loops and spreads restart attempts across clients.
+type windowsServiceExponentialBackoff struct {
+	next time.Duration
+}
+
+func newWindowsServiceExponentialBackoff() *windowsServiceExponentialBackoff {
+	return &windowsServiceExponentialBackoff{next: windowsServiceRestartBackoffInitial}
+}
+
+func (b *windowsServiceExponentialBackoff) nextDelay() time.Duration {
+	delay := b.next
+	b.next = min(2*b.next, daemonRestartBackoffMax)
+	return delay
+}
+
+func jitterWindowsServiceRestartDelay(delay time.Duration, random float64) time.Duration {
+	factor := 1 - windowsServiceRestartBackoffJitter + 2*windowsServiceRestartBackoffJitter*random
+	return min(time.Duration(float64(delay)*factor), daemonRestartBackoffMax)
+}
+
+func (b *windowsServiceExponentialBackoff) Wait(ctx context.Context) {
+	if ctx.Err() != nil {
+		return
+	}
+
+	timer := time.NewTimer(jitterWindowsServiceRestartDelay(b.nextDelay(), rand.Float64()))
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+	case <-timer.C:
+	}
+}
+
+func (b *windowsServiceExponentialBackoff) Reset() {
+	b.next = windowsServiceRestartBackoffInitial
+}
+
+// service runs the Windows SCM handler and supervises its daemon child. Dependencies are injected to keep restart and shutdown tests isolated.
 type service struct {
 	logger     *slog.Logger
 	spawnChild func([]string, string, string, string) (windowsServiceChild, error)
@@ -222,7 +262,7 @@ func newWindowsService() *service {
 			return &windowsServiceChildProcess{childProcess: child}, nil
 		},
 		newBackoff: func() windowsServiceBackoff {
-			return common.NewBackoff(daemonRestartBackoffMax)
+			return newWindowsServiceExponentialBackoff()
 		},
 	}
 }

--- a/cmd/lanternd/lanternd_windows.go
+++ b/cmd/lanternd/lanternd_windows.go
@@ -18,6 +18,11 @@ import (
 const (
 	serviceName = "LanternSvc"
 	binPath     = "C:\\Program Files\\Lantern\\" + serviceName + ".exe"
+
+	// windowsServiceChildShutdownTimeout bounds the child's graceful shutdown period.
+	windowsServiceChildShutdownTimeout = 15 * time.Second
+	// windowsServiceStopWaitHint includes headroom for forced termination after that period.
+	windowsServiceStopWaitHint = 20 * time.Second
 )
 
 var isWindowsService bool
@@ -280,7 +285,11 @@ func (s *service) run(config serviceRunConfig, r <-chan svc.ChangeRequest, statu
 		case change := <-r:
 			switch change.Cmd {
 			case svc.Stop, svc.Shutdown:
-				status <- svc.Status{State: svc.StopPending}
+				status <- svc.Status{
+					State:      svc.StopPending,
+					CheckPoint: 1,
+					WaitHint:   uint32(windowsServiceStopWaitHint / time.Millisecond),
+				}
 				cancelService()
 				if restartReady != nil {
 					<-restartReady
@@ -288,7 +297,7 @@ func (s *service) run(config serviceRunConfig, r <-chan svc.ChangeRequest, statu
 				if child != nil {
 					child.info("Service stop requested")
 					child.RequestShutdown()
-					if err := child.WaitOrKill(15 * time.Second); err != nil {
+					if err := child.WaitOrKill(windowsServiceChildShutdownTimeout); err != nil {
 						slog.Warn("Daemon process did not stop cleanly", "error", err)
 					}
 				}

--- a/cmd/lanternd/lanternd_windows_test.go
+++ b/cmd/lanternd/lanternd_windows_test.go
@@ -71,6 +71,32 @@ func (b *blockingWindowsServiceBackoff) Reset() {
 	b.resets <- struct{}{}
 }
 
+func TestWindowsServiceExponentialBackoff(t *testing.T) {
+	backoff := newWindowsServiceExponentialBackoff()
+	for _, expected := range []time.Duration{
+		1 * time.Second,
+		2 * time.Second,
+		4 * time.Second,
+		8 * time.Second,
+		16 * time.Second,
+		32 * time.Second,
+		60 * time.Second,
+		60 * time.Second,
+	} {
+		require.Equal(t, expected, backoff.nextDelay())
+	}
+
+	backoff.Reset()
+	require.Equal(t, windowsServiceRestartBackoffInitial, backoff.nextDelay())
+}
+
+func TestWindowsServiceRestartBackoffJitter(t *testing.T) {
+	require.Equal(t, 800*time.Millisecond, jitterWindowsServiceRestartDelay(time.Second, 0))
+	require.Equal(t, time.Second, jitterWindowsServiceRestartDelay(time.Second, 0.5))
+	require.Equal(t, 1200*time.Millisecond, jitterWindowsServiceRestartDelay(time.Second, 1))
+	require.Equal(t, daemonRestartBackoffMax, jitterWindowsServiceRestartDelay(daemonRestartBackoffMax, 1))
+}
+
 type windowsServiceResult struct {
 	serviceSpecificExitCode bool
 	exitCode                uint32

--- a/cmd/lanternd/lanternd_windows_test.go
+++ b/cmd/lanternd/lanternd_windows_test.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+type fakeWindowsServiceChild struct {
+	done      chan error
+	crashes   chan error
+	shutdowns chan struct{}
+	waits     chan time.Duration
+}
+
+func newFakeWindowsServiceChild() *fakeWindowsServiceChild {
+	return &fakeWindowsServiceChild{
+		done:      make(chan error, 1),
+		crashes:   make(chan error, 1),
+		shutdowns: make(chan struct{}, 1),
+		waits:     make(chan time.Duration, 1),
+	}
+}
+
+func (c *fakeWindowsServiceChild) Done() <-chan error {
+	return c.done
+}
+
+func (c *fakeWindowsServiceChild) RequestShutdown() {
+	c.shutdowns <- struct{}{}
+}
+
+func (c *fakeWindowsServiceChild) WaitOrKill(timeout time.Duration) error {
+	c.waits <- timeout
+	return nil
+}
+
+func (c *fakeWindowsServiceChild) HandleCrash(err error) {
+	c.crashes <- err
+}
+
+func (c *fakeWindowsServiceChild) info(string, ...any) {}
+
+type immediateWindowsServiceBackoff struct{}
+
+func (immediateWindowsServiceBackoff) Wait(context.Context) {}
+func (immediateWindowsServiceBackoff) Reset()               {}
+
+type blockingWindowsServiceBackoff struct {
+	started chan struct{}
+	stopped chan struct{}
+	resets  chan struct{}
+}
+
+func (b *blockingWindowsServiceBackoff) Wait(ctx context.Context) {
+	b.started <- struct{}{}
+	<-ctx.Done()
+	b.stopped <- struct{}{}
+}
+
+func (b *blockingWindowsServiceBackoff) Reset() {
+	b.resets <- struct{}{}
+}
+
+type windowsServiceResult struct {
+	serviceSpecificExitCode bool
+	exitCode                uint32
+}
+
+func TestWindowsServiceRestartsExitedChildren(t *testing.T) {
+	children := []*fakeWindowsServiceChild{
+		newFakeWindowsServiceChild(),
+		newFakeWindowsServiceChild(),
+		newFakeWindowsServiceChild(),
+	}
+	spawned := make(chan *fakeWindowsServiceChild, len(children))
+	spawnIndex := 0
+	windowsService := &service{
+		spawnChild: func([]string, string, string, string) (windowsServiceChild, error) {
+			child := children[spawnIndex]
+			spawnIndex++
+			spawned <- child
+			return child, nil
+		},
+		newBackoff: func() windowsServiceBackoff { return immediateWindowsServiceBackoff{} },
+	}
+
+	requests := make(chan svc.ChangeRequest, 1)
+	statuses := make(chan svc.Status, 2)
+	result := executeWindowsService(windowsService, requests, statuses)
+
+	require.Same(t, children[0], receive(t, spawned))
+	require.Equal(t, svc.Running, receive(t, statuses).State)
+
+	crashErr := errors.New("daemon crashed")
+	children[0].done <- crashErr
+	require.ErrorIs(t, receive(t, children[0].crashes), crashErr)
+	require.Same(t, children[1], receive(t, spawned))
+
+	children[1].done <- nil
+	require.Same(t, children[2], receive(t, spawned))
+	select {
+	case err := <-children[1].crashes:
+		t.Fatalf("clean child exit handled as crash: %v", err)
+	default:
+	}
+
+	requests <- svc.ChangeRequest{Cmd: svc.Stop}
+	require.Equal(t, svc.StopPending, receive(t, statuses).State)
+	receive(t, children[2].shutdowns)
+	require.Equal(t, 15*time.Second, receive(t, children[2].waits))
+	require.Equal(t, windowsServiceResult{false, windows.NO_ERROR}, receive(t, result))
+}
+
+func TestWindowsServiceStopsDuringRestartBackoff(t *testing.T) {
+	child := newFakeWindowsServiceChild()
+	spawned := make(chan *fakeWindowsServiceChild, 2)
+	backoff := &blockingWindowsServiceBackoff{
+		started: make(chan struct{}, 1),
+		stopped: make(chan struct{}, 1),
+		resets:  make(chan struct{}, 1),
+	}
+	windowsService := &service{
+		spawnChild: func([]string, string, string, string) (windowsServiceChild, error) {
+			spawned <- child
+			return child, nil
+		},
+		newBackoff: func() windowsServiceBackoff { return backoff },
+	}
+
+	requests := make(chan svc.ChangeRequest, 1)
+	statuses := make(chan svc.Status, 2)
+	result := executeWindowsService(windowsService, requests, statuses)
+
+	require.Same(t, child, receive(t, spawned))
+	require.Equal(t, svc.Running, receive(t, statuses).State)
+
+	child.done <- errors.New("daemon crashed")
+	receive(t, child.crashes)
+	receive(t, backoff.started)
+	requests <- svc.ChangeRequest{Cmd: svc.Stop}
+	require.Equal(t, svc.StopPending, receive(t, statuses).State)
+	receive(t, backoff.stopped)
+	require.Equal(t, windowsServiceResult{false, windows.NO_ERROR}, receive(t, result))
+	select {
+	case unexpected := <-spawned:
+		t.Fatalf("spawned child during service stop: %p", unexpected)
+	default:
+	}
+}
+
+func TestWindowsServiceReturnsFailureWhenChildCannotRestart(t *testing.T) {
+	child := newFakeWindowsServiceChild()
+	spawnCalls := 0
+	restartErr := errors.New("restart failed")
+	windowsService := &service{
+		spawnChild: func([]string, string, string, string) (windowsServiceChild, error) {
+			spawnCalls++
+			if spawnCalls == 1 {
+				return child, nil
+			}
+			return nil, restartErr
+		},
+		newBackoff: func() windowsServiceBackoff { return immediateWindowsServiceBackoff{} },
+	}
+
+	requests := make(chan svc.ChangeRequest, 1)
+	statuses := make(chan svc.Status, 1)
+	result := executeWindowsService(windowsService, requests, statuses)
+
+	require.Equal(t, svc.Running, receive(t, statuses).State)
+	child.done <- restartErr
+	require.ErrorIs(t, receive(t, child.crashes), restartErr)
+	require.Equal(t, windowsServiceResult{true, 1}, receive(t, result))
+	require.Equal(t, 2, spawnCalls)
+}
+
+type fakeWindowsServiceRecoveryConfigurer struct {
+	actions         []mgr.RecoveryAction
+	resetPeriod     uint32
+	nonCrashFailure bool
+}
+
+func (f *fakeWindowsServiceRecoveryConfigurer) SetRecoveryActions(actions []mgr.RecoveryAction, resetPeriod uint32) error {
+	f.actions = actions
+	f.resetPeriod = resetPeriod
+	return nil
+}
+
+func (f *fakeWindowsServiceRecoveryConfigurer) SetRecoveryActionsOnNonCrashFailures(flag bool) error {
+	f.nonCrashFailure = flag
+	return nil
+}
+
+func TestConfigureWindowsServiceRecovery(t *testing.T) {
+	configured := &fakeWindowsServiceRecoveryConfigurer{}
+	require.NoError(t, configureWindowsServiceRecovery(configured))
+	require.Equal(t, uint32(60), configured.resetPeriod)
+	require.Equal(t, []mgr.RecoveryAction{
+		{Type: mgr.ServiceRestart, Delay: 1 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 2 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 4 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 8 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 16 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 32 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 64 * time.Second},
+	}, configured.actions)
+	require.True(t, configured.nonCrashFailure)
+}
+
+func executeWindowsService(windowsService *service, requests chan svc.ChangeRequest, statuses chan svc.Status) <-chan windowsServiceResult {
+	result := make(chan windowsServiceResult, 1)
+	go func() {
+		serviceSpecificExitCode, exitCode := windowsService.run(serviceRunConfig{
+			dataPath:    `C:\ProgramData\Lantern`,
+			logPath:     `C:\ProgramData\Lantern`,
+			logLevel:    "debug",
+			environment: daemonEnvironmentProd,
+		}, requests, statuses)
+		result <- windowsServiceResult{serviceSpecificExitCode, exitCode}
+	}()
+	return result
+}
+
+func receive[T any](t *testing.T, values <-chan T) T {
+	t.Helper()
+	select {
+	case value := <-values:
+		return value
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for value")
+		var zero T
+		return zero
+	}
+}

--- a/cmd/lanternd/lanternd_windows_test.go
+++ b/cmd/lanternd/lanternd_windows_test.go
@@ -115,9 +115,12 @@ func TestWindowsServiceRestartsExitedChildren(t *testing.T) {
 	}
 
 	requests <- svc.ChangeRequest{Cmd: svc.Stop}
-	require.Equal(t, svc.StopPending, receive(t, statuses).State)
+	stopStatus := receive(t, statuses)
+	require.Equal(t, svc.StopPending, stopStatus.State)
+	require.Equal(t, uint32(1), stopStatus.CheckPoint)
+	require.Equal(t, uint32(windowsServiceStopWaitHint/time.Millisecond), stopStatus.WaitHint)
 	receive(t, children[2].shutdowns)
-	require.Equal(t, 15*time.Second, receive(t, children[2].waits))
+	require.Equal(t, windowsServiceChildShutdownTimeout, receive(t, children[2].waits))
 	require.Equal(t, windowsServiceResult{false, windows.NO_ERROR}, receive(t, result))
 }
 
@@ -181,7 +184,7 @@ func TestWindowsServiceLogsChildShutdownError(t *testing.T) {
 	require.Equal(t, svc.Running, receive(t, statuses).State)
 	requests <- svc.ChangeRequest{Cmd: svc.Stop}
 	require.Equal(t, svc.StopPending, receive(t, statuses).State)
-	require.Equal(t, 15*time.Second, receive(t, child.waits))
+	require.Equal(t, windowsServiceChildShutdownTimeout, receive(t, child.waits))
 	require.Equal(t, windowsServiceResult{false, windows.NO_ERROR}, receive(t, result))
 	require.Contains(t, logs.String(), "Daemon process did not stop cleanly")
 	require.Contains(t, logs.String(), shutdownErr.Error())

--- a/cmd/lanternd/lanternd_windows_test.go
+++ b/cmd/lanternd/lanternd_windows_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -17,6 +19,7 @@ type fakeWindowsServiceChild struct {
 	crashes   chan error
 	shutdowns chan struct{}
 	waits     chan time.Duration
+	waitErr   error
 }
 
 func newFakeWindowsServiceChild() *fakeWindowsServiceChild {
@@ -38,7 +41,7 @@ func (c *fakeWindowsServiceChild) RequestShutdown() {
 
 func (c *fakeWindowsServiceChild) WaitOrKill(timeout time.Duration) error {
 	c.waits <- timeout
-	return nil
+	return c.waitErr
 }
 
 func (c *fakeWindowsServiceChild) HandleCrash(err error) {
@@ -153,6 +156,35 @@ func TestWindowsServiceStopsDuringRestartBackoff(t *testing.T) {
 		t.Fatalf("spawned child during service stop: %p", unexpected)
 	default:
 	}
+}
+
+func TestWindowsServiceLogsChildShutdownError(t *testing.T) {
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	shutdownErr := errors.New("child exited unsuccessfully")
+	child := newFakeWindowsServiceChild()
+	child.waitErr = shutdownErr
+	windowsService := &service{
+		spawnChild: func([]string, string, string, string) (windowsServiceChild, error) {
+			return child, nil
+		},
+		newBackoff: func() windowsServiceBackoff { return immediateWindowsServiceBackoff{} },
+	}
+
+	requests := make(chan svc.ChangeRequest, 1)
+	statuses := make(chan svc.Status, 2)
+	result := executeWindowsService(windowsService, requests, statuses)
+
+	require.Equal(t, svc.Running, receive(t, statuses).State)
+	requests <- svc.ChangeRequest{Cmd: svc.Stop}
+	require.Equal(t, svc.StopPending, receive(t, statuses).State)
+	require.Equal(t, 15*time.Second, receive(t, child.waits))
+	require.Equal(t, windowsServiceResult{false, windows.NO_ERROR}, receive(t, result))
+	require.Contains(t, logs.String(), "Daemon process did not stop cleanly")
+	require.Contains(t, logs.String(), shutdownErr.Error())
 }
 
 func TestWindowsServiceReturnsFailureWhenChildCannotRestart(t *testing.T) {

--- a/cmd/lanternd/lanternd_windows_test.go
+++ b/cmd/lanternd/lanternd_windows_test.go
@@ -85,6 +85,7 @@ func TestWindowsServiceRestartsExitedChildren(t *testing.T) {
 	spawned := make(chan *fakeWindowsServiceChild, len(children))
 	spawnIndex := 0
 	windowsService := &service{
+		logger: slog.New(slog.DiscardHandler),
 		spawnChild: func([]string, string, string, string) (windowsServiceChild, error) {
 			child := children[spawnIndex]
 			spawnIndex++
@@ -133,6 +134,7 @@ func TestWindowsServiceStopsDuringRestartBackoff(t *testing.T) {
 		resets:  make(chan struct{}, 1),
 	}
 	windowsService := &service{
+		logger: slog.New(slog.DiscardHandler),
 		spawnChild: func([]string, string, string, string) (windowsServiceChild, error) {
 			spawned <- child
 			return child, nil
@@ -163,14 +165,12 @@ func TestWindowsServiceStopsDuringRestartBackoff(t *testing.T) {
 
 func TestWindowsServiceLogsChildShutdownError(t *testing.T) {
 	var logs bytes.Buffer
-	previousLogger := slog.Default()
-	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
-	t.Cleanup(func() { slog.SetDefault(previousLogger) })
 
 	shutdownErr := errors.New("child exited unsuccessfully")
 	child := newFakeWindowsServiceChild()
 	child.waitErr = shutdownErr
 	windowsService := &service{
+		logger: slog.New(slog.NewTextHandler(&logs, nil)),
 		spawnChild: func([]string, string, string, string) (windowsServiceChild, error) {
 			return child, nil
 		},
@@ -195,6 +195,7 @@ func TestWindowsServiceReturnsFailureWhenChildCannotRestart(t *testing.T) {
 	spawnCalls := 0
 	restartErr := errors.New("restart failed")
 	windowsService := &service{
+		logger: slog.New(slog.DiscardHandler),
 		spawnChild: func([]string, string, string, string) (windowsServiceChild, error) {
 			spawnCalls++
 			if spawnCalls == 1 {
@@ -236,7 +237,7 @@ func (f *fakeWindowsServiceRecoveryConfigurer) SetRecoveryActionsOnNonCrashFailu
 func TestConfigureWindowsServiceRecovery(t *testing.T) {
 	configured := &fakeWindowsServiceRecoveryConfigurer{}
 	require.NoError(t, configureWindowsServiceRecovery(configured))
-	require.Equal(t, uint32(60), configured.resetPeriod)
+	require.Equal(t, uint32(128), configured.resetPeriod)
 	require.Equal(t, []mgr.RecoveryAction{
 		{Type: mgr.ServiceRestart, Delay: 1 * time.Second},
 		{Type: mgr.ServiceRestart, Delay: 2 * time.Second},


### PR DESCRIPTION
Fixes getlantern/engineering#3851.

## Summary

- Keep the Windows service host running when its daemon child exits.
- Perform crash cleanup and restart the child with capped exponential backoff with jitter.
- Reset the backoff after the child has remained stable for two minutes.
- Handle service stop or shutdown safely while waiting to restart.

## Why

`LanternSvc` previously returned from its service handler whenever the daemon child exited. Recovery then depended entirely on Windows Service Control Manager configuration, which could leave Lantern installed but unable to reconnect.

The service host now supervises the daemon process directly. If the child terminates, Lantern cleans up its network state and starts a replacement while the same `LanternSvc` process remains running. Windows SCM recovery remains as a fallback if supervision itself fails.

The Lantern Windows smoke test confirmed that killing the daemon child creates a replacement child under the same running `LanternSvc` host:
https://github.com/getlantern/lantern/actions/runs/32820317801

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows service recovery now handles unexpected daemon exits with delayed, resettable restarts.
  * Restart delays use exponential backoff with jitter to reduce repeated restart pressure.
  * Service installation now enables recovery for non-crash failures.
  * Stopping the service cancels pending restart delays and cleanly terminates the active process.

* **Bug Fixes**
  * Improved failure reporting when the daemon cannot be restarted or stopped cleanly.

* **Tests**
  * Added coverage for restart behavior, backoff timing, shutdown handling, failure reporting, and recovery configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
