### PR TITLE
Include Lantern app version in account requests

### DIFF
--- a/account/client.go
+++ b/account/client.go
@@ -125,6 +125,7 @@ func (a *Client) sendRequest(
 		req.Header.Set(k, v)
 	}
 	req.Header.Set(common.AppNameHeader, common.Name)
+	req.Header.Set(common.AppVersionHeader, common.GetVersion())
 	req.Header.Set(common.VersionHeader, common.GetVersion())
 	req.Header.Set(common.PlatformHeader, common.Platform)
 	if contentType != "" {

--- a/account/subscription_test.go
+++ b/account/subscription_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/getlantern/radiance/common"
 )
 
 func TestSubscriptionPaymentRedirect(t *testing.T) {
@@ -37,6 +39,8 @@ func TestPaymentRedirect(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, url)
 	assert.Equal(t, data.IdempotencyKey, ts.paymentRedirectIdempotencyKey)
+	assert.Equal(t, common.GetVersion(), ts.paymentRedirectAppVersion)
+	assert.Equal(t, common.GetVersion(), ts.paymentRedirectLibraryVersion)
 }
 
 func TestPaymentRedirectOmitsEmptyIdempotencyKey(t *testing.T) {

--- a/account/user_test.go
+++ b/account/user_test.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/getlantern/radiance/account/protos"
+	"github.com/getlantern/radiance/common"
 	"github.com/getlantern/radiance/common/settings"
 )
 
@@ -30,6 +31,8 @@ type testServer struct {
 	paymentRedirectHasIdempotencyKey             bool
 	paymentRedirectCouponCode                    string
 	paymentRedirectHasCouponCode                 bool
+	paymentRedirectAppVersion                    string
+	paymentRedirectLibraryVersion                string
 	subscriptionPaymentRedirectIdempotencyKey    string
 	subscriptionPaymentRedirectHasIdempotencyKey bool
 	subscriptionPaymentRedirectCouponCode        string
@@ -228,6 +231,8 @@ func newTestServer(t *testing.T) (*httptest.Server, *testServer) {
 
 	mux.HandleFunc("/payment-redirect", func(w http.ResponseWriter, r *http.Request) {
 		values := r.URL.Query()
+		state.paymentRedirectAppVersion = r.Header.Get(common.AppVersionHeader)
+		state.paymentRedirectLibraryVersion = r.Header.Get(common.VersionHeader)
 		state.paymentRedirectIdempotencyKey = values.Get("idempotencyKey")
 		_, state.paymentRedirectHasIdempotencyKey = values["idempotencyKey"]
 		state.paymentRedirectCouponCode = values.Get("couponCode")


### PR DESCRIPTION
Resolves https://github.com/getlantern/engineering/issues/3872

Send `X-Lantern-App-Version` with account requests, restoring v9 version attribution in payment telemetry and purchase reports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Outgoing account-related requests now include the current app version information.
  - This version information is also included for payment redirect requests.

- **Tests**
  - Added verification that payment redirect requests report the correct app and library versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->