### PR TITLE
deps: bump metacubex/utls v1.8.4 -> v1.8.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -152,7 +152,7 @@ require (
 	github.com/knadh/koanf/maps v0.1.2 // indirect
 	github.com/libdns/acmedns v0.5.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/metacubex/utls v1.8.4 // indirect
+	github.com/metacubex/utls v1.8.7 // indirect
 	github.com/mholt/acmez/v3 v3.1.6 // indirect
 	github.com/mholt/archives v0.1.5 // indirect
 	github.com/mikelolasagasti/xz v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -493,8 +493,8 @@ github.com/mdlayher/netlink v1.9.0 h1:G8+GLq2x3v4D4MVIqDdNUhTUC7TKiCy/6MDkmItfKc
 github.com/mdlayher/netlink v1.9.0/go.mod h1:YBnl5BXsCoRuwBjKKlZ+aYmEoq0r12FDA/3JC+94KDg=
 github.com/mdlayher/socket v0.5.1 h1:VZaqt6RkGkt2OE9l3GcC6nZkqD3xKeQLyfleW/uBcos=
 github.com/mdlayher/socket v0.5.1/go.mod h1:TjPLHI1UgwEv5J1B5q0zTZq12A/6H7nKmtTanQE37IQ=
-github.com/metacubex/utls v1.8.4 h1:HmL9nUApDdWSkgUyodfwF6hSjtiwCGGdyhaSpEejKpg=
-github.com/metacubex/utls v1.8.4/go.mod h1:kncGGVhFaoGn5M3pFe3SXhZCzsbCJayNOH4UEqTKTko=
+github.com/metacubex/utls v1.8.7 h1:Cp+yWkNTFkSihETgGWq34hlVFds5HpYWVOR1xovUVTs=
+github.com/metacubex/utls v1.8.7/go.mod h1:kncGGVhFaoGn5M3pFe3SXhZCzsbCJayNOH4UEqTKTko=
 github.com/mholt/acmez/v3 v3.1.6 h1:eGVQNObP0pBN4sxqrXeg7MYqTOWyoiYpQqITVWlrevk=
 github.com/mholt/acmez/v3 v3.1.6/go.mod h1:5nTPosTGosLxF3+LU4ygbgMRFDhbAVpqMI4+a4aHLBY=
 github.com/mholt/archives v0.1.5 h1:Fh2hl1j7VEhc6DZs2DLMgiBNChUux154a1G+2esNvzQ=


### PR DESCRIPTION
Bumps the pinned `github.com/metacubex/utls` from v1.8.4 to v1.8.7, matching the companion bump in `lantern-box`.

### Why

uTLS presets track real Chrome, so a stale pin emits a ClientHello no shipping browser produces — which is the opposite of what the library is for. Keeping the two repos on the same version also avoids the transitive-resolution surprises that a version skew invites.

### Scope

Indirect dependency: `go get` plus `go mod tidy`, with `go.mod` and `go.sum` committed together. No source changes.

```
- github.com/metacubex/utls v1.8.4 // indirect
+ github.com/metacubex/utls v1.8.7 // indirect
```

### Note on CI

`cmd/lantern` currently fails to build on `main` — `ipc.NewClient` is called with no arguments but its signature takes `(context.Context, backend.Options)`. **That breakage is pre-existing and unrelated to this PR**; I verified it reproduces on a clean `origin/main` checkout. Every other package builds, and 23 test packages pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gPSMV42nWXEZZmU7SiLHv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an underlying networking dependency to improve compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->