### PR TITLE
docs: align comment guidance and clean up comments repo-wide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,127 +1,35 @@
 - Telemetry attributes: follow rules in https://github.com/getlantern/semconv/blob/main/AGENTS.md
 
-## Code Comments
+## Comments and Documentation
 
-**Language doc conventions take precedence.** When writing a doc comment that the language's tooling formats or renders (Go's `// Foo ...`, Python docstrings, JSDoc, rustdoc, etc.), follow that convention even if it conflicts with the "lead with the *why*" guidance — for Go that means start with the identifier's name. The *why* still belongs in the comment, just in the body after the conventional opening.
+**Default: no new comment.** Add a comment only when it documents a contract, invariant, concurrency rule, error condition, zero-value behavior, or surprising rationale that is not clear from the code.
 
-- **Default: no comment.** Only comment when necessary to explain a non-obvious contract, invariant, rationale, or surprising behavior.
-- Comments must answer *why* something is done a particular way, not *what* is being done (which should be clear from the code and naming).
-- Before adding a comment, ask:
-  - Is this information not obvious from the code or naming?
-  - Does it document a constraint, invariant, concurrency guarantee, or error condition that would surprise a reader?
-  - Is it essential for future maintainers to understand the reasoning or risk behind this code?
-- **Do not add comments that:**
-  - Restate the identifier name (in-line only).
-  - Narrate the next line of code.
-  - Reference tickets, coworkers, or code locations (these belong in commit messages).
-  - Describe the mechanism instead of the contract.
-  - Are aesthetic or redundant ("well-documented").
-- Prefer documenting contracts at the declaration site. Use inline comments only for truly non-obvious lines.
-- Remove or update obsolete comments promptly.
-- **TODOs:** Must state both what needs to be done and why it isn’t done now. Remove or resolve unclear TODOs.
-
-**Examples:**
-
-```go
-// BAD: Restates what the code does
-// Cancel any in-flight requests.
-cancelRequests()
-
-// GOOD: Explains why this is necessary
-// Must cancel in-flight requests to avoid leaking goroutines on shutdown.
-cancelRequests()
-```
-
----
-
-```go
-// BAD — restates name, generic preamble, narrates the code
-// updateSelectionHistoryListener manages the lifecycle of the selection history listener
-// across VPN status changes. Connected always re-attaches (canceling any
-// existing listener) so a stale event still leaves the listener bound to
-// the live storage.
-
-// GOOD — leads with the trap, no narration
-// Status events are dispatched in unordered goroutines, so reacting to
-// intermediate statuses risks a stale handler tearing down a listener
-// a concurrent Connected handler just attached. Only Connected (which
-// re-attaches unconditionally) and terminal-down statuses are acted on.
-```
-
-```go
-// BAD — narrates the next line
-// Cancel any in-flight offline tests and wait for them to finish.
-c.offlineTestCancel()
-<-done
-
-// GOOD — no comment; the names already say it
-c.offlineTestCancel()
-<-done
-```
-
-```go
-// BAD — references ticket and coworker
-// Per Freshdesk #172640 (reported by Alice), saveServers held the lock
-// for 1+ minute. We now release access before disk I/O.
-
-// GOOD — states the invariant; the ticket lives in git history
-// access is released before disk I/O so a slow write can't starve readers.
-```
-
-```go
-// BAD — doc block enumerates every branch; only one branch has hidden why,
-// the rest restate cases the code already shows
-// mapStatusEvent maps a radiance VPN status event to the wire value sent
-// to Dart. Three cases deviate from a direct pass-through:
-//   - vpn.Restarting collapses into vpn.Connecting so the UI shows a
-//     transitional state during a tunnel restart.
-//   - A non-empty evt.Error always maps to vpn.ErrorStatus.
-//   - An unrecognized status falls back to Disconnected.
-func mapStatusEvent(evt vpn.StatusUpdateEvent) (vpn.VPNStatus, string) { ... }
-
-// GOOD — no doc block; inline comment on the only branch with hidden context
-func mapStatusEvent(evt vpn.StatusUpdateEvent) (vpn.VPNStatus, string) {
-	if evt.Error != "" {
-		return vpn.ErrorStatus, evt.Error
-	}
-	switch evt.Status {
-	case vpn.Connected, vpn.Connecting, vpn.Disconnecting, vpn.Disconnected, vpn.ErrorStatus:
-		return evt.Status, ""
-	case vpn.Restarting:
-		// Map to Connecting; Dart's parser falls back to Disconnected otherwise.
-		return vpn.Connecting, ""
-	default:
-		return vpn.Disconnected, ""
-	}
-}
-```
-
-Before writing an inline comment, consider whether a doc comment on the enclosing function or type would make it unnecessary. Prefer documenting contracts at the declaration over explaining implementation details inline.
-
-Conversely, before writing a multi-bullet doc block that enumerates branches or cases, check each bullet against the line that implements it. If only one bullet carries hidden *why* and the rest restate visible branches, drop the doc block and put a single inline comment on the surprising branch. Doc blocks belong on contracts that surprise as a whole, not on functions where one corner of the implementation is non-obvious. The bar is higher for unexported helpers: the Go doc convention targets exported API, and unexported functions should default to no comment unless the contract genuinely surprises.
-
-TODO comments must state *what* needs to happen and *why* it isn't done now. `TODO: ???` is not actionable — either resolve it or remove it.
+- Prefer clearer names and smaller functions over explanatory comments.
+- Delete or shorten verbose comments in code you touch.
+- Do not narrate code, repeat the identifier, list visible branches, mention tickets/people, or praise the implementation.
+- Documentation should only document the declaration's own contract: side effects, blocking/zero-value behavior, errors, ownership, cancellation, concurrency, or surprising pre/postconditions.
+- Inline comments are for local traps only. Put them above the relevant line and keep them to one short sentence when possible.
+- TODOs must say what remains and why it is not done now.
 
 ## Go Doc Comments
 
