### PR TITLE
Added OAuth device limit updates

### DIFF
--- a/account/user.go
+++ b/account/user.go
@@ -576,12 +576,9 @@ func (a *Client) OAuthLoginCallback(ctx context.Context, oAuthToken string) (*Us
 	return user, nil
 }
 
-// OAuthDeviceLimitCallback stores the account identity carried by a
-// device-limit OAuth callback token, so the follow-up device removal
-// authenticates as that account — the same thing Login does when the email
-// flow hits the device limit. It does not log the user in: no user data is
-// fetched and no JWT or OAuth state is persisted; the client restarts the
-// OAuth flow once the user has freed up a device slot.
+// OAuthDeviceLimitCallback stores the account identity from a device-limit
+// OAuth callback token so the follow-up device removal authenticates as that
+// account. It does not log the user in.
 func (a *Client) OAuthDeviceLimitCallback(ctx context.Context, oAuthToken string) error {
 	jwtUserInfo, err := decodeJWT(oAuthToken)
 	if err != nil {

--- a/account/user.go
+++ b/account/user.go
@@ -585,19 +585,19 @@ func (a *Client) OAuthLoginCallback(ctx context.Context, oAuthToken string) (*Us
 func (a *Client) OAuthDeviceLimitCallback(ctx context.Context, oAuthToken string) error {
 	jwtUserInfo, err := decodeJWT(oAuthToken)
 	if err != nil {
-		return fmt.Errorf("error decoding JWT: %w", err)
+		return fmt.Errorf("%w: error decoding JWT: %w", ErrInvalidToken, err)
 	}
 	if jwtUserInfo.LegacyUserID == 0 || jwtUserInfo.LegacyToken == "" {
-		return fmt.Errorf("device-limit token is missing the account identity")
+		return fmt.Errorf("%w: device-limit token is missing the account identity", ErrInvalidToken)
 	}
-	// LegacyUserData stays nil so setData takes its identity-only branch
-	// instead of persisting a full login.
-	a.setData(&UserData{
-		LegacyID:    jwtUserInfo.LegacyUserID,
-		LegacyToken: jwtUserInfo.LegacyToken,
-	})
-	return nil
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return storeIdentity(jwtUserInfo.LegacyUserID, jwtUserInfo.LegacyToken)
 }
+
+// ErrInvalidToken distinguishes an unusable OAuth callback token from a
+// failure persisting its claims, so transports can map it to a client error.
+var ErrInvalidToken = errors.New("invalid OAuth token")
 
 type LinkResponse struct {
 	*protos.BaseResponse `json:",inline"`
@@ -697,6 +697,22 @@ type UserChangeEvent struct {
 	events.Event
 }
 
+// storeIdentity persists just the account identity in a single atomic write,
+// so a failure can't leave the stored user ID and token inconsistent.
+func storeIdentity(id int64, token string) error {
+	updates := settings.Settings{}
+	if id != 0 {
+		updates[settings.UserIDKey] = id
+	}
+	if token != "" {
+		updates[settings.TokenKey] = token
+	}
+	if len(updates) == 0 {
+		return nil
+	}
+	return settings.Patch(updates)
+}
+
 func (a *Client) setData(data *UserData) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -708,15 +724,8 @@ func (a *Client) setData(data *UserData) {
 	// This case when user hits device limit while login
 	if data.LegacyUserData == nil {
 		slog.Info("no user data to set, storing id and token only")
-		if data.LegacyID != 0 {
-			if err := settings.Set(settings.UserIDKey, data.LegacyID); err != nil {
-				slog.Error("failed to set user ID in settings", "error", err)
-			}
-		}
-		if data.LegacyToken != "" {
-			if err := settings.Set(settings.TokenKey, data.LegacyToken); err != nil {
-				slog.Error("failed to set token in settings", "error", err)
-			}
+		if err := storeIdentity(data.LegacyID, data.LegacyToken); err != nil {
+			slog.Error("failed to store account identity", "error", err)
 		}
 		return
 	}

--- a/account/user.go
+++ b/account/user.go
@@ -587,8 +587,6 @@ func (a *Client) OAuthDeviceLimitCallback(ctx context.Context, oAuthToken string
 	if jwtUserInfo.LegacyUserID == 0 || jwtUserInfo.LegacyToken == "" {
 		return fmt.Errorf("%w: device-limit token is missing the account identity", ErrInvalidToken)
 	}
-	a.mu.Lock()
-	defer a.mu.Unlock()
 	return storeIdentity(jwtUserInfo.LegacyUserID, jwtUserInfo.LegacyToken)
 }
 

--- a/account/user.go
+++ b/account/user.go
@@ -576,6 +576,29 @@ func (a *Client) OAuthLoginCallback(ctx context.Context, oAuthToken string) (*Us
 	return user, nil
 }
 
+// OAuthDeviceLimitCallback stores the account identity carried by a
+// device-limit OAuth callback token, so the follow-up device removal
+// authenticates as that account — the same thing Login does when the email
+// flow hits the device limit. It does not log the user in: no user data is
+// fetched and no JWT or OAuth state is persisted; the client restarts the
+// OAuth flow once the user has freed up a device slot.
+func (a *Client) OAuthDeviceLimitCallback(ctx context.Context, oAuthToken string) error {
+	jwtUserInfo, err := decodeJWT(oAuthToken)
+	if err != nil {
+		return fmt.Errorf("error decoding JWT: %w", err)
+	}
+	if jwtUserInfo.LegacyUserID == 0 || jwtUserInfo.LegacyToken == "" {
+		return fmt.Errorf("device-limit token is missing the account identity")
+	}
+	// LegacyUserData stays nil so setData takes its identity-only branch
+	// instead of persisting a full login.
+	a.setData(&UserData{
+		LegacyID:    jwtUserInfo.LegacyUserID,
+		LegacyToken: jwtUserInfo.LegacyToken,
+	})
+	return nil
+}
+
 type LinkResponse struct {
 	*protos.BaseResponse `json:",inline"`
 	UserID               int    `json:"userID"`

--- a/account/user_test.go
+++ b/account/user_test.go
@@ -2,6 +2,7 @@ package account
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"io"
@@ -432,6 +433,46 @@ func TestOAuthLoginCallback_InvalidToken(t *testing.T) {
 	_, err := ac.OAuthLoginCallback(context.Background(), "invalid-token")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "error decoding JWT")
+}
+
+// mockJWT builds an unsigned JWT from the given claims; decodeJWT uses
+// ParseUnverified, so the fake signature is never checked.
+func mockJWT(t *testing.T, claims map[string]any) string {
+	payload, err := json.Marshal(claims)
+	require.NoError(t, err)
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	return header + "." + base64.RawURLEncoding.EncodeToString(payload) + ".test"
+}
+
+func TestOAuthDeviceLimitCallback(t *testing.T) {
+	ac, _ := newTestClient(t)
+
+	token := mockJWT(t, map[string]any{
+		"email":          "test@example.com",
+		"legacy_user_id": 12345,
+		"legacy_token":   "test-token",
+	})
+	err := ac.OAuthDeviceLimitCallback(context.Background(), token)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 12345, settings.GetInt64(settings.UserIDKey))
+	assert.Equal(t, "test-token", settings.GetString(settings.TokenKey))
+}
+
+func TestOAuthDeviceLimitCallback_InvalidToken(t *testing.T) {
+	ac, _ := newTestClient(t)
+
+	err := ac.OAuthDeviceLimitCallback(context.Background(), "invalid-token")
+	assert.ErrorIs(t, err, ErrInvalidToken)
+	assert.Contains(t, err.Error(), "error decoding JWT")
+}
+
+func TestOAuthDeviceLimitCallback_MissingIdentity(t *testing.T) {
+	ac, _ := newTestClient(t)
+
+	token := mockJWT(t, map[string]any{"email": "test@example.com"})
+	err := ac.OAuthDeviceLimitCallback(context.Background(), token)
+	assert.ErrorIs(t, err, ErrInvalidToken)
+	assert.Contains(t, err.Error(), "missing the account identity")
 }
 
 func TestReferralAttach_EmptyChannelUsesV1(t *testing.T) {

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -1655,6 +1655,10 @@ func (r *LocalBackend) OAuthLoginCallback(ctx context.Context, oAuthToken string
 	return r.accountClient.OAuthLoginCallback(ctx, oAuthToken)
 }
 
+func (r *LocalBackend) OAuthDeviceLimitCallback(ctx context.Context, oAuthToken string) error {
+	return r.accountClient.OAuthDeviceLimitCallback(ctx, oAuthToken)
+}
+
 func (r *LocalBackend) OAuthLoginURL(ctx context.Context, provider string) (string, error) {
 	return r.accountClient.OAuthLoginURL(ctx, provider)
 }

--- a/ipc/client.go
+++ b/ipc/client.go
@@ -576,6 +576,14 @@ func (c *Client) OAuthLoginCallback(ctx context.Context, oAuthToken string) (*ac
 	return &userData, nil
 }
 
+// OAuthDeviceLimitCallback stores the account identity from a device-limit
+// OAuth callback token without logging the user in; see account.Client.OAuthDeviceLimitCallback.
+func (c *Client) OAuthDeviceLimitCallback(ctx context.Context, oAuthToken string) error {
+	_, err := c.do(ctx, http.MethodPost, accountOAuthDeviceLimitEndpoint,
+		OAuthTokenRequest{OAuthToken: oAuthToken})
+	return err
+}
+
 // DataCapInfo returns the current data cap information as a JSON string.
 func (c *Client) DataCapInfo(ctx context.Context) (*account.DataCapInfo, error) {
 	var resp account.DataCapInfo

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -81,19 +81,20 @@ const (
 	splitTunnelEndpoint = "/split-tunnel"
 
 	// Account endpoints
-	accountNewUserEndpoint        = "/account/new-user"
-	accountLoginEndpoint          = "/account/login"
-	accountLogoutEndpoint         = "/account/logout"
-	accountUserDataEndpoint       = "/account/user"
-	accountDevicesEndpoint        = "/account/devices/"
-	accountSignupEndpoint         = "/account/signup/"
-	accountVerifyPasswordEndpoint = "/account/verify-password"
-	accountEmailEndpoint          = "/account/email"
-	accountRecoveryEndpoint       = "/account/recovery"
-	accountDeleteEndpoint         = "/account/delete"
-	accountOAuthEndpoint          = "/account/oauth"
-	accountDataCapEndpoint        = "/account/datacap"
-	accountDataCapStreamEndpoint  = "/account/datacap/stream"
+	accountNewUserEndpoint          = "/account/new-user"
+	accountLoginEndpoint            = "/account/login"
+	accountLogoutEndpoint           = "/account/logout"
+	accountUserDataEndpoint         = "/account/user"
+	accountDevicesEndpoint          = "/account/devices/"
+	accountSignupEndpoint           = "/account/signup/"
+	accountVerifyPasswordEndpoint   = "/account/verify-password"
+	accountEmailEndpoint            = "/account/email"
+	accountRecoveryEndpoint         = "/account/recovery"
+	accountDeleteEndpoint           = "/account/delete"
+	accountOAuthEndpoint            = "/account/oauth"
+	accountOAuthDeviceLimitEndpoint = "/account/oauth/device-limit"
+	accountDataCapEndpoint          = "/account/datacap"
+	accountDataCapStreamEndpoint    = "/account/datacap/stream"
 
 	// Subscription endpoints
 	subscriptionActivationEndpoint         = "/subscription/activation"
@@ -264,6 +265,7 @@ func newLocalAPI(b *backend.LocalBackend, withAuth bool) *localapi {
 	mux.HandleFunc("POST "+accountRecoveryEndpoint+"/{action}", traced(s.accountRecoveryHandler))
 	mux.HandleFunc("DELETE "+accountDeleteEndpoint, traced(s.accountDeleteHandler))
 	mux.HandleFunc(accountOAuthEndpoint, traced(s.accountOAuthHandler))
+	mux.HandleFunc("POST "+accountOAuthDeviceLimitEndpoint, traced(s.accountOAuthDeviceLimitHandler))
 	mux.HandleFunc("GET "+accountDataCapEndpoint, traced(s.accountDataCapHandler))
 
 	// SSE routes skip the tracer middleware since it buffers the entire response body.
@@ -1185,6 +1187,19 @@ func (s *localapi) accountOAuthHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, URLResponse{URL: u})
+}
+
+func (s *localapi) accountOAuthDeviceLimitHandler(w http.ResponseWriter, r *http.Request) {
+	var req OAuthTokenRequest
+	if err := decodeJSON(r, &req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := s.backend(r.Context()).OAuthDeviceLimitCallback(r.Context(), req.OAuthToken); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
 }
 
 func (s *localapi) accountDataCapHandler(w http.ResponseWriter, r *http.Request) {

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -1195,8 +1195,16 @@ func (s *localapi) accountOAuthDeviceLimitHandler(w http.ResponseWriter, r *http
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	if req.OAuthToken == "" {
+		http.Error(w, "oAuthToken is required", http.StatusBadRequest)
+		return
+	}
 	if err := s.backend(r.Context()).OAuthDeviceLimitCallback(r.Context(), req.OAuthToken); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		status := http.StatusInternalServerError
+		if errors.Is(err, account.ErrInvalidToken) {
+			status = http.StatusBadRequest
+		}
+		http.Error(w, err.Error(), status)
 		return
 	}
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
This pull request introduces support for handling OAuth device-limit callback tokens throughout the authentication stack. The main goal is to allow the client to store account identity information when a device limit is reached during OAuth login, without performing a full login or persisting user data. This enables the user to remove a device and restart the OAuth flow as the correct account.

**OAuth Device-Limit Callback Support:**

* Added a new `OAuthDeviceLimitCallback` method to the `account.Client`, which stores account identity from a device-limit OAuth callback token without logging the user in or persisting session data.
* Implemented `OAuthDeviceLimitCallback` in the `LocalBackend` to delegate to the account client, enabling backend support for the new flow.

**IPC and API Changes:**

* Added `OAuthDeviceLimitCallback` to the IPC `Client`, sending the device-limit OAuth token to the server for processing.
* Introduced a new API endpoint, `/account/oauth/device-limit`, and registered its handler in the local API server. [[1]](diffhunk://#diff-dc406fc743858a2874d0cebfbc7c0be932056c3a247189aca780ca5ac3342c64R95) [[2]](diffhunk://#diff-dc406fc743858a2874d0cebfbc7c0be932056c3a247189aca780ca5ac3342c64R268)
* Implemented the `accountOAuthDeviceLimitHandler` in the local API server to process incoming device-limit OAuth tokens and respond appropriately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for OAuth device-limit callbacks.
  * Device-limit callbacks can store account identity without signing users in or retrieving additional account data.
  * Added an API endpoint for submitting device-limit OAuth tokens with clear success and error responses.

* **Bug Fixes**
  * Invalid or incomplete OAuth tokens now return clear client errors.
  * Split-tunnel settings are validated and applied consistently when loaded or updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->