### PR TITLE
fix(lanternd): harden daemon supervision, logging, and install

### DIFF
--- a/account/datacap.go
+++ b/account/datacap.go
@@ -139,7 +139,7 @@ func readSSE(ctx context.Context, body io.Reader) (<-chan sseEvent, func() error
 // stream errors. If the server closes with cap_exhausted, it waits for the
 // allotment reset instead of retrying immediately.
 func (a *Client) DataCapStream(ctx context.Context, handler func(*DataCapInfo)) error {
-	bo := common.NewBackoff(2 * time.Minute)
+	bo := common.NewBackoff(0, 2*time.Minute)
 	for {
 		if ctx.Err() != nil {
 			return ctx.Err()

--- a/cmd/lanternd/lanternd.go
+++ b/cmd/lanternd/lanternd.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -12,6 +11,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -66,6 +66,22 @@ func parseDaemonEnvironment(value string) (daemonEnvironment, error) {
 		return "", fmt.Errorf("unsupported environment %q (must be prod or staging)", value)
 	}
 }
+
+// gracefulShutdownTimeout is the maximum time the supervisor waits for a child
+// to exit after requesting a graceful shutdown.
+const gracefulShutdownTimeout = 15 * time.Second
+
+// childForceExitTimeout gives the child time to log a forced-exit reason before
+// the supervisor's shutdown deadline expires.
+const childForceExitTimeout = gracefulShutdownTimeout - 3*time.Second
+
+// childWaitDelay bounds how long Wait may block on inherited stdout/stderr
+// pipes after the child exits.
+const childWaitDelay = 5 * time.Second
+
+// childEnvMarker marks a supervised child process so main runs the daemon
+// directly instead of starting another supervisor.
+const childEnvMarker = "_LANTERND_CHILD"
 
 type serviceRunConfig struct {
 	dataPath    string
@@ -145,8 +161,15 @@ func main() {
 	switch {
 	case a.Run != nil:
 		config := a.Run.serviceConfig()
-		if os.Getenv("_LANTERND_CHILD") != "1" {
-			err = babysit(os.Args[1:], config.dataPath, config.logPath, config.logLevel)
+		if os.Getenv(childEnvMarker) != "1" {
+			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+			defer stop()
+			logger := newDaemonLogger(config.logPath, config.logLevel)
+			err = babysit(ctx, os.Args[1:], logger, nil)
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				os.Exit(exitErr.ExitCode())
+			}
 			break
 		}
 		ctx, cancel := context.WithCancel(context.Background())
@@ -229,63 +252,58 @@ func copyBin() (string, error) {
 	return dst, nil
 }
 
-// childProcess manages a daemon child process. The parent spawns the child, drains its output,
-// and can signal graceful shutdown by closing its stdin pipe. If the child crashes, the parent
-// cleans up stale VPN network state immediately.
-type childProcess struct {
-	cmd      *exec.Cmd
-	stdin    io.Closer
-	done     chan error
-	dataPath string
-	logger   *slog.Logger
+// newDaemonLogger returns the supervisor logger for the daemon log file.
+func newDaemonLogger(logPath, logLevel string) *slog.Logger {
+	// The child creates this directory in common.Init, but the supervisor logs — and starts
+	// draining the child — before that. A failure is not fatal: lumberjack retries the MkdirAll on
+	// its first write, and refusing to run the daemon over its log directory would be worse.
+	if err := os.MkdirAll(logPath, 0o755); err != nil {
+		slog.Warn("Failed to create log directory", "error", err, "path", logPath)
+	}
+	return rlog.NewLogger(rlog.Config{
+		LogPath:          filepath.Join(logPath, internal.LogFileName),
+		Level:            logLevel,
+		Prod:             true,
+		DisablePublisher: true,
+	})
 }
 
-// spawnChild creates and starts a daemon child process with piped I/O. The child's stdout and
-// stderr are merged and drained through the provided logger (or os.Stdout as fallback).
-func spawnChild(args []string, dataPath, logPath, logLevel string) (*childProcess, error) {
+type childProcess struct {
+	cmd    *exec.Cmd
+	stdin  io.Closer
+	done   chan error
+	logger *slog.Logger
+}
+
+func childEnv() []string {
+	return append(os.Environ(), childEnvMarker+"=1", commonenv.LogToStdout.String()+"=true")
+}
+
+// spawnChild starts the daemon as a supervised child process.
+// Child stdout and stderr are written directly to the supervisor's log writer.
+func spawnChild(args []string, logger *slog.Logger) (*childProcess, error) {
 	exe, err := os.Executable()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get executable path: %w", err)
 	}
 
 	cmd := exec.Command(exe, args...)
-	cmd.Env = append(os.Environ(), "_LANTERND_CHILD=1")
+	cmd.Env = childEnv()
 	stdinPipe, err := cmd.StdinPipe()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create stdin pipe: %w", err)
 	}
-	stdoutPipe, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
+	// The child writes preformatted log lines to stdout. Write them directly to
+	// the supervisor's output sink to avoid double formatting.
+	var w io.Writer = os.Stdout
+	if h, ok := logger.Handler().(*rlog.Handler); ok {
+		w = h.Writer()
 	}
-	cmd.Stderr = cmd.Stdout // merge stderr into the same pipe
-
-	logger := rlog.NewLogger(rlog.Config{
-		LogPath:          filepath.Join(logPath, internal.LogFileName),
-		Level:            logLevel,
-		Prod:             true,
-		DisablePublisher: true,
-	})
-
-	go func() {
-		defer stdoutPipe.Close()
-		var w io.Writer = os.Stdout
-		// TODO: the child process outputs to both stdout and the file logger, so we end up with
-		// 	duplicate log lines. we'll come back to this later and fix it, but for now just
-		// 	write to stdout to avoid the duplication.
-		// if h, ok := logger.Handler().(*rlog.Handler); ok {
-		// 	w = h.Writer()
-		// }
-		scanner := bufio.NewScanner(stdoutPipe)
-		for scanner.Scan() {
-			if s := scanner.Text(); s != "" {
-				w.Write([]byte(s + "\n"))
-			}
-		}
-		if err := scanner.Err(); err != nil {
-			logger.Error("Error reading child process output", "error", err)
-		}
-	}()
+	// Same writer value for both streams so output stays serialized through one sink.
+	out := &bestEffortWriter{w: w}
+	cmd.Stdout = out
+	cmd.Stderr = out
+	cmd.WaitDelay = childWaitDelay
 
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("failed to start daemon process: %w", err)
@@ -296,11 +314,10 @@ func spawnChild(args []string, dataPath, logPath, logLevel string) (*childProces
 	go func() { done <- cmd.Wait() }()
 
 	return &childProcess{
-		cmd:      cmd,
-		stdin:    stdinPipe,
-		done:     done,
-		dataPath: dataPath,
-		logger:   logger,
+		cmd:    cmd,
+		stdin:  stdinPipe,
+		done:   done,
+		logger: logger,
 	}, nil
 }
 
@@ -327,73 +344,86 @@ func (c *childProcess) WaitOrKill(timeout time.Duration) error {
 	}
 }
 
+// childExitError treats ErrWaitDelay as non-fatal after process exit.
+func childExitError(err error) error {
+	if errors.Is(err, exec.ErrWaitDelay) {
+		return nil
+	}
+	return err
+}
+
+// bestEffortWriter drops output rather than reporting a write error. [exec.Cmd] closes the child's
+// output pipe when its copy fails, and a Go program whose stdout or stderr pipe breaks exits on
+// SIGPIPE, so surfacing a log-sink failure here would crash-loop the daemon over unwritable logs.
+type bestEffortWriter struct {
+	w      io.Writer
+	failed atomic.Bool
+}
+
+func (b *bestEffortWriter) Write(p []byte) (int, error) {
+	if _, err := b.w.Write(p); err != nil && !b.failed.Swap(true) {
+		// Reported on stderr because the sink that just failed cannot report its own failure.
+		fmt.Fprintf(os.Stderr, "lanternd: dropping daemon output, log writer failed: %v\n", err)
+	}
+	return len(p), nil
+}
+
 // HandleCrash cleans up stale VPN network state left by a crashed child.
 func (c *childProcess) HandleCrash(err error) {
 	c.logger.Warn("Daemon process exited unexpectedly, cleaning up network state", "error", err)
 	vpn.AttemptFixNetState()
 }
 
-// babysit runs the daemon as a child process and monitors it. If the child exits unexpectedly
-// (crash, panic, etc.), the parent immediately cleans up any stale VPN network state and
-// automatically restarts the child process with exponential backoff.
+// babysit runs the daemon as a child process until ctx is canceled.
+// Unexpected exits trigger cleanup and restart with backoff.
 //
-// Graceful shutdown is signaled by closing the child's stdin pipe — this works cross-platform,
-// including inside a Windows service where there is no console for signal delivery.
-func babysit(args []string, dataPath, logPath, logLevel string) error {
-	// On termination signal, request graceful shutdown of the current child.
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	stopping := false
-
+// Graceful shutdown is requested by closing the child's stdin, which works even
+// in service environments without console signal delivery.
+//
+// ready, if non-nil, is called after the first child starts.
+//
+// The returned error is nil, a spawn failure, or the last child exit error.
+func babysit(ctx context.Context, args []string, logger *slog.Logger, ready func()) error {
 	const resetAfter = 2 * time.Minute // reset backoff if child ran longer than this
 	bo := common.NewBackoff(60 * time.Second)
 
-	for {
-		child, err := spawnChild(args, dataPath, logPath, logLevel)
+	for ctx.Err() == nil {
+		child, err := spawnChild(args, logger)
 		if err != nil {
-			if stopping {
-				return nil
-			}
 			return err
 		}
-		child.logger.Info("Monitoring daemon process")
+		if ready != nil {
+			ready()
+			ready = nil
+		}
+		logger.Info("Monitoring daemon process")
 		startedAt := time.Now()
 
-		// Wait for either a termination signal or child exit.
 		select {
-		case sig := <-sigCh:
-			stopping = true
-			child.logger.Info("Received signal, shutting down child", "signal", sig)
+		case <-ctx.Done():
+			logger.Info("Shutdown requested, stopping daemon process")
 			child.RequestShutdown()
-			err = child.WaitOrKill(15 * time.Second)
+			return childExitError(child.WaitOrKill(gracefulShutdownTimeout))
 		case err = <-child.Done():
+			err = childExitError(err)
 		}
 
-		if stopping {
-			signal.Stop(sigCh)
-			var exitErr *exec.ExitError
-			if errors.As(err, &exitErr) {
-				os.Exit(exitErr.ExitCode())
-			}
-			return err
-		}
-
-		// Unexpected exit — clean up and restart.
-		if err != nil {
+		if err != nil && ctx.Err() == nil {
 			child.HandleCrash(err)
 		}
 
-		// Reset backoff if the child ran for a while (i.e. it wasn't a fast crash loop).
 		if time.Since(startedAt) > resetAfter {
 			bo.Reset()
 		}
 
-		child.logger.Info("Restarting child process")
-		bo.Wait(context.Background())
+		logger.Info("Restarting child process")
+		bo.Wait(ctx)
 	}
+	return nil
 }
 
-// daemonBackendOptions overrides only staging so the production default preserves an externally configured development environment.
+// daemonBackendOptions overrides staging only, preserving any externally
+// configured development environment in production mode.
 func daemonBackendOptions(dataPath, logPath, logLevel string, environment daemonEnvironment) backend.Options {
 	options := backend.Options{
 		DataDir:  dataPath,
@@ -441,12 +471,11 @@ func runDaemon(ctx context.Context, dataPath, logPath, logLevel string, environm
 		return fmt.Errorf("failed to start IPC server: %w", err)
 	}
 
-	// Wait for context cancellation to gracefully shut down.
 	<-ctx.Done()
 
 	slog.Info("Shutting down...")
 
-	time.AfterFunc(15*time.Second, func() {
+	time.AfterFunc(childForceExitTimeout, func() {
 		slog.Error("Failed to shut down in time, forcing exit")
 		os.Exit(1)
 	})

--- a/cmd/lanternd/lanternd.go
+++ b/cmd/lanternd/lanternd.go
@@ -165,7 +165,7 @@ func main() {
 			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 			defer stop()
 			logger := newDaemonLogger(config.logPath, config.logLevel)
-			err = babysit(ctx, os.Args[1:], logger, nil)
+			err = babysit(ctx, os.Args[1:], logger)
 			var exitErr *exec.ExitError
 			if errors.As(err, &exitErr) {
 				os.Exit(exitErr.ExitCode())
@@ -380,10 +380,8 @@ func (c *childProcess) HandleCrash(err error) {
 // Graceful shutdown is requested by closing the child's stdin, which works even
 // in service environments without console signal delivery.
 //
-// ready, if non-nil, is called after the first child starts.
-//
 // The returned error is nil, a spawn failure, or the last child exit error.
-func babysit(ctx context.Context, args []string, logger *slog.Logger, ready func()) error {
+func babysit(ctx context.Context, args []string, logger *slog.Logger) error {
 	const resetAfter = 2 * time.Minute // reset backoff if child ran longer than this
 	bo := common.NewBackoff(60 * time.Second)
 
@@ -391,10 +389,6 @@ func babysit(ctx context.Context, args []string, logger *slog.Logger, ready func
 		child, err := spawnChild(args, logger)
 		if err != nil {
 			return err
-		}
-		if ready != nil {
-			ready()
-			ready = nil
 		}
 		logger.Info("Monitoring daemon process")
 		startedAt := time.Now()

--- a/cmd/lanternd/lanternd.go
+++ b/cmd/lanternd/lanternd.go
@@ -67,21 +67,26 @@ func parseDaemonEnvironment(value string) (daemonEnvironment, error) {
 	}
 }
 
-// gracefulShutdownTimeout is the maximum time the supervisor waits for a child
-// to exit after requesting a graceful shutdown.
-const gracefulShutdownTimeout = 15 * time.Second
+const (
+	// gracefulShutdownTimeout is the maximum time the supervisor waits for a child
+	// to exit after requesting a graceful shutdown.
+	gracefulShutdownTimeout = 15 * time.Second
 
-// childForceExitTimeout gives the child time to log a forced-exit reason before
-// the supervisor's shutdown deadline expires.
-const childForceExitTimeout = gracefulShutdownTimeout - 3*time.Second
+	// childForceExitTimeout gives the child time to log a forced-exit reason before
+	// the supervisor's shutdown deadline expires.
+	childForceExitTimeout = gracefulShutdownTimeout - 3*time.Second
 
-// childWaitDelay bounds how long Wait may block on inherited stdout/stderr
-// pipes after the child exits.
-const childWaitDelay = 5 * time.Second
+	// childWaitDelay bounds how long Wait may block on inherited stdout/stderr
+	// pipes after the child exits.
+	childWaitDelay = 5 * time.Second
 
-// childEnvMarker marks a supervised child process so main runs the daemon
-// directly instead of starting another supervisor.
-const childEnvMarker = "_LANTERND_CHILD"
+	// childEnvMarker marks a supervised child process so main runs the daemon
+	// directly instead of starting another supervisor.
+	childEnvMarker = "_LANTERND_CHILD"
+
+	// babysitBackoffBase is the base wait time for the babysit backoff strategy.
+	babysitBackoffBase = time.Second
+)
 
 type serviceRunConfig struct {
 	dataPath    string
@@ -383,7 +388,7 @@ func (c *childProcess) HandleCrash(err error) {
 // The returned error is nil, a spawn failure, or the last child exit error.
 func babysit(ctx context.Context, args []string, logger *slog.Logger) error {
 	const resetAfter = 2 * time.Minute // reset backoff if child ran longer than this
-	bo := common.NewBackoff(60 * time.Second)
+	bo := common.NewBackoff(babysitBackoffBase, 60*time.Second)
 
 	for ctx.Err() == nil {
 		child, err := spawnChild(args, logger)

--- a/cmd/lanternd/lanternd_darwin.go
+++ b/cmd/lanternd/lanternd_darwin.go
@@ -3,6 +3,8 @@
 package main
 
 import (
+	"bytes"
+	"encoding/xml"
 	"fmt"
 	"log/slog"
 	"os"
@@ -21,39 +23,49 @@ func maybePlatformService() bool {
 	return false
 }
 
-var launchdPlistTmpl = template.Must(template.New("plist").Parse(`<?xml version="1.0" encoding="UTF-8"?>
+// launchdPlistTmpl discards stdout because the supervisor already captures the
+// daemon log stream. Stderr is kept for panics and fatal output that bypass slog.
+var launchdPlistTmpl = template.Must(template.New("plist").Funcs(template.FuncMap{
+	"str": plistString,
+}).Parse(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>Label</key>
-	<string>{{.ServiceName}}</string>
+	<string>{{str .ServiceName}}</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>{{.ExePath}}</string>
+		<string>{{str .ExePath}}</string>
 		<string>run</string>
 		<string>--data-path</string>
-		<string>{{.DataPath}}</string>
+		<string>{{str .DataPath}}</string>
 		<string>--log-path</string>
-		<string>{{.LogPath}}</string>
+		<string>{{str .LogPath}}</string>
 		<string>--log-level</string>
-		<string>{{.LogLevel}}</string>
+		<string>{{str .LogLevel}}</string>
 		<string>--environment</string>
-		<string>{{.Environment}}</string>
+		<string>{{str .Environment}}</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>
 	<key>KeepAlive</key>
 	<true/>
 	<key>StandardOutPath</key>
-	<string>{{.LogPath}}/lanternd.stdout.log</string>
+	<string>/dev/null</string>
 	<key>StandardErrorPath</key>
-	<string>{{.LogPath}}/lanternd.stderr.log</string>
+	<string>{{str .LogPath}}/lanternd.stderr.log</string>
 </dict>
 </plist>
 `))
 
 func plistPath() string {
 	return fmt.Sprintf("/Library/LaunchDaemons/%s.plist", serviceName)
+}
+
+func plistString(s string) string {
+	var buf bytes.Buffer
+	xml.EscapeText(&buf, []byte(s))
+	return buf.String()
 }
 
 func install(dataPath, logPath, logLevel string, environment daemonEnvironment) error {
@@ -78,9 +90,8 @@ func install(dataPath, logPath, logLevel string, environment daemonEnvironment) 
 	defer f.Close()
 
 	err = launchdPlistTmpl.Execute(f, struct {
-		ServiceName, ExePath, DataPath, LogPath, LogLevel string
-		Environment                                       daemonEnvironment
-	}{serviceName, exe, dataPath, logPath, logLevel, environment})
+		ServiceName, ExePath, DataPath, LogPath, LogLevel, Environment string
+	}{serviceName, exe, dataPath, logPath, logLevel, string(environment)})
 	if err != nil {
 		return fmt.Errorf("failed to write plist: %w", err)
 	}

--- a/cmd/lanternd/lanternd_darwin.go
+++ b/cmd/lanternd/lanternd_darwin.go
@@ -62,6 +62,8 @@ func plistPath() string {
 	return fmt.Sprintf("/Library/LaunchDaemons/%s.plist", serviceName)
 }
 
+// plistString renders s as character data for a plist <string> element. An unescaped & or < in a
+// path yields XML that launchctl refuses to load.
 func plistString(s string) string {
 	var buf bytes.Buffer
 	xml.EscapeText(&buf, []byte(s))

--- a/cmd/lanternd/lanternd_linux.go
+++ b/cmd/lanternd/lanternd_linux.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"strings"
 	"text/template"
 
 	"github.com/getlantern/radiance/common"
@@ -20,14 +21,16 @@ func maybePlatformService() bool {
 	return false
 }
 
-var systemdUnitTmpl = template.Must(template.New("unit").Parse(`[Unit]
+var systemdUnitTmpl = template.Must(template.New("unit").Funcs(template.FuncMap{
+	"arg": systemdQuote,
+}).Parse(`[Unit]
 Description=Lantern VPN Daemon
 Wants=network-online.target
 After=network-online.target
 
 [Service]
 Type=simple
-ExecStart={{.ExePath}} run --data-path {{.DataPath}} --log-path {{.LogPath}} --log-level {{.LogLevel}} --environment {{.Environment}}
+ExecStart={{.ExePath}} run --data-path {{arg .DataPath}} --log-path {{arg .LogPath}} --log-level {{arg .LogLevel}} --environment {{arg .Environment}}
 Restart=on-failure
 RestartSec=5s
 
@@ -40,6 +43,10 @@ LogsDirectory=lantern
 [Install]
 WantedBy=multi-user.target
 `))
+
+func systemdQuote(s string) string {
+	return `"` + strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(s) + `"`
+}
 
 func install(dataPath, logPath, logLevel string, environment daemonEnvironment) error {
 	slog.Info("Installing systemd service..", "version", common.Version)
@@ -62,9 +69,8 @@ func install(dataPath, logPath, logLevel string, environment daemonEnvironment) 
 	defer f.Close()
 
 	err = systemdUnitTmpl.Execute(f, struct {
-		ExePath, DataPath, LogPath, LogLevel string
-		Environment                          daemonEnvironment
-	}{exe, dataPath, logPath, logLevel, environment})
+		ExePath, DataPath, LogPath, LogLevel, Environment string
+	}{exe, dataPath, logPath, logLevel, string(environment)})
 	if err != nil {
 		return fmt.Errorf("failed to write unit file: %w", err)
 	}

--- a/cmd/lanternd/lanternd_linux.go
+++ b/cmd/lanternd/lanternd_linux.go
@@ -44,8 +44,18 @@ LogsDirectory=lantern
 WantedBy=multi-user.target
 `))
 
+var systemdArgEscaper = strings.NewReplacer(
+	`\`, `\\`,
+	`"`, `\"`,
+	`%`, `%%`,
+	`$`, `$$`,
+)
+
+// systemdQuote renders s as a single systemd command-line argument. systemd splits a command line
+// on unquoted whitespace, and inside double quotes it still applies C-style escapes, % specifier
+// expansion and $ variable expansion, so each of those is escaped rather than left to expand.
 func systemdQuote(s string) string {
-	return `"` + strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(s) + `"`
+	return `"` + systemdArgEscaper.Replace(s) + `"`
 }
 
 func install(dataPath, logPath, logLevel string, environment daemonEnvironment) error {

--- a/cmd/lanternd/lanternd_linux_test.go
+++ b/cmd/lanternd/lanternd_linux_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSystemdUnitQuotesAwkwardPaths(t *testing.T) {
+	var out strings.Builder
+	err := systemdUnitTmpl.Execute(&out, struct {
+		ExePath, DataPath, LogPath, LogLevel, Environment string
+	}{"/usr/bin/lanternd", "/home/a b/data", "/home/a&b/logs", "info", "prod"})
+	require.NoError(t, err)
+
+	var execStart string
+	for line := range strings.SplitSeq(out.String(), "\n") {
+		if after, ok := strings.CutPrefix(line, "ExecStart="); ok {
+			execStart = after
+		}
+	}
+	require.NotEmpty(t, execStart, "unit file has no ExecStart line")
+	require.Equal(t,
+		`/usr/bin/lanternd run --data-path "/home/a b/data" --log-path "/home/a&b/logs" --log-level "info" --environment "prod"`,
+		execStart)
+}

--- a/cmd/lanternd/lanternd_linux_test.go
+++ b/cmd/lanternd/lanternd_linux_test.go
@@ -25,3 +25,25 @@ func TestSystemdUnitQuotesAwkwardPaths(t *testing.T) {
 		`/usr/bin/lanternd run --data-path "/home/a b/data" --log-path "/home/a&b/logs" --log-level "info" --environment "prod"`,
 		execStart)
 }
+
+func TestSystemdQuoteEscapesExpansions(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain path", `/var/lib/lantern`, `"/var/lib/lantern"`},
+		{"space", `/home/a b/Lantern`, `"/home/a b/Lantern"`},
+		{"ampersand", `/tmp/a&b`, `"/tmp/a&b"`},
+		{"double quote", `/tmp/a"b`, `"/tmp/a\"b"`},
+		{"backslash", `/tmp/a\b`, `"/tmp/a\\b"`},
+		{"percent specifier", `/tmp/50%off`, `"/tmp/50%%off"`},
+		{"dollar variable", `/tmp/$HOME`, `"/tmp/$$HOME"`},
+		{"empty", ``, `""`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, systemdQuote(test.in))
+		})
+	}
+}

--- a/cmd/lanternd/lanternd_test.go
+++ b/cmd/lanternd/lanternd_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/alexflint/go-arg"
@@ -135,4 +136,33 @@ func TestProductionBackendOptionsPreserveDevelopmentEnvironment(t *testing.T) {
 	options := daemonBackendOptions("/data", "/logs", "debug", daemonEnvironmentProd)
 	require.NotContains(t, options.EnvOverrides, commonenv.ENV.String())
 	require.Equal(t, "dev", common.Env())
+}
+
+func TestChildEnvRedirectsLoggingToStdout(t *testing.T) {
+	env := childEnv()
+	require.Contains(t, env, childEnvMarker+"=1")
+	require.Contains(t, env, commonenv.LogToStdout.String()+"=true")
+}
+
+func TestChildForceExitPrecedesSupervisorKill(t *testing.T) {
+	require.Less(t, childForceExitTimeout, gracefulShutdownTimeout)
+}
+
+type failingWriter struct{ writes int }
+
+func (f *failingWriter) Write(p []byte) (int, error) {
+	f.writes++
+	return 0, errors.New("sink is broken")
+}
+
+func TestBestEffortWriterHidesSinkFailures(t *testing.T) {
+	sink := &failingWriter{}
+	w := &bestEffortWriter{w: sink}
+
+	for range 3 {
+		n, err := w.Write([]byte("line\n"))
+		require.NoError(t, err, "a write error would close the child's pipe and SIGPIPE it")
+		require.Equal(t, len("line\n"), n)
+	}
+	require.Equal(t, 3, sink.writes)
 }

--- a/cmd/lanternd/lanternd_windows.go
+++ b/cmd/lanternd/lanternd_windows.go
@@ -15,6 +15,32 @@ import (
 	"github.com/getlantern/radiance/common"
 )
 
+// serviceStopWait covers the supervisor's full shutdown path so the service
+// stop handler does not time out while babysit is still finishing.
+const serviceStopWait = gracefulShutdownTimeout + childWaitDelay + 5*time.Second
+
+// serviceRestartDelays defines the SCM restart policy for failures of the
+// supervising service process itself.
+var serviceRestartDelays = []time.Duration{
+	1 * time.Second,
+	2 * time.Second,
+	4 * time.Second,
+	8 * time.Second,
+	16 * time.Second,
+	32 * time.Second,
+	64 * time.Second,
+}
+
+// serviceFailureResetPeriod returns how long the service must run without
+// failing before the SCM resets its failure count.
+func serviceFailureResetPeriod() uint32 {
+	var span time.Duration
+	for _, delay := range serviceRestartDelays {
+		span += delay
+	}
+	return uint32((2 * span).Seconds())
+}
+
 const (
 	serviceName = "LanternSvc"
 	binPath     = "C:\\Program Files\\Lantern\\" + serviceName + ".exe"
@@ -69,25 +95,30 @@ func install(dataPath, logPath, logLevel string, environment daemonEnvironment) 
 	}).args()
 
 	slog.Info("Creating Windows service", "exe", exe, "args", args)
-	service, err := m.CreateService(serviceName, exe, config, args...)
+	svcHandle, err := m.CreateService(serviceName, exe, config, args...)
 	if err != nil {
 		return fmt.Errorf("failed to create %q service: %w", serviceName, err)
 	}
-	defer service.Close()
+	defer svcHandle.Close()
 
-	err = service.SetRecoveryActions([]mgr.RecoveryAction{
-		{Type: mgr.ServiceRestart, Delay: 1 * time.Second},
-		{Type: mgr.ServiceRestart, Delay: 2 * time.Second},
-		{Type: mgr.ServiceRestart, Delay: 4 * time.Second},
-		{Type: mgr.ServiceRestart, Delay: 8 * time.Second},
-		{Type: mgr.ServiceRestart, Delay: 16 * time.Second},
-		{Type: mgr.ServiceRestart, Delay: 32 * time.Second},
-		{Type: mgr.ServiceRestart, Delay: 64 * time.Second},
-	}, 60)
+	actions := make([]mgr.RecoveryAction, 0, len(serviceRestartDelays)+1)
+	for _, delay := range serviceRestartDelays {
+		actions = append(actions, mgr.RecoveryAction{Type: mgr.ServiceRestart, Delay: delay})
+	}
+	// The SCM repeats the final recovery action indefinitely, so append NoAction to
+	// make the retry ladder terminate.
+	actions = append(actions, mgr.RecoveryAction{Type: mgr.NoAction})
+
+	err = svcHandle.SetRecoveryActions(actions, serviceFailureResetPeriod())
 	if err != nil {
 		return fmt.Errorf("failed to set service recovery actions: %w", err)
 	}
-	if err := service.Start(); err != nil {
+	// Execute always reports SERVICE_STOPPED on return, so enable recovery actions
+	// for non-crash failures as well.
+	if err := svcHandle.SetRecoveryActionsOnNonCrashFailures(true); err != nil {
+		return fmt.Errorf("failed to enable recovery actions on non-crash failures: %w", err)
+	}
+	if err := svcHandle.Start(); err != nil {
 		return fmt.Errorf("failed to start service: %w", err)
 	}
 
@@ -103,21 +134,25 @@ func uninstall() error {
 	}
 	defer m.Disconnect()
 
-	service, err := m.OpenService(serviceName)
+	svcHandle, err := m.OpenService(serviceName)
 	if err != nil {
 		return fmt.Errorf("failed to open %q service: %w", serviceName, err)
 	}
 
-	status, err := service.Query()
+	status, err := svcHandle.Query()
 	if err != nil {
-		service.Close()
+		svcHandle.Close()
 		return fmt.Errorf("failed to query service state: %w", err)
 	}
 	if status.State != svc.Stopped {
-		service.Control(svc.Stop)
+		// Continue with deletion even if stop fails; the service will be removed once
+		// its process exits.
+		if _, err := svcHandle.Control(svc.Stop); err != nil {
+			slog.Warn("Failed to stop service before deleting", "error", err)
+		}
 	}
-	err = service.Delete()
-	service.Close()
+	err = svcHandle.Delete()
+	svcHandle.Close()
 	if err != nil {
 		return fmt.Errorf("failed to delete service: %w", err)
 	}
@@ -130,14 +165,14 @@ func uninstall() error {
 		case <-ctx.Done():
 			return fmt.Errorf("timed out waiting for service to be removed")
 		case <-time.After(100 * time.Millisecond):
-			if service, err = m.OpenService(serviceName); err != nil {
+			if svcHandle, err = m.OpenService(serviceName); err != nil {
 				slog.Info("Windows service uninstalled successfully")
 				if err := os.Remove(binPath); err != nil && !os.IsNotExist(err) {
 					return fmt.Errorf("failed to remove binary: %w", err)
 				}
 				return nil
 			}
-			service.Close()
+			svcHandle.Close()
 		}
 	}
 }
@@ -170,33 +205,53 @@ func (s *service) Execute(args []string, r <-chan svc.ChangeRequest, status chan
 		slog.Error("Failed to parse service arguments", "error", err)
 		return true, 1
 	}
+	logger := newDaemonLogger(config.logPath, config.logLevel)
 
-	// Run the daemon as a child process so we can clean up network state if it crashes,
-	// regardless of whether the SCM is configured to restart the service.
-	childArgs := config.args()
-	child, err := spawnChild(childArgs, config.dataPath, config.logPath, config.logLevel)
-	if err != nil {
-		slog.Error("Failed to start daemon", "error", err)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	supervisor := make(chan error, 1)
+	running := make(chan struct{})
+	go func() {
+		supervisor <- babysit(ctx, config.args(), logger, func() { close(running) })
+	}()
+
+	// Delay reporting Running until the first child starts, so startup failures are
+	// reported as service start failures.
+	select {
+	case <-running:
+	case err := <-supervisor:
+		logger.Error("Daemon failed to start", "error", err)
 		return true, 1
 	}
 
 	status <- svc.Status{State: svc.Running, Accepts: svc.AcceptStop | svc.AcceptShutdown}
-	child.logger.Info("Running as Windows service")
+	logger.Info("Running as Windows service")
 
 	for {
 		select {
-		case err := <-child.Done():
-			if err != nil {
-				child.HandleCrash(err)
-			}
+		case err := <-supervisor:
+			logger.Error("Daemon supervisor exited, stopping service", "error", err)
 			return true, 1
 		case change := <-r:
 			switch change.Cmd {
 			case svc.Stop, svc.Shutdown:
-				status <- svc.Status{State: svc.StopPending}
-				child.logger.Info("Service stop requested")
-				child.RequestShutdown()
-				child.WaitOrKill(15 * time.Second)
+				status <- svc.Status{
+					State:      svc.StopPending,
+					CheckPoint: 1,
+					WaitHint:   uint32(serviceStopWait.Milliseconds()),
+				}
+				logger.Info("Service stop requested")
+				cancel()
+				select {
+				case err := <-supervisor:
+					if err != nil {
+						logger.Warn("Daemon did not stop cleanly", "error", err)
+					}
+				case <-time.After(serviceStopWait):
+					logger.Warn("Daemon supervisor did not exit in time", "wait", serviceStopWait)
+				}
+				// Report a clean stop even on timeout to avoid SCM-triggered restart racing a
+				// child process that may still be exiting.
 				return false, windows.NO_ERROR
 			case svc.Interrogate:
 				status <- change.CurrentStatus

--- a/cmd/lanternd/lanternd_windows.go
+++ b/cmd/lanternd/lanternd_windows.go
@@ -15,32 +15,6 @@ import (
 	"github.com/getlantern/radiance/common"
 )
 
-// serviceStopWait covers the supervisor's full shutdown path so the service
-// stop handler does not time out while babysit is still finishing.
-const serviceStopWait = gracefulShutdownTimeout + childWaitDelay + 5*time.Second
-
-// serviceRestartDelays defines the SCM restart policy for failures of the
-// supervising service process itself.
-var serviceRestartDelays = []time.Duration{
-	1 * time.Second,
-	2 * time.Second,
-	4 * time.Second,
-	8 * time.Second,
-	16 * time.Second,
-	32 * time.Second,
-	64 * time.Second,
-}
-
-// serviceFailureResetPeriod returns how long the service must run without
-// failing before the SCM resets its failure count.
-func serviceFailureResetPeriod() uint32 {
-	var span time.Duration
-	for _, delay := range serviceRestartDelays {
-		span += delay
-	}
-	return uint32((2 * span).Seconds())
-}
-
 const (
 	serviceName = "LanternSvc"
 	binPath     = "C:\\Program Files\\Lantern\\" + serviceName + ".exe"
@@ -95,30 +69,25 @@ func install(dataPath, logPath, logLevel string, environment daemonEnvironment) 
 	}).args()
 
 	slog.Info("Creating Windows service", "exe", exe, "args", args)
-	svcHandle, err := m.CreateService(serviceName, exe, config, args...)
+	service, err := m.CreateService(serviceName, exe, config, args...)
 	if err != nil {
 		return fmt.Errorf("failed to create %q service: %w", serviceName, err)
 	}
-	defer svcHandle.Close()
+	defer service.Close()
 
-	actions := make([]mgr.RecoveryAction, 0, len(serviceRestartDelays)+1)
-	for _, delay := range serviceRestartDelays {
-		actions = append(actions, mgr.RecoveryAction{Type: mgr.ServiceRestart, Delay: delay})
-	}
-	// The SCM repeats the final recovery action indefinitely, so append NoAction to
-	// make the retry ladder terminate.
-	actions = append(actions, mgr.RecoveryAction{Type: mgr.NoAction})
-
-	err = svcHandle.SetRecoveryActions(actions, serviceFailureResetPeriod())
+	err = service.SetRecoveryActions([]mgr.RecoveryAction{
+		{Type: mgr.ServiceRestart, Delay: 1 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 2 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 4 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 8 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 16 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 32 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 64 * time.Second},
+	}, 60)
 	if err != nil {
 		return fmt.Errorf("failed to set service recovery actions: %w", err)
 	}
-	// Execute always reports SERVICE_STOPPED on return, so enable recovery actions
-	// for non-crash failures as well.
-	if err := svcHandle.SetRecoveryActionsOnNonCrashFailures(true); err != nil {
-		return fmt.Errorf("failed to enable recovery actions on non-crash failures: %w", err)
-	}
-	if err := svcHandle.Start(); err != nil {
+	if err := service.Start(); err != nil {
 		return fmt.Errorf("failed to start service: %w", err)
 	}
 
@@ -134,25 +103,21 @@ func uninstall() error {
 	}
 	defer m.Disconnect()
 
-	svcHandle, err := m.OpenService(serviceName)
+	service, err := m.OpenService(serviceName)
 	if err != nil {
 		return fmt.Errorf("failed to open %q service: %w", serviceName, err)
 	}
 
-	status, err := svcHandle.Query()
+	status, err := service.Query()
 	if err != nil {
-		svcHandle.Close()
+		service.Close()
 		return fmt.Errorf("failed to query service state: %w", err)
 	}
 	if status.State != svc.Stopped {
-		// Continue with deletion even if stop fails; the service will be removed once
-		// its process exits.
-		if _, err := svcHandle.Control(svc.Stop); err != nil {
-			slog.Warn("Failed to stop service before deleting", "error", err)
-		}
+		service.Control(svc.Stop)
 	}
-	err = svcHandle.Delete()
-	svcHandle.Close()
+	err = service.Delete()
+	service.Close()
 	if err != nil {
 		return fmt.Errorf("failed to delete service: %w", err)
 	}
@@ -165,14 +130,14 @@ func uninstall() error {
 		case <-ctx.Done():
 			return fmt.Errorf("timed out waiting for service to be removed")
 		case <-time.After(100 * time.Millisecond):
-			if svcHandle, err = m.OpenService(serviceName); err != nil {
+			if service, err = m.OpenService(serviceName); err != nil {
 				slog.Info("Windows service uninstalled successfully")
 				if err := os.Remove(binPath); err != nil && !os.IsNotExist(err) {
 					return fmt.Errorf("failed to remove binary: %w", err)
 				}
 				return nil
 			}
-			svcHandle.Close()
+			service.Close()
 		}
 	}
 }
@@ -205,53 +170,33 @@ func (s *service) Execute(args []string, r <-chan svc.ChangeRequest, status chan
 		slog.Error("Failed to parse service arguments", "error", err)
 		return true, 1
 	}
-	logger := newDaemonLogger(config.logPath, config.logLevel)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	supervisor := make(chan error, 1)
-	running := make(chan struct{})
-	go func() {
-		supervisor <- babysit(ctx, config.args(), logger, func() { close(running) })
-	}()
-
-	// Delay reporting Running until the first child starts, so startup failures are
-	// reported as service start failures.
-	select {
-	case <-running:
-	case err := <-supervisor:
-		logger.Error("Daemon failed to start", "error", err)
+	// Run the daemon as a child process so we can clean up network state if it crashes,
+	// regardless of whether the SCM is configured to restart the service.
+	childArgs := config.args()
+	child, err := spawnChild(childArgs, newDaemonLogger(config.logPath, config.logLevel))
+	if err != nil {
+		slog.Error("Failed to start daemon", "error", err)
 		return true, 1
 	}
 
 	status <- svc.Status{State: svc.Running, Accepts: svc.AcceptStop | svc.AcceptShutdown}
-	logger.Info("Running as Windows service")
+	child.logger.Info("Running as Windows service")
 
 	for {
 		select {
-		case err := <-supervisor:
-			logger.Error("Daemon supervisor exited, stopping service", "error", err)
+		case err := <-child.Done():
+			if err != nil {
+				child.HandleCrash(err)
+			}
 			return true, 1
 		case change := <-r:
 			switch change.Cmd {
 			case svc.Stop, svc.Shutdown:
-				status <- svc.Status{
-					State:      svc.StopPending,
-					CheckPoint: 1,
-					WaitHint:   uint32(serviceStopWait.Milliseconds()),
-				}
-				logger.Info("Service stop requested")
-				cancel()
-				select {
-				case err := <-supervisor:
-					if err != nil {
-						logger.Warn("Daemon did not stop cleanly", "error", err)
-					}
-				case <-time.After(serviceStopWait):
-					logger.Warn("Daemon supervisor did not exit in time", "wait", serviceStopWait)
-				}
-				// Report a clean stop even on timeout to avoid SCM-triggered restart racing a
-				// child process that may still be exiting.
+				status <- svc.Status{State: svc.StopPending}
+				child.logger.Info("Service stop requested")
+				child.RequestShutdown()
+				child.WaitOrKill(15 * time.Second)
 				return false, windows.NO_ERROR
 			case svc.Interrogate:
 				status <- change.CurrentStatus

--- a/common/backoff.go
+++ b/common/backoff.go
@@ -6,36 +6,40 @@ import (
 	"time"
 )
 
-const waitScale = 10 * time.Millisecond // scale factor for backoff timing
+const defaultBaseWait = 10 * time.Millisecond
 
-// Backoff implements an quadratic backoff strategy with jitter. Should not be used by multiple
+// Backoff implements a quadratic backoff strategy with jitter. Should not be used by multiple
 // goroutines concurrently.
 type Backoff struct {
-	n       int // number of consecutive failures
-	maxWait time.Duration
+	n        int // number of consecutive failures
+	baseWait time.Duration
+	maxWait  time.Duration
 }
 
-func NewBackoff(maxWait time.Duration) *Backoff {
+// NewBackoff creates a new Backoff with the given base wait time and maximum wait time.
+// If baseWait is zero or negative, a default value of 10ms is used.
+func NewBackoff(baseWait, maxWait time.Duration) *Backoff {
+	if baseWait <= 0 {
+		baseWait = defaultBaseWait
+	}
 	return &Backoff{
-		maxWait: maxWait,
+		baseWait: baseWait,
+		maxWait:  maxWait,
 	}
 }
 
-// Wait waits for the appropriate backoff duration based on the number of consecutive failures or
-// until the context is done.
+// Wait pauses for the next backoff interval or returns early if the context is done.
 func (b *Backoff) Wait(ctx context.Context) {
 	if ctx.Err() != nil {
 		return
 	}
 
 	b.n++
-	// quadratic backoff: waitScale * n^2, capped at maxWait
-	wait := waitScale * time.Duration(b.n*b.n)
-	wait = min(wait, b.maxWait)
+	wait := b.baseWait * time.Duration(b.n*b.n)
 
 	// add jitter between 80% and 120% of wait time to avoid thundering herd
 	jitter := 0.8 + 0.4*rand.Float64()
-	wait = time.Duration(float64(wait) * jitter)
+	wait = min(b.maxWait, time.Duration(float64(wait)*jitter))
 	select {
 	case <-ctx.Done():
 	case <-time.After(wait):

--- a/common/env/env.go
+++ b/common/env/env.go
@@ -36,6 +36,10 @@ var (
 	// on the user's router (handy for eero / ISP CPE that don't expose UPnP).
 	PeerExternalPort _key = "RADIANCE_PEER_EXTERNAL_PORT"
 
+	// LogToStdout makes common.Init configure logging to stdout instead of a file.
+	// The log directory is still needed for crash dumps and support archives.
+	LogToStdout _key = "RADIANCE_LOG_TO_STDOUT"
+
 	Testing _key = "RADIANCE_TESTING"
 
 	mu     sync.RWMutex

--- a/common/init.go
+++ b/common/init.go
@@ -90,7 +90,7 @@ func Init(dataDir, logDir, logLevel string) (err error) {
 	}
 
 	logger := log.NewLogger(log.Config{
-		LogPath: filepath.Join(logs, internal.LogFileName),
+		LogPath: loggerPath(logs),
 		Level:   logLevel,
 		Prod:    Prod(),
 	})
@@ -168,6 +168,13 @@ func createCrashReporter() {
 		// We can close f after SetCrashOutput because it duplicates the file descriptor.
 		f.Close()
 	}
+}
+
+func loggerPath(logs string) string {
+	if env.GetBool(env.LogToStdout) {
+		return log.StdoutPath
+	}
+	return filepath.Join(logs, internal.LogFileName)
 }
 
 // setupDirectories creates the data and logs directories, and needed subdirectories if they do

--- a/common/init_test.go
+++ b/common/init_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestLoggerPathUsesLogFileInDirectory(t *testing.T) {
+	t.Setenv(env.LogToStdout.String(), "false")
 	logs := t.TempDir()
 	require.Equal(t, filepath.Join(logs, internal.LogFileName), loggerPath(logs))
 }

--- a/common/init_test.go
+++ b/common/init_test.go
@@ -1,0 +1,22 @@
+package common
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getlantern/radiance/common/env"
+	"github.com/getlantern/radiance/internal"
+	"github.com/getlantern/radiance/log"
+)
+
+func TestLoggerPathUsesLogFileInDirectory(t *testing.T) {
+	logs := t.TempDir()
+	require.Equal(t, filepath.Join(logs, internal.LogFileName), loggerPath(logs))
+}
+
+func TestLoggerPathRedirectsToStdout(t *testing.T) {
+	t.Setenv(env.LogToStdout.String(), "true")
+	require.Equal(t, log.StdoutPath, loggerPath(t.TempDir()))
+}

--- a/config/config.go
+++ b/config/config.go
@@ -300,7 +300,7 @@ func setWireGuardKeyInOptions(endpoints []option.Endpoint, privateKey wgtypes.Ke
 // back to the default pollInterval. This allows the bandit to control how
 // often the client re-fetches based on learning confidence.
 func (ch *ConfigHandler) fetchLoop(defaultPollInterval time.Duration) {
-	backoff := common.NewBackoff(maxRetryDelay)
+	backoff := common.NewBackoff(0, maxRetryDelay)
 	for {
 		if err := ch.fetchConfig(); err != nil {
 			ch.logger.Error("Failed to fetch config. Retrying", "error", err)

--- a/ipc/client.go
+++ b/ipc/client.go
@@ -687,7 +687,7 @@ func (c *Client) ReportIssue(ctx context.Context, issueType issue.IssueType, des
 
 // sseRetryLoop runs sseStream in a retry loop until ctx is cancelled.
 func (c *Client) sseRetryLoop(ctx context.Context, endpoint string, handler func([]byte)) error {
-	bo := common.NewBackoff(30 * time.Second)
+	bo := common.NewBackoff(0, 30*time.Second)
 	for ctx.Err() == nil {
 		err := c.sseStream(ctx, endpoint, handler)
 		if ctx.Err() != nil {

--- a/log/log.go
+++ b/log/log.go
@@ -52,8 +52,8 @@ type Config struct {
 // NewLogger returns a configured logger that writes to a rotating file and
 // optionally stdout, or to stdout only when LogPath is StdoutPath.
 //
-// When env.Testing is set, a no-op logger is returned.
-// the log file is still created.
+// When env.Testing is set, a no-op logger is returned before any file is created. A "disable"
+// level is different: it only filters records, so the log file is still created.
 func NewLogger(cfg Config) *slog.Logger {
 	if env.GetBool(env.Testing) {
 		return NoOpLogger()

--- a/log/log.go
+++ b/log/log.go
@@ -33,8 +33,12 @@ const (
 	Disable = slog.LevelInfo + 1000 // A level that disables logging, used for testing or no-op logger.
 )
 
+// StdoutPath makes Config.LogPath write to stdout instead of a file.
+// No file is opened and no rotation is performed.
+const StdoutPath = "stdout"
+
 type Config struct {
-	// LogPath is the full path to the log file.
+	// LogPath is the full path to the log file, or [StdoutPath].
 	LogPath string
 	// Level is the log level string (e.g., "info", "debug").
 	Level string
@@ -45,9 +49,11 @@ type Config struct {
 	DisablePublisher bool
 }
 
-// NewLogger creates and returns a configured *slog.Logger that writes to a rotating log file
-// and optionally to stdout.
-// Returns noop logger if log level is set to disable.
+// NewLogger returns a configured logger that writes to a rotating file and
+// optionally stdout, or to stdout only when LogPath is StdoutPath.
+//
+// When env.Testing is set, a no-op logger is returned.
+// the log file is still created.
 func NewLogger(cfg Config) *slog.Logger {
 	if env.GetBool(env.Testing) {
 		return NoOpLogger()
@@ -66,42 +72,43 @@ func NewLogger(cfg Config) *slog.Logger {
 	slog.SetLogLoggerLevel(slevel)
 	leveler := settingsLeveler{fallback: slevel}
 
-	// lumberjack creates the log file with 0600 if it does not exist, otherwise it carries over
-	// the existing permissions. Pre-create with [fileperm.File] so the platform-appropriate mode is
-	// applied.
-	f, err := os.OpenFile(cfg.LogPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, fileperm.File)
-	if err != nil {
-		slog.Warn("Failed to pre-create log file", "error", err, "path", cfg.LogPath)
-	} else {
-		f.Close()
-	}
-
-	logRotator := &lumberjack.Logger{
-		Filename:   cfg.LogPath, // Log file path
-		MaxSize:    25,          // Rotate log when it reaches 25 MB
-		MaxBackups: 2,           // Keep up to 2 rotated log files
-		MaxAge:     30,          // Retain old log files for up to 30 days
-		Compress:   cfg.Prod,    // Compress rotated log files
-	}
-
 	isWindows := runtime.GOOS == "windows"
-	isWindowsProd := isWindows && cfg.Prod
+	toStdout := cfg.LogPath == StdoutPath
 
 	loggingToStdOut := true
 	var logWriter io.Writer
-	if env.GetBool(env.DisableStdout) {
-		logWriter = logRotator
-		loggingToStdOut = false
-	} else if isWindowsProd {
-		// For some reason, logging to both stdout and a file on Windows
-		// causes issues with some Windows services where the logs
-		// do not get written to the file. So in prod mode on Windows,
-		// we log to file only. See:
-		// https://www.reddit.com/r/golang/comments/1fpo3cg/golang_windows_service_cannot_write_log_files/
-		logWriter = logRotator
-		loggingToStdOut = false
+	if toStdout {
+		logWriter = os.Stdout
 	} else {
-		logWriter = io.MultiWriter(os.Stdout, logRotator)
+		// Pre-create the file so the intended platform-specific permissions apply
+		// before lumberjack reuses it.
+		f, err := os.OpenFile(cfg.LogPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, fileperm.File)
+		if err != nil {
+			slog.Warn("Failed to pre-create log file", "error", err, "path", cfg.LogPath)
+		} else {
+			f.Close()
+		}
+
+		logRotator := &lumberjack.Logger{
+			Filename:   cfg.LogPath,
+			MaxSize:    25, // Rotate log when it reaches 25 MB
+			MaxBackups: 2,  // Keep up to 2 rotated log files
+			MaxAge:     30, // Retain old log files for up to 30 days
+			Compress:   cfg.Prod,
+		}
+
+		switch {
+		case env.GetBool(env.DisableStdout):
+			logWriter = logRotator
+			loggingToStdOut = false
+		case isWindows && cfg.Prod:
+			// Windows services silently stop writing the file when the same logger also writes
+			// stdout, so prod on Windows is file-only.
+			logWriter = logRotator
+			loggingToStdOut = false
+		default:
+			logWriter = io.MultiWriter(os.Stdout, logRotator)
+		}
 	}
 	if !cfg.DisablePublisher {
 		logWriter = io.MultiWriter(logWriter, Publisher())
@@ -127,7 +134,9 @@ func NewLogger(cfg Config) *slog.Logger {
 	handler = newSourceHandler(handler)
 	handler = &Handler{Handler: handler, w: logWriter}
 	logger := slog.New(handler)
-	if !loggingToStdOut {
+	if toStdout {
+		fmt.Printf("Logging to stdout only, level: %s\n", FormatLogLevel(slevel))
+	} else if !loggingToStdOut {
 		if isWindows {
 			fmt.Printf("Logging to file only on Windows prod -- run with RADIANCE_ENV=dev to enable stdout path: %s, level: %s\n", cfg.LogPath, FormatLogLevel(slevel))
 		} else {


### PR DESCRIPTION
This pull request significantly refactors the supervisor/child process management and service installation logic for the `lanternd` daemon across platforms (Linux, macOS). The changes improve logging reliability, shutdown handling, and service configuration safety, while adding comprehensive tests for the new behaviors.

**Process Supervision and Logging Improvements:**

- Refactored the supervisor (`babysit`) to use a context-based shutdown and improved signal handling, ensuring graceful shutdown and reliable log capture. Introduced constants for shutdown timeouts and improved error handling for child process exits. [[1]](diffhunk://#diff-16002bcd07d33ee2e66973c96c6e218a3acd34034be0bad5f85da21dddc9b1c8R70-R85) [[2]](diffhunk://#diff-16002bcd07d33ee2e66973c96c6e218a3acd34034be0bad5f85da21dddc9b1c8L148-R172) [[3]](diffhunk://#diff-16002bcd07d33ee2e66973c96c6e218a3acd34034be0bad5f85da21dddc9b1c8R347-R426) [[4]](diffhunk://#diff-16002bcd07d33ee2e66973c96c6e218a3acd34034be0bad5f85da21dddc9b1c8L444-R478)
- Replaced the previous log piping and duplication logic with a `bestEffortWriter` that writes child output directly to the supervisor's log sink, dropping output silently if the sink fails to avoid crash loops. [[1]](diffhunk://#diff-16002bcd07d33ee2e66973c96c6e218a3acd34034be0bad5f85da21dddc9b1c8L232-R306) [[2]](diffhunk://#diff-16002bcd07d33ee2e66973c96c6e218a3acd34034be0bad5f85da21dddc9b1c8L302) [[3]](diffhunk://#diff-16002bcd07d33ee2e66973c96c6e218a3acd34034be0bad5f85da21dddc9b1c8R347-R426)
- Added tests to verify child environment setup, log redirection, and the behavior of the `bestEffortWriter`.

**Service Installation and Configuration Hardening:**

- Updated the macOS launchd and Linux systemd templates to safely quote/escape arguments, preventing issues with special characters in file paths and ensuring logs are not duplicated. Added utility functions for XML and shell quoting. [[1]](diffhunk://#diff-6881a896f7c335c4ea244ee6e429cbc8a038879172ac06b36ae64205dca65ecaL24-R56) [[2]](diffhunk://#diff-6881a896f7c335c4ea244ee6e429cbc8a038879172ac06b36ae64205dca65ecaR65-R70) [[3]](diffhunk://#diff-64e21ea52bfb19c04a9a4e504278f8123a4a8c255363eeaead5a7c71164d5fd5L23-R33) [[4]](diffhunk://#diff-64e21ea52bfb19c04a9a4e504278f8123a4a8c255363eeaead5a7c71164d5fd5R47-R50)
- Changed service templates to discard stdout (since the supervisor already captures logs), and ensured stderr is still captured for fatal errors.
- Added tests to verify correct quoting in the systemd unit file.

**Other Improvements:**

- Cleaned up and simplified code by removing unused imports and parameters, and by centralizing environment variable logic for child processes. [[1]](diffhunk://#diff-16002bcd07d33ee2e66973c96c6e218a3acd34034be0bad5f85da21dddc9b1c8L4) [[2]](diffhunk://#diff-16002bcd07d33ee2e66973c96c6e218a3acd34034be0bad5f85da21dddc9b1c8R14) [[3]](diffhunk://#diff-16002bcd07d33ee2e66973c96c6e218a3acd34034be0bad5f85da21dddc9b1c8L302)

**Most Important Changes:**

**Process Supervision & Logging**
- Refactored `babysit` to use context-based shutdown, improved signal handling, and introduced shutdown timeout constants for more robust and predictable daemon lifecycle management. [[1]](diffhunk://#diff-16002bcd07d33ee2e66973c96c6e218a3acd34034be0bad5f85da21dddc9b1c8R70-R85) [[2]](diffhunk://#diff-16002bcd07d33ee2e66973c96c6e218a3acd34034be0bad5f85da21dddc9b1c8L148-R172) [[3]](diffhunk://#diff-16002bcd07d33ee2e66973c96c6e218a3acd34034be0bad5f85da21dddc9b1c8R347-R426)
- Replaced log duplication and piping logic with a `bestEffortWriter` that prevents crash loops if the log sink fails, and added corresponding tests for this behavior. [[1]](diffhunk://#diff-16002bcd07d33ee2e66973c96c6e218a3acd34034be0bad5f85da21dddc9b1c8L232-R306) [[2]](diffhunk://#diff-16002bcd07d33ee2e66973c96c6e218a3acd34034be0bad5f85da21dddc9b1c8L302) [[3]](diffhunk://#diff-8edf3db6079061defe80cda8134d98db1261300a0a58a81b0dd833843f995c8bR140-R168)

**Service Installation Hardening**
- Updated launchd (macOS) and systemd (Linux) templates to safely quote/escape arguments, discard stdout (to avoid duplicate logs), and keep stderr for critical errors. Added utility functions for quoting and escaping. [[1]](diffhunk://#diff-6881a896f7c335c4ea244ee6e429cbc8a038879172ac06b36ae64205dca65ecaL24-R56) [[2]](diffhunk://#diff-6881a896f7c335c4ea244ee6e429cbc8a038879172ac06b36ae64205dca65ecaR65-R70) [[3]](diffhunk://#diff-64e21ea52bfb19c04a9a4e504278f8123a4a8c255363eeaead5a7c71164d5fd5L23-R33) [[4]](diffhunk://#diff-64e21ea52bfb19c04a9a4e504278f8123a4a8c255363eeaead5a7c71164d5fd5R47-R50)
- Added unit tests to ensure correct quoting in the systemd unit file for paths with special characters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an option to send application logs directly to standard output while retaining support files.
  * Improved daemon supervision with graceful cancellation, restart backoff, bounded shutdown, and clearer child-process status handling.
  * Enhanced Windows service recovery and shutdown behavior.

* **Bug Fixes**
  * Improved escaping of paths and arguments in Linux and macOS service configurations.
  * Made child log setup failures non-fatal and retry behavior more responsive.

* **Tests**
  * Added coverage for logging, shutdown behavior, output handling, and service command escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->