### PR TITLE
feat(split-tunnel): add include/exclude policy

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -188,6 +188,11 @@ func NewLocalBackend(ctx context.Context, opts Options) (*LocalBackend, error) {
 	if err != nil {
 		slog.Error("Loading split tunnel handler", "error", err)
 	}
+	// Empty filters do not persist the invert flag, so reload can reset the
+	// loaded policy. Re-apply the persisted setting as the source of truth.
+	if err := splitTunnelMgr.SetPolicy(vpn.SplitTunnelPolicy(settings.GetString(settings.SplitTunnelPolicyKey))); err != nil {
+		slog.Warn("Reconciling split-tunnel policy", "error", err)
+	}
 
 	vpnClient := vpn.NewVPNClient(dataDir, slog.Default().With("service", "vpn"), opts.PlatformInterface)
 
@@ -613,15 +618,22 @@ func (r *LocalBackend) PatchSettings(updates settings.Settings) error {
 	}
 
 	// vpn settings
-	k := settings.SplitTunnelKey
-	if _, ok := diff[k]; ok {
-		r.splitTunnelMgr.SetEnabled(settings.GetBool(k))
-	}
-	// settings.Patch above already persisted the whole diff, so an early
-	// return here would leave a persisted key that no runtime state matches —
-	// exactly the divergence applyPeerShare's rollback exists to prevent.
-	// Run both handlers and join their errors.
+	//
+	// settings.Patch above already persisted the whole diff, so an early return
+	// on a handler error would leave a persisted key that no runtime state
+	// matches — the divergence applyPeerShare's rollback exists to prevent. Run
+	// every handler and join their errors so the caller sees write failures.
 	var errs error
+	if _, ok := diff[settings.SplitTunnelKey]; ok {
+		if err := r.splitTunnelMgr.SetEnabled(settings.GetBool(settings.SplitTunnelKey)); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("set split-tunnel enabled: %w", err))
+		}
+	}
+	if _, ok := diff[settings.SplitTunnelPolicyKey]; ok {
+		if err := r.splitTunnelMgr.SetPolicy(vpn.SplitTunnelPolicy(settings.GetString(settings.SplitTunnelPolicyKey))); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("set split-tunnel policy: %w", err))
+		}
+	}
 	if err := r.maybeRestartVPN(diff); err != nil {
 		errs = errors.Join(errs, err)
 	}

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -603,6 +603,13 @@ func (r *LocalBackend) PatchSettings(updates settings.Settings) error {
 	if len(diff) == 0 {
 		return nil
 	}
+	// Reject an invalid split-tunnel policy before persisting, so settings.json
+	// can't hold a value the runtime would silently fall back to exclude for.
+	if v, ok := diff[settings.SplitTunnelPolicyKey]; ok {
+		if p := vpn.SplitTunnelPolicy(fmt.Sprintf("%v", v)); !p.Valid() {
+			return fmt.Errorf("invalid %s: %v", settings.SplitTunnelPolicyKey, v)
+		}
+	}
 	if err := settings.Patch(diff); err != nil {
 		return fmt.Errorf("failed to update settings: %w", err)
 	}

--- a/backend/radiance_test.go
+++ b/backend/radiance_test.go
@@ -351,6 +351,20 @@ func newPeerTestBackend(t *testing.T, fake *fakePeerController) *LocalBackend {
 	return &LocalBackend{ctx: ctx, peerClient: fake}
 }
 
+func TestPatchSettings_RejectsInvalidSplitTunnelPolicy(t *testing.T) {
+	require.NoError(t, settings.InitSettings(t.TempDir()))
+	t.Cleanup(settings.Reset)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	r := &LocalBackend{ctx: ctx}
+
+	err := r.PatchSettings(settings.Settings{settings.SplitTunnelPolicyKey: "bogus"})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid")
+	assert.Empty(t, settings.GetString(settings.SplitTunnelPolicyKey),
+		"an invalid policy must not be persisted")
+}
+
 func TestApplyPeerShare_StartsOnEnable(t *testing.T) {
 	fake := &fakePeerController{}
 	r := newPeerTestBackend(t, fake)

--- a/cmd/lantern/settings.go
+++ b/cmd/lantern/settings.go
@@ -8,6 +8,7 @@ import (
 	"github.com/getlantern/radiance/common/settings"
 	"github.com/getlantern/radiance/ipc"
 	rlog "github.com/getlantern/radiance/log"
+	"github.com/getlantern/radiance/vpn"
 )
 
 type FeaturesCmd struct{}
@@ -24,7 +25,7 @@ func runFeatures(ctx context.Context, c *ipc.Client) error {
 }
 
 var settingNames = []string{
-	"smart-routing", "ad-block", "telemetry", "split-tunnel",
+	"smart-routing", "ad-block", "telemetry", "split-tunnel", "split-tunnel-policy",
 	"fetch-config", "log-level", "feature-overrides", "country",
 }
 
@@ -38,6 +39,12 @@ func settingValue(name string, s settings.Settings) (any, bool) {
 		return orBool(s[settings.TelemetryKey]), true
 	case "split-tunnel":
 		return orBool(s[settings.SplitTunnelKey]), true
+	case "split-tunnel-policy":
+		p := vpn.SplitTunnelPolicy(fmt.Sprintf("%v", orString(s[settings.SplitTunnelPolicyKey])))
+		if !p.Valid() {
+			p = vpn.SplitTunnelPolicyExclude
+		}
+		return string(p), true
 	case "fetch-config":
 		return !toBool(s[settings.ConfigFetchDisabledKey]), true
 	case "log-level":
@@ -51,14 +58,15 @@ func settingValue(name string, s settings.Settings) (any, bool) {
 }
 
 type SetCmd struct {
-	SmartRouting     *bool   `arg:"--smart-routing" help:"enable or disable smart routing (true|false)"`
-	AdBlock          *bool   `arg:"--ad-block" help:"enable or disable ad blocking (true|false)"`
-	Telemetry        *bool   `arg:"--telemetry" help:"enable or disable telemetry (true|false)"`
-	SplitTunnel      *bool   `arg:"--split-tunnel" help:"enable or disable split tunneling (true|false)"`
-	FetchConfig      *bool   `arg:"--fetch-config" help:"enable or disable periodic config fetching (true|false)"`
-	LogLevel         *string `arg:"--log-level" help:"log level (trace|debug|info|warn|error|fatal|panic|disable)"`
-	FeatureOverrides *string `arg:"--feature-overrides" help:"comma-separated feature flags to force-enable via the X-Lantern-Feature-Override header (empty string clears)"`
-	Country          *string `arg:"--country" help:"override the client country code sent to the config server (empty string clears)"`
+	SmartRouting      *bool   `arg:"--smart-routing" help:"enable or disable smart routing (true|false)"`
+	AdBlock           *bool   `arg:"--ad-block" help:"enable or disable ad blocking (true|false)"`
+	Telemetry         *bool   `arg:"--telemetry" help:"enable or disable telemetry (true|false)"`
+	SplitTunnel       *bool   `arg:"--split-tunnel" help:"enable or disable split tunneling (true|false)"`
+	SplitTunnelPolicy *string `arg:"--split-tunnel-policy" help:"split-tunnel policy: exclude matches from the VPN, or include only matches in the VPN (exclude|include)"`
+	FetchConfig       *bool   `arg:"--fetch-config" help:"enable or disable periodic config fetching (true|false)"`
+	LogLevel          *string `arg:"--log-level" help:"log level (trace|debug|info|warn|error|fatal|panic|disable)"`
+	FeatureOverrides  *string `arg:"--feature-overrides" help:"comma-separated feature flags to force-enable via the X-Lantern-Feature-Override header (empty string clears)"`
+	Country           *string `arg:"--country" help:"override the client country code sent to the config server (empty string clears)"`
 }
 
 func runSet(ctx context.Context, c *ipc.Client, cmd *SetCmd) error {
@@ -74,6 +82,13 @@ func runSet(ctx context.Context, c *ipc.Client, cmd *SetCmd) error {
 	}
 	if cmd.SplitTunnel != nil {
 		updates[settings.SplitTunnelKey] = *cmd.SplitTunnel
+	}
+	if cmd.SplitTunnelPolicy != nil {
+		policy := vpn.SplitTunnelPolicy(*cmd.SplitTunnelPolicy)
+		if !policy.Valid() {
+			return fmt.Errorf("invalid --split-tunnel-policy %q (want exclude|include)", *cmd.SplitTunnelPolicy)
+		}
+		updates[settings.SplitTunnelPolicyKey] = string(policy)
 	}
 	if cmd.FetchConfig != nil {
 		updates[settings.ConfigFetchDisabledKey] = !*cmd.FetchConfig
@@ -108,7 +123,7 @@ func runSet(ctx context.Context, c *ipc.Client, cmd *SetCmd) error {
 }
 
 type GetCmd struct {
-	Name string `arg:"positional" help:"setting name (smart-routing, ad-block, telemetry, split-tunnel, fetch-config, log-level, feature-overrides, country); omit to list all"`
+	Name string `arg:"positional" help:"setting name (smart-routing, ad-block, telemetry, split-tunnel, split-tunnel-policy, fetch-config, log-level, feature-overrides, country); omit to list all"`
 }
 
 func runGet(ctx context.Context, c *ipc.Client, cmd *GetCmd) error {

--- a/cmd/lantern/split_tunnel.go
+++ b/cmd/lantern/split_tunnel.go
@@ -49,6 +49,11 @@ func splitTunnelList(ctx context.Context, c *ipc.Client) error {
 	}
 	enabled, _ := strconv.ParseBool(fmt.Sprintf("%v", s[settings.SplitTunnelKey]))
 	fmt.Printf("Split tunneling: %v\n", enabled)
+	policy := vpn.SplitTunnelPolicy(fmt.Sprintf("%v", orString(s[settings.SplitTunnelPolicyKey])))
+	if !policy.Valid() {
+		policy = vpn.SplitTunnelPolicyExclude
+	}
+	fmt.Printf("Policy: %v\n", policy)
 	filters, err := c.SplitTunnelFilters(ctx)
 	if err != nil {
 		return err

--- a/common/settings/settings.go
+++ b/common/settings/settings.go
@@ -50,11 +50,12 @@ const (
 	OAuthProviderKey _key = "oauth_provider" // string (e.g. "google", "apple", "email")
 
 	// VPN related keys.
-	SmartRoutingKey     _key = "smart_routing"      // bool
-	SplitTunnelKey      _key = "split_tunnel"       // bool
-	AdBlockKey          _key = "ad_block"           // bool
-	AutoConnectKey      _key = "auto_connect"       // bool
-	PeerShareEnabledKey _key = "peer_share_enabled" // bool
+	SmartRoutingKey      _key = "smart_routing"       // bool
+	SplitTunnelKey       _key = "split_tunnel"        // bool
+	SplitTunnelPolicyKey _key = "split_tunnel_policy" // string ("exclude"|"include")
+	AdBlockKey           _key = "ad_block"            // bool
+	AutoConnectKey       _key = "auto_connect"        // bool
+	PeerShareEnabledKey  _key = "peer_share_enabled"  // bool
 	// PeerManualPortKey is the TCP port number the user has manually
 	// forwarded on their router for the peer-proxy inbound (single-
 	// port 1:1 NAT). Valid range is 1..65535; 0 means unset, in which

--- a/ipc/client.go
+++ b/ipc/client.go
@@ -353,6 +353,16 @@ func (c *Client) EnableSplitTunneling(ctx context.Context, enable bool) error {
 	return err
 }
 
+// SetSplitTunnelPolicy selects how the split-tunnel filter is interpreted (see
+// [vpn.SplitTunnelPolicy]).
+func (c *Client) SetSplitTunnelPolicy(ctx context.Context, policy vpn.SplitTunnelPolicy) error {
+	if !policy.Valid() {
+		return fmt.Errorf("invalid split-tunnel policy: %q", policy)
+	}
+	_, err := c.PatchSettings(ctx, settings.Settings{settings.SplitTunnelPolicyKey: string(policy)})
+	return err
+}
+
 func (c *Client) EnableSmartRouting(ctx context.Context, enable bool) error {
 	_, err := c.PatchSettings(ctx, settings.Settings{settings.SmartRoutingKey: enable})
 	return err

--- a/vpn/split_tunnel.go
+++ b/vpn/split_tunnel.go
@@ -26,14 +26,15 @@ import (
 
 const splitTunnelFile = internal.SplitTunnelFileName
 
-// SplitTunnel manages the split tunneling feature, allowing users to specify which domains,
-// processes, or packages should bypass the VPN tunnel.
+// SplitTunnel manages split tunneling for configured domains, processes, and
+// packages.
 type SplitTunnel struct {
 	rule         O.LogicalHeadlessRule
 	activeFilter *O.LogicalHeadlessRule
 	ruleFile     string
 	ruleMap      map[string]*O.DefaultHeadlessRule
 	enabled      *atomic.Bool
+	inverted     *atomic.Bool
 	access       sync.Mutex
 	logger       *slog.Logger
 }
@@ -61,6 +62,7 @@ func newSplitTunnel(path string, logger *slog.Logger) *SplitTunnel {
 		activeFilter: &(rule.Rules[1].LogicalOptions),
 		ruleMap:      make(map[string]*O.DefaultHeadlessRule),
 		enabled:      &atomic.Bool{},
+		inverted:     &atomic.Bool{},
 		logger:       logger,
 	}
 	s.initRuleMap()
@@ -100,6 +102,37 @@ func (s *SplitTunnel) SetEnabled(enabled bool) error {
 
 func (s *SplitTunnel) IsEnabled() bool {
 	return s.enabled.Load()
+}
+
+// SetPolicy changes how the split-tunnel filter is interpreted and persists it.
+// Invalid policies default to [SplitTunnelPolicyExclude].
+//
+// Empty filters serialize without a filter rule, so traffic remains tunneled in
+// either policy.
+func (s *SplitTunnel) SetPolicy(policy SplitTunnelPolicy) error {
+	invert := policy == SplitTunnelPolicyInclude
+	s.access.Lock()
+	defer s.access.Unlock()
+	if s.inverted.Load() == invert {
+		return nil
+	}
+	prev := s.activeFilter.Invert
+	s.activeFilter.Invert = invert
+	if err := s.saveLocked(); err != nil {
+		s.activeFilter.Invert = prev
+		return fmt.Errorf("writing rule to %s: %w", s.ruleFile, err)
+	}
+	s.inverted.Store(invert)
+	s.logger.Log(context.Background(), log.LevelTrace, "Updated split-tunnel policy", "policy", policy)
+	return nil
+}
+
+// Policy reports the current split-tunnel filter interpretation.
+func (s *SplitTunnel) Policy() SplitTunnelPolicy {
+	if s.inverted.Load() {
+		return SplitTunnelPolicyInclude
+	}
+	return SplitTunnelPolicyExclude
 }
 
 func (s *SplitTunnel) Filters() SplitTunnelFilter {
@@ -250,8 +283,9 @@ func (s *SplitTunnel) saveLocked() error {
 		outerRules = append(outerRules, O.HeadlessRule{
 			Type: s.rule.Rules[1].Type,
 			LogicalOptions: O.LogicalHeadlessRule{
-				Mode:  s.activeFilter.Mode,
-				Rules: filterRules,
+				Mode:   s.activeFilter.Mode,
+				Rules:  filterRules,
+				Invert: s.activeFilter.Invert,
 			},
 		})
 	}
@@ -375,9 +409,11 @@ func (s *SplitTunnel) loadRule() error {
 	s.activeFilter = &(s.rule.Rules[1].LogicalOptions)
 	s.initRuleMap()
 	s.enabled.Store(s.rule.Mode == C.LogicalTypeOr)
+	s.inverted.Store(s.activeFilter.Invert)
 
 	s.logger.Log(context.Background(), log.LevelTrace, "loaded split tunnel rules",
-		"file", s.ruleFile, "filters", s.Filters().String(), "enabled", s.IsEnabled(),
+		"file", s.ruleFile, "filters", s.Filters().String(),
+		"enabled", s.IsEnabled(), "policy", s.Policy(),
 	)
 	return nil
 }

--- a/vpn/split_tunnel.go
+++ b/vpn/split_tunnel.go
@@ -110,6 +110,9 @@ func (s *SplitTunnel) IsEnabled() bool {
 // Empty filters serialize without a filter rule, so traffic remains tunneled in
 // either policy.
 func (s *SplitTunnel) SetPolicy(policy SplitTunnelPolicy) error {
+	if !policy.Valid() {
+		policy = SplitTunnelPolicyExclude
+	}
 	invert := policy == SplitTunnelPolicyInclude
 	s.access.Lock()
 	defer s.access.Unlock()

--- a/vpn/split_tunnel_novpn.go
+++ b/vpn/split_tunnel_novpn.go
@@ -17,6 +17,10 @@ func (s *SplitTunnel) IsEnabled() bool { return false }
 
 func (s *SplitTunnel) SetEnabled(_ bool) error { return nil }
 
+func (s *SplitTunnel) Policy() SplitTunnelPolicy { return SplitTunnelPolicyExclude }
+
+func (s *SplitTunnel) SetPolicy(_ SplitTunnelPolicy) error { return nil }
+
 func (s *SplitTunnel) Filters() SplitTunnelFilter { return SplitTunnelFilter{} }
 
 func (s *SplitTunnel) AddItems(_ SplitTunnelFilter) error { return nil }

--- a/vpn/split_tunnel_test.go
+++ b/vpn/split_tunnel_test.go
@@ -292,6 +292,140 @@ func (r *mockRouter) RuleSet(tag string) (adapter.RuleSet, bool) {
 	return r.ruleSet, true
 }
 
+// splitTunnelMatcher builds a live route rule from st's saved rule file.
+// waitReload blocks until the rule set reflects the latest saved state.
+// A match means the connection is routed direct.
+func splitTunnelMatcher(t *testing.T, st *SplitTunnel) (rule adapter.Rule, waitReload func()) {
+	t.Helper()
+	ruleOpts := O.Rule{
+		Type: C.RuleTypeDefault,
+		DefaultOptions: O.DefaultRule{
+			RawDefaultRule: O.RawDefaultRule{RuleSet: []string{splitTunnelTag}},
+			RuleAction: O.RuleAction{
+				Action:       C.RuleActionTypeRoute,
+				RouteOptions: O.RouteActionOptions{Outbound: "direct"},
+			},
+		},
+	}
+	rsetOpts := O.RuleSet{
+		Type:         C.RuleSetTypeLocal,
+		Tag:          splitTunnelTag,
+		LocalOptions: O.LocalRuleSet{Path: st.ruleFile},
+		Format:       C.RuleSetFormatSource,
+	}
+
+	ctx := service.ContextWithDefaultRegistry(context.Background())
+	logger := log.NewNOPFactory().Logger()
+	router := &mockRouter{}
+	service.MustRegister[adapter.Router](ctx, router)
+	service.MustRegister(ctx, new(adapter.NetworkManager))
+
+	ruleSet, err := R.NewRuleSet(ctx, logger, rsetOpts)
+	require.NoError(t, err)
+	require.NoError(t, ruleSet.StartContext(ctx, new(adapter.HTTPStartContext)))
+	t.Cleanup(func() { ruleSet.Close() })
+	router.ruleSet = ruleSet
+
+	rule, err = R.NewRule(ctx, logger, ruleOpts, false)
+	require.NoError(t, err)
+	require.NoError(t, rule.Start())
+	t.Cleanup(func() { rule.Close() })
+
+	last := ruleSet.String()
+	waitReload = func() {
+		t.Helper()
+		require.Eventually(t, func() bool {
+			return ruleSet.String() != last
+		}, time.Second, 50*time.Millisecond, "timed out waiting for rule reload")
+		last = ruleSet.String()
+	}
+	return rule, waitReload
+}
+
+func TestPolicyInvertsMatch(t *testing.T) {
+	st := newSplitTunnel(t.TempDir(), rlog.NoOpLogger())
+	require.NoError(t, st.AddItem(TypeDomain, "example.com"))
+
+	rule, waitReload := splitTunnelMatcher(t, st)
+	matched := &adapter.InboundContext{Domain: "example.com"}
+	unmatched := &adapter.InboundContext{Domain: "other.com"}
+
+	require.NoError(t, st.SetEnabled(true))
+	waitReload()
+
+	assert.True(t, rule.Match(matched), "exclude: matched should route direct")
+	assert.False(t, rule.Match(unmatched), "exclude: unmatched should stay tunneled")
+
+	require.NoError(t, st.SetPolicy(SplitTunnelPolicyInclude))
+	waitReload()
+
+	assert.False(t, rule.Match(matched), "include: matched should stay tunneled")
+	assert.True(t, rule.Match(unmatched), "include: unmatched should route direct")
+}
+
+func TestEmptyFilterModeInert(t *testing.T) {
+	st := newSplitTunnel(t.TempDir(), rlog.NoOpLogger())
+	require.NoError(t, st.SetEnabled(true))
+	require.NoError(t, st.SetPolicy(SplitTunnelPolicyInclude))
+
+	// Build the matcher after the state is set; an empty filter serializes to a
+	// disable-only rule set whose stringified form doesn't change on the
+	// enable/policy toggle, so there is no reload edge to wait on.
+	rule, _ := splitTunnelMatcher(t, st)
+
+	assert.False(t, rule.Match(&adapter.InboundContext{Domain: "anything.com"}),
+		"empty include filter should tunnel everything (route nothing direct)")
+}
+
+func TestPolicyPersistence(t *testing.T) {
+	tmpDir := t.TempDir()
+	st, err := NewSplitTunnelHandler(tmpDir, rlog.NoOpLogger())
+	require.NoError(t, err)
+	require.Equal(t, SplitTunnelPolicyExclude, st.Policy(), "default policy should be exclude")
+
+	require.NoError(t, st.AddItem(TypeDomain, "example.com"))
+	require.NoError(t, st.SetPolicy(SplitTunnelPolicyInclude))
+
+	st2, err := NewSplitTunnelHandler(tmpDir, rlog.NoOpLogger())
+	require.NoError(t, err)
+	assert.Equal(t, SplitTunnelPolicyInclude, st2.Policy(), "policy should persist across reload")
+	assert.ElementsMatch(t, []string{"example.com"}, st2.Filters().Domain)
+}
+
+func TestEmptyFilterPolicyReloadAndReconcile(t *testing.T) {
+	tmpDir := t.TempDir()
+	st, err := NewSplitTunnelHandler(tmpDir, rlog.NoOpLogger())
+	require.NoError(t, err)
+	require.NoError(t, st.SetPolicy(SplitTunnelPolicyInclude)) // empty filter
+
+	st2, err := NewSplitTunnelHandler(tmpDir, rlog.NoOpLogger())
+	require.NoError(t, err)
+	require.Equal(t, SplitTunnelPolicyExclude, st2.Policy(), "empty-filter policy is not persisted across reload")
+
+	// Reconcile from the durable intent, then add an item so it persists.
+	require.NoError(t, st2.SetPolicy(SplitTunnelPolicyInclude))
+	require.NoError(t, st2.AddItem(TypeDomain, "example.com"))
+
+	st3, err := NewSplitTunnelHandler(tmpDir, rlog.NoOpLogger())
+	require.NoError(t, err)
+	assert.Equal(t, SplitTunnelPolicyInclude, st3.Policy(), "policy persists once the filter is non-empty")
+}
+
+func TestSetPolicyIdempotentAndDefaults(t *testing.T) {
+	st := newSplitTunnel(t.TempDir(), rlog.NoOpLogger())
+	require.Equal(t, SplitTunnelPolicyExclude, st.Policy())
+
+	require.NoError(t, st.SetPolicy(SplitTunnelPolicyInclude))
+	require.NoError(t, st.SetPolicy(SplitTunnelPolicyInclude)) // no-op when already in policy
+	assert.Equal(t, SplitTunnelPolicyInclude, st.Policy())
+
+	require.NoError(t, st.SetPolicy(SplitTunnelPolicyExclude))
+	assert.Equal(t, SplitTunnelPolicyExclude, st.Policy())
+
+	require.NoError(t, st.SetPolicy(SplitTunnelPolicy("bogus")), "unrecognized policy is treated as exclude")
+	assert.Equal(t, SplitTunnelPolicyExclude, st.Policy())
+}
+
 func TestMigration(t *testing.T) {
 	st := newSplitTunnel(t.TempDir(), rlog.NoOpLogger())
 

--- a/vpn/split_tunnel_types.go
+++ b/vpn/split_tunnel_types.go
@@ -10,6 +10,25 @@ import (
 // asserting the rule-set is absent.
 const splitTunnelTag = "split-tunnel"
 
+// SplitTunnelPolicy selects how the split-tunnel filter list is interpreted.
+//
+// The values describe the user-facing behavior: whether matching filters are
+// excluded from the VPN tunnel or are the only traffic included in it.
+type SplitTunnelPolicy string
+
+const (
+	// SplitTunnelPolicyExclude makes matching apps/domains bypass the VPN and
+	// routes everything else through it.
+	SplitTunnelPolicyExclude SplitTunnelPolicy = "exclude"
+	// SplitTunnelPolicyInclude routes only matching apps/domains through the VPN
+	// and sends everything else direct.
+	SplitTunnelPolicyInclude SplitTunnelPolicy = "include"
+)
+
+func (p SplitTunnelPolicy) Valid() bool {
+	return p == SplitTunnelPolicyExclude || p == SplitTunnelPolicyInclude
+}
+
 // Filter type identifiers accepted by SplitTunnel.AddItems/RemoveItems and exposed
 // through the backend and CLI. Defined here (rather than alongside the real
 // implementation) so the novpn build, which compiles an inert SplitTunnel, still
@@ -26,7 +45,7 @@ const (
 )
 
 // SplitTunnelFilter is the set of domains, processes, and packages a user has
-// configured to bypass (or be confined to) the tunnel.
+// configured for split-tunnel routing.
 type SplitTunnelFilter struct {
 	Domain           []string
 	DomainSuffix     []string

--- a/vpn/split_tunnel_types.go
+++ b/vpn/split_tunnel_types.go
@@ -13,7 +13,8 @@ const splitTunnelTag = "split-tunnel"
 // SplitTunnelPolicy selects how the split-tunnel filter list is interpreted.
 //
 // The values describe the user-facing behavior: whether matching filters are
-// excluded from the VPN tunnel or are the only traffic included in it.
+// excluded from the VPN tunnel or are the only traffic included in it. An empty
+// filter list keeps all traffic in the tunnel regardless of the policy.
 type SplitTunnelPolicy string
 
 const (


### PR DESCRIPTION
This pull request adds support for configuring and persisting a split-tunnel policy, allowing users to choose whether matching domains/apps are excluded from the VPN (default behavior) or included as the only traffic routed through the VPN. The changes span the backend, CLI, and VPN logic, ensuring the policy is maintained across reloads and exposed to users. Several tests validate the new behavior and persistence.

**Split-tunnel policy support and persistence:**

- Added the `SplitTunnelPolicy` type (`exclude` or `include`) to control whether matching filters are excluded from or included in the VPN tunnel, with validation and sensible defaults. The policy is now persisted and re-applied on reload. 

- Updated the backend to reconcile and persist the split-tunnel policy on reload and when settings are patched, ensuring runtime state matches persisted settings.

**CLI and settings integration:**

- Exposed `split-tunnel-policy` as a CLI argument, allowing users to set and get the policy via commands, with validation and help text. The policy is also included in the list of available settings. 

**IPC and API changes:**

- Added a new IPC client method `SetSplitTunnelPolicy` for programmatically updating the split-tunnel policy.

**Testing:**

- Added comprehensive tests to verify policy inversion, persistence across reloads, idempotency, and correct behavior with empty filters.

These changes make split-tunnel behavior more flexible and robust, improving user control and reliability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added split-tunnel policies for including or excluding selected traffic.
  * Added CLI support to view and configure the split-tunnel policy.
  * Added validation for policy values, defaulting invalid values to exclude mode.
  * Policies now persist across reloads and stay synchronized with the active configuration.
  * Empty filter lists continue routing all traffic through the tunnel.

* **Bug Fixes**
  * Improved handling and reporting when split-tunnel settings cannot be applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->