-- Use Go doc comments (`// Foo ...`) for exported identifiers and any unexported ones with non-obvious contracts.
-- Start with the identifier’s name and a concise summary: `// Foo does X.` The first sentence is shown by `go doc` and pkg.go.dev.
-- Follow with additional context or rationale as needed, especially if the *why* is not obvious.
-- Place the comment immediately above the declaration, with no blank line.
-- For package comments, place one above the `package` clause (typically in `doc.go`), starting with `// Package foo ...`.
-- Formatting:
-  - Use blank lines for paragraphs.
-  - Indent code blocks.
-  - Use lists and headings as supported by Go doc formatting.
-  - Avoid HTML and manual line wrapping; let gofmt handle formatting.
-- Use `// Deprecated: ...` on its own paragraph for deprecated identifiers.
-- Prefer `ExampleFoo` functions in `_test.go` for usage examples; these are rendered and tested by Go tooling.
-- Review doc comments regularly to keep them accurate and relevant.
+Follow [Go doc comment conventions](https://go.dev/doc/comment), not generic prose style.
 
-**Reference:** [Go doc comment guidelines](https://go.dev/doc/comment)
+- Exported package-level declarations need doc comments; unexported declarations usually do not.
+- Place doc comments immediately above the declaration, with no blank line.
+- Use complete sentences. For packages, begin `Package name ...`. For commands, begin with the command name. For funcs and methods, begin with the function or method name. For types, name the type in the first sentence (`T ...`, `A T ...`, or `An T ...`).
+- Keep the first sentence short; it is the synopsis shown by `go doc` and pkg.go.dev.
+- Stop after one sentence unless callers need more to use the API correctly.
+- Add extra paragraphs only for non-obvious contracts: concurrency safety, zero-value meaning, ownership/lifetime, blocking behavior, errors, panics, cancellation, ordering, or compatibility constraints.
+- For bool-returning functions, prefer “reports whether”; do not add “or not.”
+- Use `Deprecated:` on its own paragraph for deprecations.
+- Prefer executable `ExampleFoo` tests over long usage prose.
+- Use lists, headings, and code blocks only when the rendered public documentation genuinely needs structure.
+
+Before finalizing Go code, re-read every added or modified comment and remove any sentence that only restates the declaration or implementation.
 
 ## Comment Verification
 
-After any edit that adds or modifies a comment, you MUST spawn a code-reviewer subagent with the diff before declaring the task done. The subagent applies the Code Comments checklist above and reports violations. Fix the violations and re-spawn until the subagent reports none.
+After any edit that adds or modifies a comment, you MUST spawn a code-reviewer subagent with the diff before declaring the task done. The subagent applies the Comments and Documentation checklist above and reports violations, including misplaced documentation where a function comment describes another declaration’s type, fields, payload shape, or consumer behavior. Fix the violations and re-spawn until the subagent reports none.
 
 You MUST NOT skip this by self-reviewing the diff. The point of the subagent is to review without the generation bias of the Claude that wrote the comment — a self-review by the writer is a known failure mode and does not satisfy this step.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,9 @@
 - Delete or shorten verbose comments in code you touch.
 - Do not narrate code, repeat the identifier, list visible branches, mention tickets/people, or praise the implementation.
 - Documentation should only document the declaration's own contract: side effects, blocking/zero-value behavior, errors, ownership, cancellation, concurrency, or surprising pre/postconditions.
+- Document the caller-relevant semantics of a sentinel error, enum, status, or constant — retryability, permanence, lifecycle — as the value's own contract, phrased as what it means rather than advice: prefer "retryable only after …" over "callers should …". The consumer behavior to avoid is a separate component's policy, not the meaning of a value callers inspect.
+- Comment a literal value when it encodes a non-obvious protocol, compatibility, migration, or product invariant: say why this exact value is required and what breaks if it changes, not what the assignment does. Prefer a named constant when that rationale is reusable.
+- Document a contract at the narrowest declaration that depends on it — a sentinel's meaning on the sentinel or the function that returns it, a request-shape invariant at the request construction. If a comment reads as advice or sits on the wrong declaration, restate it as that declaration's contract and move it there.
 - Inline comments are for local traps only. Put them above the relevant line and keep them to one short sentence when possible.
 - TODOs must say what remains and why it is not done now.
 

--- a/account/client.go
+++ b/account/client.go
@@ -89,7 +89,6 @@ func (a *Client) sendRequest(
 	queryParams, headers map[string]string,
 	body any,
 ) ([]byte, error) {
-	// check if url is absolute, if not prepend base URL
 	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
 		url = a.baseURL() + url
 	}

--- a/account/datacap.go
+++ b/account/datacap.go
@@ -46,9 +46,9 @@ const (
 	datacapDisabledRetry = time.Hour
 )
 
-// errCapExhausted marks a deliberate server close after the daily allotment is
+// ErrCapExhausted marks a deliberate server close after the daily allotment is
 // spent.
-var errCapExhausted = errors.New("datacap exhausted")
+var ErrCapExhausted = errors.New("datacap exhausted")
 
 type dataCapStreamState struct {
 	progressed   bool
@@ -156,7 +156,7 @@ func (a *Client) DataCapStream(ctx context.Context, handler func(*DataCapInfo)) 
 			return err
 		}
 
-		if errors.Is(err, errCapExhausted) {
+		if errors.Is(err, ErrCapExhausted) {
 			if err := a.waitForAllotmentReset(ctx, state.allotmentEnd); err != nil {
 				return err
 			}
@@ -222,7 +222,9 @@ func waitOrDone(ctx context.Context, d time.Duration) error {
 }
 
 // connectDataCapSSE opens an SSE connection to the datacap stream endpoint and
-// processes events until the stream ends or ctx is cancelled.
+// processes events until the stream ends or ctx is cancelled. It returns
+// ErrCapExhausted when the server closes after the daily allotment is spent, so
+// the caller waits for the reset instead of reconnecting immediately.
 func (a *Client) connectDataCapSSE(ctx context.Context, handler func(*DataCapInfo)) error {
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "datacap_sse")
 	defer span.End()
@@ -294,7 +296,7 @@ func (a *Client) connectDataCapSSE(ctx context.Context, handler func(*DataCapInf
 		return traces.RecordError(ctx, err)
 	}
 	if capExhausted {
-		return errCapExhausted
+		return ErrCapExhausted
 	}
 	if err := scanErr(); err != nil {
 		return traces.RecordError(ctx, fmt.Errorf("datacap SSE scanner: %w", err))

--- a/account/datacap.go
+++ b/account/datacap.go
@@ -47,7 +47,7 @@ const (
 )
 
 // errCapExhausted marks a deliberate server close after the daily allotment is
-// spent. Callers should wait for reset instead of reconnecting immediately.
+// spent.
 var errCapExhausted = errors.New("datacap exhausted")
 
 type dataCapStreamState struct {

--- a/account/datacap_test.go
+++ b/account/datacap_test.go
@@ -124,7 +124,7 @@ func TestConnectDataCapSSE_CapExhausted(t *testing.T) {
 		got = append(got, *info)
 	})
 
-	assert.ErrorIs(t, err, errCapExhausted)
+	assert.ErrorIs(t, err, ErrCapExhausted)
 	require.Len(t, got, 2)
 	assert.False(t, got[0].Exhausted)
 	assert.True(t, got[1].Exhausted, "cap_exhausted must re-emit the info with Exhausted set")

--- a/account/jwt.go
+++ b/account/jwt.go
@@ -23,7 +23,6 @@ func decodeJWT(tokenStr string) (*JWTUserInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Convert MapClaims to JSON
 	claimsJSON, err := json.Marshal(token.Claims)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal claims: %v", err)

--- a/account/subscription.go
+++ b/account/subscription.go
@@ -175,7 +175,6 @@ func (a *Client) RestoreSubscription(ctx context.Context, service SubscriptionSe
 }
 
 // StripeBillingPortalURL generates the Stripe billing portal URL for the given user ID.
-// baseURL = common.GetProServerURL
 func (a *Client) StripeBillingPortalURL(ctx context.Context, baseURL, userID, proToken string) (string, error) {
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "stripe_billing_portal_url")
 	defer span.End()
@@ -237,7 +236,6 @@ func (a *Client) SubscriptionPaymentRedirectURL(ctx context.Context, data Paymen
 }
 
 // PaymentRedirect is used to get the payment redirect URL with PaymentRedirectData.
-// This is used in the desktop and android apps.
 func (a *Client) PaymentRedirect(ctx context.Context, data PaymentRedirectData) (string, error) {
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "payment_redirect")
 	defer span.End()

--- a/account/user.go
+++ b/account/user.go
@@ -59,7 +59,7 @@ func (a *Client) FetchUserData(ctx context.Context) (*UserData, error) {
 	return a.fetchUserData(ctx)
 }
 
-// fetchUserData calls the /user-data endpoint and stores the result via storeData.
+// fetchUserData fetches the user's account data and stores it.
 func (a *Client) fetchUserData(ctx context.Context) (*UserData, error) {
 	resp, err := a.sendProRequest(ctx, "GET", "/user-data", nil, nil, nil)
 	if err != nil {
@@ -99,8 +99,7 @@ type DataCapInfo struct {
 	// Data cap usage details (only populated if enabled is true)
 	Usage *DataCapUsageDetails `json:"usage,omitempty"`
 	// Exhausted is set locally when the SSE stream emits cap_exhausted. It is not
-	// part of the server JSON payload. If present, the AllotmentEndTime at which
-	// the allotment resets is stored in Usage.AllotmentEndTime.
+	// part of the server JSON payload.
 	Exhausted bool `json:"exhausted,omitempty"`
 }
 
@@ -153,9 +152,7 @@ func (a *Client) SignUp(ctx context.Context, email, password string) ([]byte, *p
 		Salt:                  salt,
 		Verifier:              verifierKey.Bytes(),
 		SkipEmailConfirmation: true,
-		// Set temp always to true for now
-		// If new user faces any issue while sign up user can sign up again
-		Temp: true,
+		Temp:                  true,
 	}
 
 	proToken := settings.GetString(settings.TokenKey)
@@ -249,7 +246,6 @@ func readSalt(path string) ([]byte, error) {
 
 // Login logs the user in.
 func (a *Client) Login(ctx context.Context, email, password string) (*UserData, error) {
-	// clear any previous salt value
 	a.setSalt(nil)
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "login")
 	defer span.End()
@@ -547,7 +543,7 @@ func (a *Client) OAuthLoginCallback(ctx context.Context, oAuthToken string) (*Us
 		return nil, fmt.Errorf("error decoding JWT: %w", err)
 	}
 
-	// Temporary  set user data to so api can read it
+	// Seed the identity first so the fetchUserData call below can authenticate.
 	login := &UserData{
 		LegacyID:    jwtUserInfo.LegacyUserID,
 		LegacyToken: jwtUserInfo.LegacyToken,
@@ -559,7 +555,6 @@ func (a *Client) OAuthLoginCallback(ctx context.Context, oAuthToken string) (*Us
 		},
 	}
 	a.setData(login)
-	// Get user data from api this will also save data in user config
 	user, err := a.fetchUserData(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error getting user data: %w", err)
@@ -716,7 +711,8 @@ func (a *Client) setData(data *UserData) {
 		return
 	}
 
-	// This case when user hits device limit while login
+	// A device-limit login carries only the identity, not full user data, so
+	// store the id and token alone.
 	if data.LegacyUserData == nil {
 		slog.Info("no user data to set, storing id and token only")
 		if err := storeIdentity(data.LegacyID, data.LegacyToken); err != nil {

--- a/account/user.go
+++ b/account/user.go
@@ -152,7 +152,8 @@ func (a *Client) SignUp(ctx context.Context, email, password string) ([]byte, *p
 		Salt:                  salt,
 		Verifier:              verifierKey.Bytes(),
 		SkipEmailConfirmation: true,
-		Temp:                  true,
+		// Always temporary so a user who hits an error mid-signup can sign up again.
+		Temp: true,
 	}
 
 	proToken := settings.GetString(settings.TokenKey)

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -287,7 +287,6 @@ func (r *LocalBackend) Start() {
 	events.SubscribeOnce(func(evt config.NewConfigEvent) {
 		setCountryCodeFromConfig(evt.New)
 	})
-	// update VPN outbounds when new config is received
 	events.SubscribeContext(r.ctx, func(evt config.NewConfigEvent) {
 		r.applyConfig(evt.New)
 		go r.prewarmOfflineURLTests("config update")
@@ -1159,8 +1158,8 @@ func (r *LocalBackend) ConnectVPN(ctx context.Context, tag string) error {
 // awaitConnectable blocks until the connect has something to dial, or ctx is
 // done. Connecting with neither a config nor a server of the user's own
 // produces "no outbounds or endpoints found", and on mobile the process that
-// reports that failure is the one hosting the config fetch it needed
-// (getlantern/engineering#3814), so failing fast deadlocks the first run.
+// reports that failure is the one hosting the config fetch it needed, so
+// failing fast deadlocks the first run.
 func (r *LocalBackend) awaitConnectable(ctx context.Context, tag string) error {
 	if r.connectable(tag) {
 		return nil
@@ -1169,7 +1168,7 @@ func (r *LocalBackend) awaitConnectable(ctx context.Context, tag string) error {
 	ready := make(chan struct{})
 	// Subscribe, not SubscribeOnce: this unsubscribes on return anyway, and
 	// SubscribeUntil's self-referential `sub` capture is read from the callback
-	// goroutine without synchronization (events.go:78 vs :85).
+	// goroutine without synchronization.
 	//
 	// Emit runs each callback on its own goroutine, so configs landing together
 	// can both reach this. Closing twice would panic.

--- a/cmd/geosite-throttle-test/main.go
+++ b/cmd/geosite-throttle-test/main.go
@@ -47,9 +47,7 @@ const (
 // happens at the exit (CONNECT carries the hostname).
 type connectDialer struct{ user, pass string }
 
-// DialStream opens a TLS tunnel to the oxylabs proxy, issues an authenticated
-// CONNECT to addr, and returns the resulting stream so the target dial exits
-// from a CN residential IP.
+// DialStream returns a stream to addr that exits from a CN residential IP.
 func (d connectDialer) DialStream(ctx context.Context, addr string) (transport.StreamConn, error) {
 	raw, err := (&net.Dialer{Timeout: 15 * time.Second}).DialContext(ctx, "tcp", oxyGateway)
 	if err != nil {

--- a/cmd/kindling-tester/main.go
+++ b/cmd/kindling-tester/main.go
@@ -40,7 +40,6 @@ func performKindlingPing(urlToHit string, runID string, deviceID string, userID 
 	cli := kindling.HTTPClient()
 
 	t2 := time.Now()
-	// Run the command and capture the output
 	resp, err := cli.Get(urlToHit)
 	if err != nil {
 		slog.Error("failed on get request", slog.Any("error", err))
@@ -55,7 +54,7 @@ func performKindlingPing(urlToHit string, runID string, deviceID string, userID 
 	}
 	t3 := time.Now()
 	slog.Info("lantern ping completed successfully")
-	// create a marker file that will be used by the pinger to determine success
+	// empty marker file signals success to the pinger
 	if err := os.WriteFile(dataDir+"/success", []byte(""), 0o644); err != nil {
 		slog.Error("failed to write success file", slog.Any("error", err), slog.String("path", dataDir+"/success"))
 	}

--- a/cmd/lantern/account.go
+++ b/cmd/lantern/account.go
@@ -306,7 +306,6 @@ func accountDevices(ctx context.Context, c *ipc.Client, cmd *DevicesCmd) error {
 		fmt.Println("Device removed.")
 		return printJSON(resp)
 	default:
-		// Default to listing devices
 		devices, err := c.UserDevices(ctx)
 		if err != nil {
 			return err
@@ -315,7 +314,6 @@ func accountDevices(ctx context.Context, c *ipc.Client, cmd *DevicesCmd) error {
 	}
 }
 
-// prompt prints a prompt and reads a line of input from stdin.
 func prompt(label string) (string, error) {
 	fmt.Print(label)
 	return readLine()

--- a/cmd/lantern/ip.go
+++ b/cmd/lantern/ip.go
@@ -58,7 +58,8 @@ func runIP(ctx context.Context, cmd *IPCmd) error {
 // before the tunnel is fully established.
 var fakeIPRange = netip.MustParsePrefix("198.18.0.0/15")
 
-// getPublicIP fetches the public IP address
+// getPublicIP fetches the public IP address, rejecting private, loopback,
+// unspecified, and fake-ip results as not a valid public IP.
 func getPublicIP(ctx context.Context) (string, error) {
 	result, err := publicip.Detect(ctx, publicIPCfg)
 	if err != nil {

--- a/cmd/lanternd/lanternd.go
+++ b/cmd/lanternd/lanternd.go
@@ -84,7 +84,6 @@ const (
 	// directly instead of starting another supervisor.
 	childEnvMarker = "_LANTERND_CHILD"
 
-	// babysitBackoffBase is the base wait time for the babysit backoff strategy.
 	babysitBackoffBase = time.Second
 
 	// daemonRestartBackoffMax keeps repeated crashes from delaying recovery by more than a minute.

--- a/cmd/residential-urltest/main.go
+++ b/cmd/residential-urltest/main.go
@@ -15,7 +15,7 @@
 //
 // Usage:
 //
-//	export OXY_USER=... OXY_PASS=...           # oxylabs residential creds (vault: secret/lantern_cloud/pinger)
+//	export OXY_USER=... OXY_PASS=...           # oxylabs residential creds
 //	go run ./cmd/residential-urltest --config /path/to/debug-box-options.json --country ru
 //
 // Input is either a marshaled sing-box options file (top-level "outbounds") or

--- a/common/deviceid/deviceid_nonwindows.go
+++ b/common/deviceid/deviceid_nonwindows.go
@@ -51,7 +51,8 @@ func Get(path string) string {
 
 // migrateLegacyDeviceID copies a device ID from the pre-refactor location ($HOME/.lanternsecrets/.deviceid)
 // to dst, returning the migrated ID on success. The legacy file is left in place.
-// TODO(2026-04-20): remove this migration code after a few releases.
+// TODO: remove once clients predating the $HOME/.lanternsecrets location are no
+// longer in the field; kept so upgrades from those builds don't regenerate the device ID.
 func migrateLegacyDeviceID(dst string) (string, bool) {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/common/env/env.go
+++ b/common/env/env.go
@@ -31,9 +31,8 @@ var (
 	BufPoolBudgetMB  _key = "RADIANCE_BUF_POOL_BUDGET_MB"
 	MemoryLimitMB    _key = "RADIANCE_MEM_LIMIT_MB"
 
-	// PeerExternalPort, when set to a 1..65535 value, makes peer.Client.Start
-	// skip UPnP discovery and treat the value as a manually-forwarded port
-	// on the user's router (handy for eero / ISP CPE that don't expose UPnP).
+	// PeerExternalPort is a manually-forwarded router port (1..65535) for the
+	// peer inbound; empty/0 means unset.
 	PeerExternalPort _key = "RADIANCE_PEER_EXTERNAL_PORT"
 
 	// LogToStdout makes common.Init configure logging to stdout instead of a file.
@@ -53,7 +52,6 @@ func init() {
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		slog.Error(".env file found, but failed to read", slog.Any("error", err))
 	} else if err == nil {
-		// Parse the .env file and populate envVars
 		lines := strings.SplitSeq(string(buf), "\n")
 		for line := range lines {
 			line = strings.TrimSpace(line)

--- a/common/errors.go
+++ b/common/errors.go
@@ -3,5 +3,4 @@ package common
 import "errors"
 
 // ErrNotImplemented is returned by functions that have not yet been implemented.
-// It is temporary and will be removed once the API stabilizes.
 var ErrNotImplemented = errors.New("not yet implemented")

--- a/common/fileperm/fileperm_nonmobile.go
+++ b/common/fileperm/fileperm_nonmobile.go
@@ -5,4 +5,4 @@ package fileperm
 
 import "os"
 
-const File os.FileMode = 0o644 // temporarily set to 644 to during developement, will be set to 600 for production builds.
+const File os.FileMode = 0o644 // temporarily set to 644 until full release, after which it will be set to 600.

--- a/common/init.go
+++ b/common/init.go
@@ -198,8 +198,7 @@ func setupDirectories(data, logs string) (dataDir, logDir string, err error) {
 	// written settings.json under <caller-path>/, while v9.1.x reads from
 	// <caller-path>/data/, so every existing install lost its persisted
 	// user_id, device_id, jwt token, and user_level on upgrade — surfacing
-	// as "Pro is suddenly expired after the update." See ticket #174515
-	// and the "Pro lost on upgrade" memory note.
+	// as "Pro is suddenly expired after the update."
 	data, _ = filepath.Abs(data)
 	logs, _ = filepath.Abs(logs)
 	for _, path := range []string{data, logs} {

--- a/common/settings/legacy_crossdir.go
+++ b/common/settings/legacy_crossdir.go
@@ -16,26 +16,12 @@ import (
 var windowsCrossDirCandidatesFn = windowsCrossDirCandidates
 
 // windowsCrossDirCandidates returns settings candidates from the v9.0.x
-// Windows data directory (${PUBLIC}\Lantern\data), which is no longer
-// scanned by the same-dir migration after PR #370 moved the lanternd
-// daemon to ${ProgramData}\Lantern.
+// Windows data directory (${PUBLIC}\Lantern\data), which the same-dir
+// migration doesn't cover: radiance's data dir moved to
+// ${ProgramData}\Lantern and the two directories don't share a parent, so
+// the same-dir candidates never see the v9.0.x file.
 //
-// On v9.0.x Windows, radiance was embedded in the Flutter app via FFI
-// and used the Dart-supplied data dir at C:\Users\Public\Lantern\data
-// (see lantern/lib/core/utils/storage_utils.dart). PR #370 (the same
-// commit that introduced cmd/lanternd/lanternd_windows.go) split radiance
-// off into a standalone Windows service that reads/writes under
-// internal.DefaultDataPath() = ${ProgramData}\Lantern. The two directories
-// don't share a parent, so the same-dir candidates in
-// migrateLegacySettingsIfNeeded never see the v9.0.x file and the user's
-// Pro state is lost on upgrade. See getlantern/engineering#3460 and
-// Freshdesk #174606.
-//
-// Returns nil on non-Windows hosts or when %PUBLIC% is unset. Both
-// known v9.0.x filenames are tried (local.json — the original — and
-// settings.json — what the file was renamed to in PR #370 for users who
-// upgraded through an intermediate build) so the recovery works
-// regardless of which v9.0.x release the user is coming from.
+// Returns nil on non-Windows hosts or when %PUBLIC% is unset.
 func windowsCrossDirCandidates(fileDir string) []candidateSource {
 	if runtime.GOOS != "windows" {
 		return nil

--- a/common/settings/settings.go
+++ b/common/settings/settings.go
@@ -58,20 +58,9 @@ const (
 	PeerShareEnabledKey  _key = "peer_share_enabled"  // bool
 	// PeerManualPortKey is the TCP port number the user has manually
 	// forwarded on their router for the peer-proxy inbound (single-
-	// port 1:1 NAT). Valid range is 1..65535; 0 means unset, in which
-	// case the peer falls back to UPnP discovery. Out-of-range values
-	// (negative, > 65535) are logged on read and treated as unset
-	// rather than silently wrapping to a wrong port. Surfaced as an
-	// Advanced setting in the Share My Connection UI for users on
-	// networks where UPnP is disabled or unavailable.
+	// port 1:1 NAT). Valid range is 1..65535; 0 means unset.
 	PeerManualPortKey _key = "peer_manual_port" // int (0 = unset; 1..65535 = manual port)
-	// UnboundedKey is the local opt-in for the broflake / Unbounded
-	// widget proxy. When true AND the server-side Features[unbounded]
-	// flag is on AND the server provides UnboundedConfig (discovery
-	// + egress URLs), the widget proxy starts. Surfaced as a "Basic
-	// mode" option in the Share My Connection UI for networks where
-	// UPnP isn't workable but the user still wants to contribute via
-	// the WebRTC-based donor path.
+	// UnboundedKey is the local opt-in (bool) for the Unbounded widget proxy.
 	UnboundedKey      _key = "unbounded"       // bool
 	SelectedServerKey _key = "selected_server" // [servers.Server] Server.Options is not stored
 
@@ -79,7 +68,7 @@ const (
 
 	settingsFileName = "settings.json"
 	// legacySettingsFileName is what v9.0.x called the same file (it was
-	// renamed in radiance PR #370). On upgrade from v9.0.x, the user's
+	// renamed). On upgrade from v9.0.x, the user's
 	// persisted user_id / token / user_level live at <dataDir>/local.json;
 	// migrateLegacySettingsIfNeeded reads it from there so Pro state
 	// survives the rename.
@@ -166,11 +155,11 @@ type candidateSource struct {
 // by older client versions. Candidates in priority order:
 //
 //  1. <fileDir>/settings.json                 — canonical
-//  2. <fileDir>/local.json                    — v9.0.x (renamed in #370)
-//  3. Windows ${PUBLIC}\Lantern\data\*        — v9.0.x cross-dir (#3460);
+//  2. <fileDir>/local.json                    — v9.0.x (renamed)
+//  3. Windows ${PUBLIC}\Lantern\data\*        — v9.0.x cross-dir;
 //     spliced in below, Windows only
-//  4. pre-9.x platform-specific YAML (legacy_yaml.go); spliced in below
-//  5. <fileDir>/data/settings.json            — v9.1.x (bugged: #370's
+//  4. pre-9.x platform-specific YAML; spliced in below
+//  5. <fileDir>/data/settings.json            — v9.1.x (bugged:
 //     setupDirectories appended an
 //     unconditional "/data" suffix)
 //
@@ -205,24 +194,15 @@ func migrateLegacySettingsIfNeeded(fileDir, canonicalPath string) {
 			}
 		}
 	}
-	// Splice optional candidates in. Each splice inserts at index 2 (right
-	// after canonical and same-dir local.json), so doing them in order
-	// from oldest-priority to newest-priority gives the final ordering:
-	//
-	//   canonical > same-dir local.json
-	//     > Windows cross-dir (newest of the optional candidates)
-	//       > pre-9.x YAML (older than v9.0.x)
-	//         > v9.1.x nested (always last, the bug-victim case)
-	//
-	// Insert pre-9.x YAML first, then Windows cross-dir, so the Windows
-	// candidate ends up *before* (higher priority than) the YAML.
+	// Optional candidates splice in at index 2, inserted oldest-first so
+	// newer generations end up higher priority.
 	if yc := legacyYAMLCandidate(fileDir); yc.exists {
 		candidates = append(candidates[:2], append([]candidateSource{yc}, candidates[2:]...)...)
 	}
 	// Windows v9.0.x cross-dir candidates (${PUBLIC}\Lantern\data) are the
 	// same generation of state as the same-dir local.json, just stored
-	// under a different filesystem root because PR #370 moved lanternd's
-	// data dir to ${ProgramData}\Lantern. On every other GOOS / when the
+	// under a different filesystem root because lanternd's data dir moved
+	// to ${ProgramData}\Lantern. On every other GOOS / when the
 	// env is unset windowsCrossDirCandidatesFn returns nil and this is a
 	// no-op.
 	if winExtras := windowsCrossDirCandidatesFn(fileDir); len(winExtras) > 0 {

--- a/config/config.go
+++ b/config/config.go
@@ -224,11 +224,7 @@ func (ch *ConfigHandler) doFetchConfig() error {
 		ch.logger.Error("writing raw config file", "error", writeErr)
 	}
 
-	// Otherwise, we keep the previous config and store any error that might have occurred.
-	// We still want to keep the previous config if there was an error. This is important
-	// because the error could have been due to temporary network issues, such as brief
-	// power loss or internet disconnection.
-	// On the other hand, if we have a new config, we want to overwrite any previous error.
+	// On fetch/parse error, retain the last-good config since the failure is often transient.
 	confResp, err := singjson.UnmarshalExtendedContext[C.ConfigResponse](box.BaseContext(), resp)
 	if err != nil {
 		ch.logger.Error("failed to parse config", "error", err)
@@ -251,9 +247,9 @@ func setCustomProtocolOptions(outbounds []option.Outbound) {
 		switch opts := outbound.Options.(type) {
 		case *lbO.WATEROutboundOptions:
 			opts.Dir = filepath.Join(settings.GetString(settings.DataPathKey), "water")
-			// TODO: we need to measure the client upload and download metrics
-			// in order to set hysteria custom parameters and support brutal sender
-			// as congestion control
+			// TODO: set hysteria custom parameters and brutal congestion
+			// control; blocked on per-client upload/download measurements we
+			// don't collect yet.
 		default:
 		}
 	}
@@ -445,9 +441,6 @@ func migrateToNewFmt(data []byte) (*Config, error) {
 
 // saveConfig saves the config to the disk. It creates the config file if it doesn't exist.
 func saveConfig(cfg *Config, path string) error {
-	// Marshal the config to bytes and write it to the config file.
-	// If the config is nil, we don't write anything.
-	// This is important because we don't want to overwrite the config file with an empty file.
 	buf, err := singjson.Marshal(cfg)
 	if err != nil {
 		return fmt.Errorf("marshalling config: %w", err)

--- a/config/fetcher.go
+++ b/config/fetcher.go
@@ -176,7 +176,6 @@ func (f *fetcher) send(ctx context.Context, body io.Reader) ([]byte, error) {
 		req.Header.Set("X-Lantern-Feature-Override", val)
 	}
 
-	// Add If-Modified-Since header to the request
 	// Note that on the first run, lastModified is zero, so the server will return the latest config.
 	req.Header.Set("If-Modified-Since", f.lastModified.Format(http.TimeFormat))
 	if f.etag != "" {
@@ -189,7 +188,6 @@ func (f *fetcher) send(ctx context.Context, body io.Reader) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	// Update the etag from the response
 	if etag := resp.Header.Get("ETag"); etag != "" {
 		f.etag = etag
 	}
@@ -201,17 +199,13 @@ func (f *fetcher) send(ctx context.Context, body io.Reader) ([]byte, error) {
 	}
 	switch resp.StatusCode {
 	case http.StatusOK:
-		// 200 OK
 		return buf, nil
 	case http.StatusPartialContent:
-		// 206 Partial Content
 		return buf, nil
 	case http.StatusNotModified:
-		// 304 Not Modified
 		slog.Debug("Config is not modified")
 		return nil, nil
 	case http.StatusNoContent:
-		// 204 No Content
 		return nil, nil
 	default:
 		return nil, fmt.Errorf("unexpected status code: %d. %s", resp.StatusCode, buf)

--- a/events/events.go
+++ b/events/events.go
@@ -114,11 +114,10 @@ func (s *subscriber) invoke(key reflect.Type, evt any) {
 }
 
 // enqueue never blocks. Emit has always returned without waiting on
-// subscribers, and callers depend on that — peer.Client emits lifecycle
-// phases from the same goroutine that is bringing the session up. A full
-// queue is therefore dropped rather than waited on, loudly, because by then
-// the subscriber has ignored 256 events and waiting would only spread its
-// problem to the emitter.
+// subscribers, and callers depend on that — emitters may call from a
+// goroutine mid-session-bringup. A full queue is therefore dropped rather
+// than waited on, loudly, because by then the subscriber has ignored 256
+// events and waiting would only spread its problem to the emitter.
 func (s *subscriber) enqueue(key reflect.Type, evt any) {
 	select {
 	case s.queue <- evt:
@@ -244,9 +243,9 @@ func Emit[T Event](evt T) {
 
 // emitDebugLogger holds the hook invoked once per Emit with the event type
 // and current subscriber count; nil means no-op. Held atomically because
-// Emit reads it from arbitrary goroutines — peer.Client's heartbeat and
-// rotation loops emit for the process lifetime, so any post-startup
-// SetEmitDebugLogger would otherwise race an in-flight Emit.
+// Emit reads it from arbitrary goroutines — long-lived emitters emit for the
+// process lifetime, so any post-startup SetEmitDebugLogger would otherwise
+// race an in-flight Emit.
 var emitDebugLogger atomic.Pointer[func(reflect.Type, int)]
 
 // SetEmitDebugLogger replaces the no-op diagnostic hook for the

--- a/ipc/client_events_mobile.go
+++ b/ipc/client_events_mobile.go
@@ -50,8 +50,8 @@ func (c *Client) URLTestEvents(ctx context.Context, handler func(vpn.URLTestComp
 	})
 }
 
-// ConfigEvents streams config-updated notifications. Payloads are empty — callers should treat each
-// call as a "refresh" signal. Blocks until ctx is cancelled.
+// ConfigEvents streams config-updated notifications. Each event signals that
+// config changed and carries no payload. Blocks until ctx is cancelled.
 func (c *Client) ConfigEvents(ctx context.Context, handler func()) error {
 	// The bus subscription is not redundant with SSE: when the tunnel process is down,
 	// the client's fallback LocalBackend emits NewConfigEvents on the in-process bus.
@@ -86,22 +86,9 @@ func (c *Client) DataCapStream(ctx context.Context, handler func(account.DataCap
 	return c.dataCapStream(ctx, handler)
 }
 
-// PeerStatusEvents streams peer-share lifecycle phase changes (mapping_port
-// → registering → verifying → serving on Start, stopping → idle on Stop,
-// error on failure). Each frame is a peer.StatusEvent JSON whose .Status
-// is the live snapshot at the moment the event fired — consumers SHOULD
-// re-render on every frame rather than diffing.
-//
-// Frames from the event bus arrive in the order they were emitted, which was
-// not true before it serialized delivery per subscriber: a consumer rendering
-// the newest frame could settle on a stale phase. That guarantee covers the
-// bus only. This method can feed handler from two independent sources at once
-// (below), and nothing orders them against each other, so a delayed SSE frame
-// can still follow a newer local one.
-// Mobile builds
-// may share a process with radiance (localOnly), in which case
-// events.SubscribeContext delivers directly; otherwise the SSE retry loop
-// is used. Blocks until ctx is cancelled.
+// PeerStatusEvents streams peer-share lifecycle status changes. Frames may
+// arrive out of order — a delayed frame can follow a newer one — so do not
+// assume monotonic ordering. Blocks until ctx is cancelled.
 func (c *Client) PeerStatusEvents(ctx context.Context, handler func(peer.StatusEvent)) error {
 	events.SubscribeContext(ctx, handler)
 	if c.localOnly {
@@ -116,12 +103,8 @@ func (c *Client) PeerStatusEvents(ctx context.Context, handler func(peer.StatusE
 	})
 }
 
-// PeerConnectionEvents streams accept/close events for the local
-// samizdat-in inbound. State is +1 on accept and -1 on close; Source is
-// the remote "ip:port" string for geo-lookup / abuse attribution.
-// Same mobile dual-path as PeerStatusEvents (localOnly delivers via
-// the in-process event bus; otherwise the SSE retry loop is used).
-// Blocks until ctx is cancelled.
+// PeerConnectionEvents streams accept/close events for the local samizdat-in
+// inbound. Blocks until ctx is cancelled.
 func (c *Client) PeerConnectionEvents(ctx context.Context, handler func(peer.ConnectionEvent)) error {
 	events.SubscribeContext(ctx, handler)
 	if c.localOnly {
@@ -136,15 +119,8 @@ func (c *Client) PeerConnectionEvents(ctx context.Context, handler func(peer.Con
 	})
 }
 
-// UnboundedConnectionEvents streams accept/close events for the local
-// broflake widget proxy ("Unbounded" / Basic mode). The JSON shape
-// matches peer.ConnectionEvent but the Go type is distinct — in-process
-// subscribers must subscribe to both event types separately to see all
-// peer activity. State is +1 on consumer accept, -1 on close; Source
-// is the consumer's IP if broflake exposes it, otherwise empty. Same
-// mobile dual-path: localOnly subscribes directly to the in-process
-// event bus; otherwise the SSE retry loop is used. Blocks until ctx
-// is cancelled.
+// UnboundedConnectionEvents streams accept/close events for the local broflake
+// widget proxy ("Unbounded" / Basic mode). Blocks until ctx is cancelled.
 func (c *Client) UnboundedConnectionEvents(ctx context.Context, handler func(unbounded.ConnectionEvent)) error {
 	events.SubscribeContext(ctx, handler)
 	if c.localOnly {

--- a/ipc/client_events_nonmobile.go
+++ b/ipc/client_events_nonmobile.go
@@ -34,8 +34,8 @@ func (c *Client) URLTestEvents(ctx context.Context, handler func(vpn.URLTestComp
 	})
 }
 
-// ConfigEvents streams config-updated notifications. Payloads are empty — callers should treat each
-// call as a "refresh" signal. Blocks until ctx is cancelled.
+// ConfigEvents streams config-updated notifications. Each event signals that
+// config changed and carries no payload. Blocks until ctx is cancelled.
 func (c *Client) ConfigEvents(ctx context.Context, handler func()) error {
 	return c.sseRetryLoop(ctx, configEventsEndpoint, func([]byte) { handler() })
 }
@@ -55,12 +55,9 @@ func (c *Client) DataCapStream(ctx context.Context, handler func(account.DataCap
 	return c.dataCapStream(ctx, handler)
 }
 
-// PeerStatusEvents streams peer-share lifecycle phase changes (mapping_port
-// → registering → verifying → serving on Start, stopping → idle on Stop,
-// error on failure). Each frame is a peer.StatusEvent JSON whose .Status
-// is the live snapshot at the moment the event fired — consumers SHOULD
-// re-render on every frame rather than diffing. Frames arrive in order, so
-// the last one seen is the current phase. Blocks until ctx is cancelled.
+// PeerStatusEvents streams peer-share lifecycle status changes. Frames arrive
+// in order, so the last one seen is the current phase. Blocks until ctx is
+// cancelled.
 func (c *Client) PeerStatusEvents(ctx context.Context, handler func(peer.StatusEvent)) error {
 	return c.sseRetryLoop(ctx, peerStatusEventsEndpoint, func(data []byte) {
 		var evt peer.StatusEvent
@@ -71,9 +68,7 @@ func (c *Client) PeerStatusEvents(ctx context.Context, handler func(peer.StatusE
 }
 
 // PeerConnectionEvents streams accept/close events for the local
-// samizdat-in inbound. State is +1 on accept and -1 on close; Source
-// is the remote "ip:port" string for geo-lookup / abuse attribution.
-// Blocks until ctx is cancelled.
+// samizdat-in inbound. Blocks until ctx is cancelled.
 //
 // Why this exists alongside events.Subscribe[peer.ConnectionEvent]:
 // the events package's globals are process-scoped, so a subscriber in
@@ -87,13 +82,8 @@ func (c *Client) PeerConnectionEvents(ctx context.Context, handler func(peer.Con
 	})
 }
 
-// UnboundedConnectionEvents streams accept/close events for the
-// local broflake widget proxy ("Unbounded" / Basic mode). The JSON
-// shape matches peer.ConnectionEvent but the Go type is distinct —
-// in-process subscribers must subscribe to both event types separately
-// to see all peer activity. State is +1 on consumer accept, -1 on
-// close; Source is the consumer's IP if broflake exposes it,
-// otherwise empty. Blocks until ctx is cancelled.
+// UnboundedConnectionEvents streams accept/close events for the local broflake
+// widget proxy ("Unbounded" / Basic mode). Blocks until ctx is cancelled.
 func (c *Client) UnboundedConnectionEvents(ctx context.Context, handler func(unbounded.ConnectionEvent)) error {
 	return c.sseRetryLoop(ctx, unboundedConnectionEventsEndpoint, func(data []byte) {
 		var evt unbounded.ConnectionEvent

--- a/ipc/conn_windows.go
+++ b/ipc/conn_windows.go
@@ -17,7 +17,6 @@ import (
 
 const (
 	pipePath = `\\.\pipe\Lantern\lantern`
-	// pipePath = `\\.\pipe\ProtectedPrefix\Administrators\`
 
 	apiURL         = "http://pipe"
 	connectTimeout = 10 * time.Second
@@ -132,5 +131,6 @@ func getConnPeer(conn net.Conn) (p usr, err error) {
 	return usr, nil
 }
 
-// this is a no-op on windows
+// setSocketPathForTesting does nothing on Windows: the pipe path is a fixed
+// constant, so there is nothing to override.
 func setSocketPathForTesting(path string) {}

--- a/ipc/middlewares.go
+++ b/ipc/middlewares.go
@@ -17,7 +17,6 @@ import (
 
 func logger(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Pull the trace ID from the request, if it exists.
 		ctx := otel.GetTextMapPropagator().Extract(r.Context(), propagation.HeaderCarrier(r.Header))
 		r = r.WithContext(ctx)
 		span := trace.SpanFromContext(r.Context())

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -1,6 +1,4 @@
-// Package ipc implements the IPC server for communicating between the client and the VPN service.
-// It provides HTTP endpoints for retrieving statistics, managing groups, selecting outbounds,
-// changing modes, and closing connections.
+// Package ipc implements the IPC server between the client and the VPN service (lanternd), exposing HTTP endpoints over a Unix socket (named pipe on Windows).
 package ipc
 
 import (
@@ -538,9 +536,9 @@ func (s *localapi) peerStatusEventsHandler(w http.ResponseWriter, r *http.Reques
 
 // peerConnectionEventsHandler streams peer.ConnectionEvent over SSE for
 // each accept/close on the local samizdat-in. Unlike peerStatusEventsHandler
-// (which always sends the live snapshot), each emit's captured value is
-// what the consumer needs here — the Source IP and +1/-1 state ARE the
-// payload, not a periodic poll, so none may be collapsed into a wakeup.
+// (which always sends the live snapshot), each event's captured value is
+// load-bearing, not a resendable snapshot, so none may be collapsed into a
+// single wakeup.
 //
 // The events package lives in this process (lanternd); cross-process
 // consumers in Liblantern can only receive these via this SSE stream,

--- a/ipc/socket.go
+++ b/ipc/socket.go
@@ -19,6 +19,6 @@ func socketPath() string {
 
 func setPermissions() error {
 	// we set the socket as world accessible and authorize users on connect
-	// by checking if they're a suder instead.
+	// by checking if they're a sudoer instead.
 	return os.Chmod(socketPath(), 0666)
 }

--- a/ipc/socket.go
+++ b/ipc/socket.go
@@ -9,7 +9,6 @@ import (
 // use a var so it can be overridden in tests
 var _socketPath = "/var/run/lantern/lanternd.sock"
 
-// setSocketPathForTesting is only used for testing.
 func setSocketPathForTesting(path string) {
 	_socketPath = path
 }
@@ -19,6 +18,7 @@ func socketPath() string {
 }
 
 func setPermissions() error {
-	// we'll check if user is sudoer to restrict access
+	// we set the socket as world accessible and authorize users on connect
+	// by checking if they're a suder instead.
 	return os.Chmod(socketPath(), 0666)
 }

--- a/ipc/socket_mobile.go
+++ b/ipc/socket_mobile.go
@@ -14,7 +14,8 @@ import (
 	"github.com/getlantern/radiance/log"
 )
 
-// this is a no-op on mobile
+// setSocketPathForTesting does nothing on mobile: the socket path is derived
+// from settings at runtime, so there is nothing to override.
 func setSocketPathForTesting(path string) {}
 
 func socketPath() string {

--- a/ipc/testsetup.go
+++ b/ipc/testsetup.go
@@ -4,8 +4,6 @@ import (
 	_ "unsafe" // for go:linkname
 )
 
-// this file is only used to set up testing environment
-
 var _testing bool
 
 //go:linkname serverTestSetup github.com/getlantern/radiance/internal/testutil.ipc_serverTestSetup

--- a/ipc/usr.go
+++ b/ipc/usr.go
@@ -13,7 +13,7 @@ var executable string
 func init() {
 	exe, err := os.Executable()
 	if err != nil {
-		// if by chance we can't get our executable path, default to 'ls'
+		// Fall back to a benign always-present binary so the sudo --list probe still works.
 		executable = "ls"
 	} else {
 		executable = exe

--- a/issue/issue.go
+++ b/issue/issue.go
@@ -59,21 +59,8 @@ const (
 	UpdateFails
 )
 
-// // issue text to type mapping
-// var issueTypeMap = map[string]IssueType{
-// 	"Cannot complete purchase":    CannotCompletePurchase,
-// 	"Cannot sign in":              CannotSignIn,
-// 	"Spinner loads endlessly":     SpinnerLoadsEndlessly,
-// 	"Cannot access blocked sites": CannotAccessBlockedSites,
-// 	"Slow":                        Slow,
-// 	"Cannot link device":          CannotLinkDevice,
-// 	"Application crashes":         ApplicationCrashes,
-// 	"Other":                       Other,
-// 	"Update fails":                UpdateFails,
-// }
-
 type IssueReport struct {
-	// Type is one of the predefined issue type strings
+	// Type is one of the predefined IssueType constants.
 	Type        IssueType
 	Description string
 	Email       string
@@ -95,16 +82,14 @@ type IssueReport struct {
 	AdditionalAttachments []string
 }
 
-// Report sends an issue report to lantern-cloud/issue, which is then forwarded to ticket system via API
+// Report sends an issue report, substituting a random support address when report.Email is empty.
 func (ir *IssueReporter) Report(ctx context.Context, report IssueReport) error {
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "Report")
 	defer span.End()
-	// set a random email if it's empty
 	if report.Email == "" {
 		report.Email = "support+" + randStr(8) + "@getlantern.org"
 	}
 
-	// userStatus := settings.GetString(settings.UserLevelKey)
 	osVersion, err := osversion.GetHumanReadable()
 	if err != nil {
 		slog.Error("Unable to get OS version", "error", err)
@@ -161,7 +146,6 @@ func (ir *IssueReporter) Report(ctx context.Context, report IssueReport) error {
 		})
 	}
 
-	// send message to lantern-cloud
 	out, err := proto.Marshal(r)
 	if err != nil {
 		slog.Error("unable to marshal issue report", "error", err)

--- a/kindling/dnstt/parser.go
+++ b/kindling/dnstt/parser.go
@@ -62,13 +62,11 @@ func DNSTTOptions(ctx context.Context, localConfigFilepath string, logger io.Wri
 		"DNSTTOptions",
 	)
 	defer span.End()
-	// parsing embedded configs and loading options
 	options, err := parseDNSTTConfigs(embeddedConfig)
 	if err != nil {
 		return nil, traces.RecordError(ctx, fmt.Errorf("failed to parse dnstt embedded config: %w", err))
 	}
 
-	// if local config is set and exists, parse, load the dnstt config and close the embedded dns tunnels
 	if localConfigFilepath != "" {
 		localConfigMutex.Lock()
 		defer localConfigMutex.Unlock()
@@ -103,7 +101,6 @@ func DNSTTOptions(ctx context.Context, localConfigFilepath string, logger io.Wri
 		}()
 	})
 
-	// starting config updater/fetcher
 	client, err := smart.NewHTTPClientWithSmartTransport(logger, dnsttConfigURL)
 	if err != nil {
 		span.RecordError(err)
@@ -396,8 +393,7 @@ func (m *multipleDNSTTTransport) RequestTimeout() time.Duration {
 
 // MaxLength returns the maximum request body size this transport supports.
 // DNS tunnels have a 135-byte MTU — a 10 KB body requires ~75 DNS queries
-// which already pushes the RequestTimeout budget. Larger bodies are routed
-// to a different transport.
+// which already pushes the RequestTimeout budget.
 func (m *multipleDNSTTTransport) MaxLength() int {
 	return 10_000
 }

--- a/log/log.go
+++ b/log/log.go
@@ -92,7 +92,7 @@ func NewLogger(cfg Config) *slog.Logger {
 		logRotator := &lumberjack.Logger{
 			Filename:   cfg.LogPath,
 			MaxSize:    25, // Rotate log when it reaches 25 MB
-			MaxBackups: 2,  // Keep up to 2 rotated log files
+			MaxBackups: 2,
 			MaxAge:     30, // Retain old log files for up to 30 days
 			Compress:   cfg.Prod,
 		}
@@ -123,8 +123,7 @@ func NewLogger(cfg Config) *slog.Logger {
 				}
 				return a
 			case slog.LevelKey:
-				// format the log level to account for the custom levels defined in internal/util.go, i.e. trace
-				// otherwise, slog will print as "DEBUG-4" (trace) or similar
+				// slog renders custom levels like trace as "DEBUG-4"; FormatLogLevel gives them real names.
 				level := a.Value.Any().(slog.Level)
 				a.Value = slog.StringValue(FormatLogLevel(level))
 			}
@@ -319,9 +318,7 @@ func FormatLogLevel(level slog.Level) string {
 	}
 }
 
-// NoOpLogger returns a no-op logger that does not log anything.
 func NoOpLogger() *slog.Logger {
-	// Create a no-op logger that does nothing.
 	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{
 		Level: Disable,
 	}))

--- a/peer/api.go
+++ b/peer/api.go
@@ -1,5 +1,5 @@
-// Package peer implements the client side of "Share My Connection". api.go
-// is the thin HTTP client for lantern-cloud's /v1/peer/* endpoints.
+// Package peer implements the client side of "Share My Connection",
+// including the thin HTTP client for the /v1/peer/* endpoints.
 package peer
 
 import (
@@ -42,9 +42,7 @@ type HeartbeatRequest struct {
 	ActiveClients int `json:"active_clients"`
 }
 
-// APIError carries the server's HTTP status and body. Callers map specific
-// statuses to user-facing errors (404 → not registered, 422 → not reachable
-// from the public internet, 503 → feature off).
+// APIError carries the server's HTTP status and body.
 type APIError struct {
 	Status int
 	Body   string
@@ -81,7 +79,7 @@ func (a *API) Register(ctx context.Context, req RegisterRequest) (*RegisterRespo
 // freshly-built samizdat client. Called after Start has finished bringing
 // up sing-box locally so the server's verifier hits a live listener with
 // the matching creds. Server-side failure deprecates the row + returns
-// 422; the caller treats that as a fatal Start error and tears down.
+// 422.
 func (a *API) Verify(ctx context.Context, routeID string) error {
 	if err := a.do(ctx, http.MethodPost, "/peer/verify", LifecycleRequest{RouteID: routeID}, nil); err != nil {
 		return fmt.Errorf("verify: %w", err)
@@ -141,11 +139,9 @@ func (a *API) do(ctx context.Context, method, path string, body, out any) error 
 	// the API's bound deviceID for parity with the prior behavior in case
 	// the two ever diverge.
 	r.Header.Set(common.DeviceIDHeader, a.deviceID)
-	// Forward the same feature-override header that config/fetcher.go uses
-	// for /config-new requests, so QA can flip on `peer_proxy` ahead of the
-	// public-flag rollout via FeatureOverridesKey (RADIANCE_FEATURE_OVERRIDES).
-	// Without this the server-side gate rejects register/heartbeat/deregister
-	// regardless of the local toggle.
+	// The server-side gate rejects register/heartbeat/deregister regardless of
+	// the local toggle unless this header (fed by RADIANCE_FEATURE_OVERRIDES)
+	// is set.
 	if val := settings.GetString(settings.FeatureOverridesKey); val != "" {
 		r.Header.Set("X-Lantern-Feature-Override", val)
 	}

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -29,19 +29,16 @@ import (
 )
 
 // StatusEvent fires whenever the Client's session state changes — successful
-// Start, user Stop, or auto-Stop on a 404 heartbeat.
+// Start, user Stop, or auto-Stop on a 404 heartbeat. Status is a full snapshot
+// of session state at emit time, not a delta.
 type StatusEvent struct {
 	events.Event
 	Status Status `json:"status"`
 }
 
 // ConnectionEvent fires every time a remote client opens or closes a
-// samizdat session against the local peer's inbound. Source carries the
-// remote "ip:port" string; consumers (the globe view, abuse aggregation)
-// extract the IP for geo-lookup or rate-limit attribution. Timestamp
-// is the emit time in Unix millis; consumers that aggregate across a
-// time window or that need to order events when the underlying
-// dispatch is async can compare it directly.
+// samizdat session against the local peer's inbound. Source is the remote
+// "ip:port" string; Timestamp is the emit time in Unix milliseconds.
 //
 //	State     +1 on accept, -1 on close
 //	Source    remote peer "ip:port"
@@ -102,16 +99,15 @@ const (
 type Status struct {
 	Phase Phase `json:"phase"`
 	// Error is the human-readable failure reason when Phase == PhaseError.
-	// Empty for every other phase; consumers should render this only when
-	// the UI is in the error state.
+	// Empty for every other phase.
 	Error string `json:"error,omitempty"`
 	// Reason classifies Error for consumers that need to branch on the cause
 	// or localize it. Empty when the failure could not be named, in which
 	// case Error is the raw Go error and is not worth translating.
 	Reason Reason `json:"reason,omitempty"`
-	// Active is true only when Phase == PhaseServing. Kept distinct from
-	// Phase so subscribers that just want a boolean "is sharing?" don't
-	// have to switch on the phase enum.
+	// Active is true only when Phase == PhaseServing; kept as a separate
+	// field so a boolean "is sharing?" check need not switch on the phase
+	// enum.
 	Active       bool      `json:"active"`
 	SharingSince time.Time `json:"sharing_since,omitempty"`
 	ExternalIP   string    `json:"external_ip,omitempty"`
@@ -657,9 +653,6 @@ func (c *Client) currentPhase() Phase {
 	return c.status.Phase
 }
 
-// heartbeatLoop closes done on exit so Stop can wait for the loop before
-// tearing down resources. The channel is passed in rather than read off the
-// Client because Stop nils c.runDone before waiting on its local copy.
 // trackConn maintains the per-IP open-connection tally behind ActiveClients.
 // A -1 for an IP with no recorded connection is ignored rather than allowed to
 // go negative: peerconn is process-wide and a disconnect for a connection
@@ -715,6 +708,9 @@ func (c *Client) resetConnTracking() {
 	c.connsByIP = nil
 }
 
+// heartbeatLoop closes done on exit so Stop can wait for the loop before
+// tearing down resources. The channel is passed in rather than read off the
+// Client because Stop nils c.runDone before waiting on its local copy.
 func (c *Client) heartbeatLoop(ctx context.Context, interval time.Duration, done chan struct{}) {
 	defer close(done)
 	t := time.NewTicker(interval)
@@ -1176,4 +1172,3 @@ func newPeerBoxContext(ctx context.Context) context.Context {
 	service.MustRegister[sblog.Factory](ctx, lblog.NewFactory(slog.Default().Handler()))
 	return ctx
 }
-

--- a/peer/validate.go
+++ b/peer/validate.go
@@ -129,7 +129,7 @@ func validateAbuseRejectRules(rules []option.Rule) error {
 // validateStaticRejectCanaries spot-checks that the static
 // destination-based reject rules (RFC1918 CIDRs + abuse ports) are
 // present. Picks one canary from each block rather than asserting the
-// full set so legitimate additions in samizdat.go don't break this
+// full set so legitimate additions to the rules don't break this
 // check.
 func validateStaticRejectCanaries(rules []option.Rule) error {
 	gotRFC1918 := false

--- a/servers/manager.go
+++ b/servers/manager.go
@@ -48,10 +48,9 @@ import (
 
 // Thresholds for flagging slow operations on the servers Manager.
 //
-// These instrument the lock/marshal/disk path to help root-cause cases like
-// Freshdesk #172640, where saveServers held the write lock for 1+ minute
-// and starved cgo-callback readers in GetAvailableServers. See
-// getlantern/engineering#3176 for context.
+// These instrument the lock/marshal/disk path. saveServers must not hold the
+// write lock across disk I/O or it starves cgo-callback readers in
+// AllServers/GetServerByTag.
 const (
 	// saveSlowThreshold: log a WARN with per-phase breakdown if saveServers
 	// exceeds this. Normal operation is well under 100ms.
@@ -408,11 +407,10 @@ func (m *Manager) RemoveServers(tags []string) ([]*Server, error) {
 // around marshalling. saveMu serializes the full marshal+write sequence so
 // concurrent callers can't reorder and overwrite a newer snapshot with an
 // older one. Readers (e.g. AllServers) are not blocked by the disk write —
-// only by the brief marshal window (see getlantern/engineering#3176).
+// only by the brief marshal window.
 //
 // Each phase (saveMu wait, RLock+marshal, disk write) is timed so we can
-// root-cause any future slow case — we still don't have a definitive
-// explanation for the 1-minute hold observed in Freshdesk #172640.
+// root-cause any future slow case.
 func (m *Manager) saveServers() error {
 	start := time.Now()
 
@@ -648,7 +646,8 @@ func (m *Manager) AddPrivateServer(tag, ip string, port int, accessToken string,
 		return fmt.Errorf("no endpoints or outbounds in response")
 	}
 
-	// TODO: update when we support endpoints
+	// TODO: this assumes a single outbound; once we support endpoints it must
+	// also handle cfg.Endpoints instead of indexing Outbounds[0].
 	cfg.Outbounds[0].Tag = tag
 	srv := &Server{
 		Tag:       tag,

--- a/telemetry/otel.go
+++ b/telemetry/otel.go
@@ -186,7 +186,6 @@ func setupOTelSDK(ctx context.Context, attributes Attributes, cfg config.Config)
 		if err != nil {
 			return shutdown, fmt.Errorf("failed to initialize tracer: %w", err)
 		}
-		// Successfully initialized tracer
 		shutdownFuncs = append(shutdownFuncs, shutdownFunc)
 		slog.Info("OpenTelemetry tracer initialized")
 	}
@@ -198,7 +197,6 @@ func setupOTelSDK(ctx context.Context, attributes Attributes, cfg config.Config)
 		if err != nil {
 			return shutdown, fmt.Errorf("failed to initialize meter provider: %w", err)
 		}
-		// Successfully initialized meter provider
 		shutdownFuncs = append(shutdownFuncs, mp)
 	}
 

--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -510,10 +510,6 @@ func mergeAndCollectTags(dst, src *O.Options, nonSelectable []string) []string {
 		dst.DNS = &dns
 	}
 
-	// Infrastructure tags — reserved (auto/manual/direct/block) and any the server declares
-	// non-selectable — are merged into the config but excluded from the selectable
-	// set: not added to the auto (URLTest) group and not offered in the manual
-	// selector. Applies to both outbounds and endpoints.
 	skip := func(tag string) bool {
 		return slices.Contains(reservedTags, tag) || slices.Contains(nonSelectable, tag)
 	}

--- a/vpn/clash.go
+++ b/vpn/clash.go
@@ -27,8 +27,7 @@ import (
 
 const rejectMode = "reject"
 
-// dialAdmissionGate is notified on each dial so the AdmissionGate can record
-// the dial and decide whether to reject new connections.
+// dialAdmissionGate is notified via RecordDial on each dial, with the dial time.
 type dialAdmissionGate interface {
 	RecordDial(time.Time)
 }

--- a/vpn/conntrack.go
+++ b/vpn/conntrack.go
@@ -69,10 +69,9 @@ func (r *record) attrs() ConnAttrs {
 	}
 }
 
-// trackerMetadata synthesizes the upstream metadata view required by the lantern-box group manager
-// (groups.ConnectionManager). That consumer reads only Outbound and ClosedAt.IsZero(); ClosedAt is
-// left zero because only active records are ever exposed. Upload/Download point at the live atomics
-// so any future consumer that converts or marshals the value does not dereference nil.
+// trackerMetadata synthesizes the upstream metadata view required by the lantern-box group manager.
+// ClosedAt is left zero because only active records are ever exposed.
+// Upload/Download point at the live atomics so the value is safe to marshal.
 func (r *record) trackerMetadata() trafficontrol.TrackerMetadata {
 	return trafficontrol.TrackerMetadata{
 		ID:           r.id,

--- a/vpn/kernel_android_others.go
+++ b/vpn/kernel_android_others.go
@@ -2,6 +2,6 @@
 
 package vpn
 
-// kernelVersion returns an empty string on non-Linux platforms where kernel
+// kernelVersion returns an empty string on non-Android platforms, where kernel
 // version detection is not needed for TUN stack selection.
 func kernelVersion() string { return "" }

--- a/vpn/memmon/dumpfile.go
+++ b/vpn/memmon/dumpfile.go
@@ -48,7 +48,6 @@ func buildDump(buf []byte, a Decision, routed, dialed int, now time.Time, platfo
 		nonGo = last.Footprint - last.GoBytes
 	}
 
-	// dump header
 	b := append(buf, "ts="...)
 	b = now.AppendFormat(b, time.RFC3339Nano)
 	b = appendKVStr(b, " platform", platform)
@@ -56,7 +55,6 @@ func buildDump(buf []byte, a Decision, routed, dialed int, now time.Time, platfo
 	b = appendKVStr(b, " reason", a.Reason)
 	b = append(b, '\n')
 
-	// dump memory line
 	b = appendKVFloat(b, "pressure", last.PressureRatio())
 	b = appendKVU64(b, " footprint_bytes", last.Footprint)
 	b = appendKVU64(b, " avail_bytes", last.Available)
@@ -65,7 +63,6 @@ func buildDump(buf []byte, a Decision, routed, dialed int, now time.Time, platfo
 	b = appendKVBool(b, " has_native_footprint", last.HasNativeFootprint)
 	b = append(b, '\n')
 
-	// dump go/connection line
 	b = append(b, "go"...)
 	b = appendKVU64(b, ".total_sys", last.GoStats.TotalSys)
 	b = appendKVU64(b, " heap_objects", last.GoStats.HeapObjects)
@@ -77,7 +74,6 @@ func buildDump(buf []byte, a Decision, routed, dialed int, now time.Time, platfo
 	b = appendKVInt(b, " dialed_conns", dialed)
 	b = append(b, '\n')
 
-	// dump samples
 	b = append(b, "samples:\n"...)
 	for _, s := range samples {
 		b = append(b, "  at="...)
@@ -90,7 +86,6 @@ func buildDump(buf []byte, a Decision, routed, dialed int, now time.Time, platfo
 		b = append(b, '\n')
 	}
 
-	// dump levels
 	b = append(b, "levels:\n"...)
 	for _, l := range levels {
 		b = append(b, "  at="...)

--- a/vpn/memmon/types.go
+++ b/vpn/memmon/types.go
@@ -62,7 +62,7 @@ type GoStats struct {
 	NumGC        uint64 // /gc/cycles/total:gc-cycles
 }
 
-// Sample is one point-in-time reading. At is supplied by the run loop rather
+// Sample is one point-in-time reading. Timestamp is supplied by the run loop rather
 // than read from the clock inside the Sensor or DecisionEngine, so both stay deterministic
 // under test.
 //
@@ -98,8 +98,8 @@ type LevelChange struct {
 }
 
 // Snapshot is the pre-assembled state the crash dump needs, built from the
-// core's ring with no allocation on the hot path beyond the copy. The executor
-// adds the open-connection count at write time and serializes.
+// core's ring with no allocation on the hot path beyond the copy. It does not
+// include the open-connection count.
 type Snapshot struct {
 	Samples []Sample
 	Levels  []LevelChange

--- a/vpn/split_tunnel.go
+++ b/vpn/split_tunnel.go
@@ -351,8 +351,8 @@ func (s *SplitTunnel) loadRule() error {
 			},
 		})
 	} else if len(s.rule.Rules) > 1 && s.rule.Rules[1].Type == C.RuleTypeDefault {
-		// Migrate legacy format: wrap DefaultOptions into LogicalOptions
-		// TODO(2/10): remove in future commit
+		// TODO: drop this migration once all persisted rules use the LogicalOptions
+		// format; kept for now to stay compatible with configs written by older builds.
 		s.logger.Debug("Migrating legacy split tunnel rule format")
 		legacyRule := s.rule.Rules[1].DefaultOptions
 		s.rule.Rules[1] = O.HeadlessRule{

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -195,7 +195,6 @@ func (t *tunnel) init(ctx context.Context, options O.Options, platformIfce libbo
 	cacheFile := service.FromContext[adapter.CacheFile](t.ctx)
 	service.MustRegister[adapter.CacheFile](t.ctx, &cacheFileWrapper{CacheFile: cacheFile})
 
-	// setup client info tracker
 	outboundMgr := service.FromContext[adapter.OutboundManager](t.ctx)
 	clientContextInjector := newClientContextInjector(outboundMgr, t.dataPath, t.initialLanternTags)
 	service.MustRegisterPtr[clientcontext.ClientContextInjector](t.ctx, clientContextInjector)
@@ -443,7 +442,7 @@ func (t *tunnel) addOutboundsLocked(list servers.ServerList) (err error) {
 	}
 
 	slog.Info("Adding servers", "tags", list.Tags())
-	// remove duplicates from newOpts before adding to avoid unnecessary reloads
+	// remove duplicates from list before adding to avoid unnecessary reloads
 	newList := removeDuplicates(t.ctx, t.optsMap, list)
 	newOutbounds := newList.Outbounds()
 	newEndpoints := newList.Endpoints()

--- a/vpn/types.go
+++ b/vpn/types.go
@@ -8,8 +8,7 @@ import (
 	"github.com/getlantern/radiance/events"
 )
 
-// AutoSelectHistoryStorage is an alias for the lantern-box adapter
-// interface used by MutableAutoSelect for per-tag history persistence.
+// AutoSelectHistoryStorage aliases the lantern-box per-tag history-storage interface.
 type AutoSelectHistoryStorage = lbA.AutoSelectHistoryStorage
 
 // StatusUpdateEvent is emitted when the VPN status changes.

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -94,8 +94,8 @@ type PlatformInterface interface {
 	PostServiceClose()
 }
 
-// NewVPNClient creates a new VPNClient instance with the provided configuration paths, log
-// level, and platform interface.
+// NewVPNClient creates a new VPNClient instance with the given data path, logger, and
+// platform interface.
 func NewVPNClient(dataPath string, logger *slog.Logger, platformIfce PlatformInterface) *VPNClient {
 	if logger == nil {
 		logger = slog.Default()
@@ -117,7 +117,6 @@ func (c *VPNClient) Connect(ctx context.Context, boxOptions BoxOptions) error {
 	defer span.End()
 
 	c.mu.Lock()
-	// Cancel any running offline tests and wait for them to finish.
 	c.offlineTestCancel()
 	done := c.offlineTestDone
 	c.mu.Unlock()
@@ -282,9 +281,6 @@ func (c *VPNClient) setStatus(s VPNStatus, err error) {
 		return
 	}
 	c.status.Store(s)
-	// [vpn-state-trace] hop=daemon_setstatus — start of the status delivery chain.
-	// Pair this timestamp with hop=ssehandler_flushed / hop=ffi_to_port / hop=dart_applied
-	// to localize where Connecting/Disconnecting transitions stall on Windows.
 	// Use c.logger (not slog.Info) so this respects the VPNClient's configured
 	// logger — important for tests that pass NoOpLogger via WithLogger.
 	c.logger.Info("[vpn-state-trace]", "hop", "daemon_setstatus", "status", s, "ts_ms", time.Now().UnixMilli())
@@ -596,7 +592,6 @@ func (c *VPNClient) RunOfflineURLTests(ctx context.Context, basePath string, out
 	}
 	select {
 	case <-c.offlineTestDone:
-		// no tests currently running, safe to start new tests
 	default:
 		c.mu.Unlock()
 		return nil, errors.New("offline tests already running")
@@ -638,8 +633,7 @@ func (c *VPNClient) RunOfflineURLTests(ctx context.Context, basePath string, out
 		Outbounds: outbounds,
 	}
 
-	// create offlineed box instance. we just use the standard box since we don't need a
-	// platform interface for testing.
+	// Standard box: the offline pre-warm needs no platform interface.
 	ctx = service.ContextWith[filemanager.Manager](ctx, nil)
 
 	// MutableAutoSelect probes outbounds with bounded concurrency, so the


### PR DESCRIPTION
## Summary

Updates the comment and doc guidance in `AGENTS.md` and cleans up comments across the codebase to match it. Comment-only — no logic changes.

### AGENTS.md
- Replaces the comment sections with the current conventions ("Comments and Documentation" + "Go Doc Comments"), keeping the Comment Verification step.
- Adds the rule that documentation should only document the declaration's own contract.

### Comment cleanup (Go files)
- Remove next-line narration, restated-identifier summaries, and preamble.
- Remove ticket/PR/coworker/file-path references and commented-out dead code.
- Make TODOs actionable (state what and why) or drop them.
- Fix inaccurate/stale doc comments (e.g. a drifted phase list, a wrong field name, a reference to a nonexistent file, and a described nil-guard that the code never had).
- Move or drop documentation that described another declaration's fields/payload or prescribed consumer behavior, so each doc states only its own contract.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved guidance for comments, documentation contracts, TODOs, and Go documentation.
  * Clarified descriptions across public APIs, configuration, networking, events, errors, settings, and platform-specific behavior.
  * Updated explanations for public IP validation, socket behavior, connection events, and data migration.
  * Removed outdated, redundant, and overly implementation-focused comments.

* **Refactor**
  * Removed obsolete commented-out code and stale references without changing application behavior.
  * Made the data-cap exhaustion error available through the public API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->