### PR TITLE
fix(vpn): keep non-selectable outbounds off the selection path

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -341,6 +341,10 @@ func (r *LocalBackend) applyConfig(cfg *config.Config) {
 	if err := r.updateServers(list); err != nil {
 		slog.Error("updating servers in manager", "error", err)
 	}
+	if err := r.vpnClient.UpdateNonSelectableOutbounds(nonSelectableOutboundsFromConfig(cfg)); err != nil &&
+		!errors.Is(err, vpn.ErrTunnelNotConnected) {
+		slog.Error("updating non-selectable outbounds", "error", err)
+	}
 }
 
 // setCountryCodeFromConfig stores the config country for diagnostics unless
@@ -358,8 +362,15 @@ func setCountryCodeFromConfig(cfg *config.Config) {
 // serverListFromConfig converts config outbounds and endpoints into managed
 // Lantern servers while preserving location and bandit URL metadata.
 func serverListFromConfig(cfg *config.Config) servers.ServerList {
+	nonSelectable := nonSelectableSet(cfg)
 	srvs := make([]*servers.Server, 0, len(cfg.Options.Outbounds)+len(cfg.Options.Endpoints))
 	addSvr := func(tag, typ string, opts any, loc *C.ServerLocation) {
+		// Non-selectable tags are merged into the box for dialing but must never
+		// become managed servers, or they surface in the server list, get probed by
+		// offline URL tests, and join the auto-select group on live update.
+		if _, ok := nonSelectable[tag]; ok {
+			return
+		}
 		s := &servers.Server{
 			Tag: tag, Type: typ, IsLantern: true, Options: opts,
 		}
@@ -375,6 +386,29 @@ func serverListFromConfig(cfg *config.Config) servers.ServerList {
 		addSvr(ep.Tag, ep.Type, ep, cfg.OutboundLocations[ep.Tag])
 	}
 	return servers.ServerList{Servers: srvs, URLOverrides: cfg.BanditURLOverrides}
+}
+
+func nonSelectableSet(cfg *config.Config) map[string]struct{} {
+	set := make(map[string]struct{}, len(cfg.NonSelectableOutbounds))
+	for _, tag := range cfg.NonSelectableOutbounds {
+		set[tag] = struct{}{}
+	}
+	return set
+}
+
+// nonSelectableOutboundsFromConfig returns the config's non-selectable outbounds for
+// the tunnel to instantiate off the managed-server path. Endpoints are excluded: a
+// non-selectable endpoint stays build-time only.
+func nonSelectableOutboundsFromConfig(cfg *config.Config) servers.ServerList {
+	nonSelectable := nonSelectableSet(cfg)
+	srvs := make([]*servers.Server, 0, len(nonSelectable))
+	for _, out := range cfg.Options.Outbounds {
+		if _, ok := nonSelectable[out.Tag]; !ok {
+			continue
+		}
+		srvs = append(srvs, &servers.Server{Tag: out.Tag, Type: out.Type, IsLantern: true, Options: out})
+	}
+	return servers.ServerList{Servers: srvs}
 }
 
 func (r *LocalBackend) Close() {

--- a/backend/radiance_test.go
+++ b/backend/radiance_test.go
@@ -671,6 +671,56 @@ func TestBuildIssueReportMetadataFallsBackToSettings(t *testing.T) {
 	assert.NotNil(t, meta.reporter, "a reporter is always needed to upload the report")
 }
 
+func TestServerListFromConfig_ExcludesNonSelectable(t *testing.T) {
+	cfg := &config.Config{
+		Options: option.Options{
+			Outbounds: []option.Outbound{
+				{Tag: "proxy-1", Type: "shadowsocks"},
+				{Tag: "testing-out", Type: "testing"},
+			},
+			Endpoints: []option.Endpoint{
+				{Tag: "ep-1", Type: "wireguard"},
+				{Tag: "infra-ep", Type: "wireguard"},
+			},
+		},
+		NonSelectableOutbounds: []string{"testing-out", "infra-ep"},
+	}
+
+	list := serverListFromConfig(cfg)
+
+	gotTags := make([]string, 0, len(list.Servers))
+	for _, s := range list.Servers {
+		gotTags = append(gotTags, s.Tag)
+	}
+	assert.ElementsMatch(t, []string{"proxy-1", "ep-1"}, gotTags,
+		"non-selectable outbounds and endpoints must be excluded from the managed server list")
+}
+
+func TestNonSelectableOutboundsFromConfig(t *testing.T) {
+	cfg := &config.Config{
+		Options: option.Options{
+			Outbounds: []option.Outbound{
+				{Tag: "proxy-1", Type: "shadowsocks"},
+				{Tag: "testing-out", Type: "testing"},
+			},
+			Endpoints: []option.Endpoint{
+				{Tag: "infra-ep", Type: "wireguard"},
+			},
+		},
+		NonSelectableOutbounds: []string{"testing-out", "infra-ep"},
+	}
+
+	list := nonSelectableOutboundsFromConfig(cfg)
+
+	gotTags := make([]string, 0, len(list.Servers))
+	for _, s := range list.Servers {
+		gotTags = append(gotTags, s.Tag)
+	}
+	assert.ElementsMatch(t, []string{"testing-out"}, gotTags,
+		"only non-selectable outbounds are returned; selectable outbounds and non-selectable endpoints are excluded")
+	require.Len(t, list.Outbounds(), 1, "the returned server must decode as an outbound for the tunnel")
+}
+
 func TestLanternServerTags(t *testing.T) {
 	cfg := &config.Config{
 		Options: option.Options{

--- a/vpn/nonselectable_test.go
+++ b/vpn/nonselectable_test.go
@@ -49,3 +49,20 @@ func TestMergeAndCollectTags_ExcludesNonSelectable(t *testing.T) {
 	assert.True(t, outMerged, "the non-selectable outbound must still be merged into the config")
 	assert.True(t, epMerged, "the non-selectable endpoint must still be merged into the config")
 }
+
+func TestMakeNonSelectableTagSet_OutboundsOnly(t *testing.T) {
+	options := O.Options{
+		Outbounds: []O.Outbound{
+			{Type: "shadowsocks", Tag: "proxy"},
+			{Type: "testing", Tag: "testing-out"},
+		},
+		Endpoints: []O.Endpoint{
+			{Type: "wireguard", Tag: "infra-ep"},
+		},
+	}
+
+	assert.Equal(t, map[string]struct{}{"testing-out": {}},
+		makeNonSelectableTagSet([]string{"testing-out", "infra-ep"}, options),
+		"only non-selectable outbounds are seeded; endpoints are managed elsewhere")
+	assert.Nil(t, makeNonSelectableTagSet(nil, options))
+}

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -59,10 +59,18 @@ type tunnel struct {
 	optsMap     *lsync.TypedMap[string, []byte]
 	mutGrpMgr   *groups.MutableGroupManager
 	outboundMgr adapter.OutboundManager
+	// nonSelectableTags is the set of non-selectable outbound tags the tunnel manages
+	// directly through outboundMgr, never joined to a selection group, so a later
+	// reconcile can remove the ones a config drops. Guarded by outboundMu.
+	nonSelectableTags map[string]struct{}
 
 	clientContextTracker *clientcontext.ClientContextInjector
 
 	initialLanternTags []string
+	// initialNonSelectable is the config's non-selectable tags at connect. It seeds
+	// nonSelectableTags so an outbound dropped before the first reconcile is still
+	// torn down rather than left dialable.
+	initialNonSelectable []string
 
 	// memoryMonitor starts during tunnel init in visibility-only mode.
 	// On iOS, its executor is installed later, after the clash server exists.
@@ -105,6 +113,7 @@ func (t *tunnel) start(ctx context.Context, options O.Options, platformIfce libb
 		return fmt.Errorf("connecting tunnel: %w", err)
 	}
 	t.optsMap = makeOutboundOptsMap(t.ctx, options)
+	t.nonSelectableTags = makeNonSelectableTagSet(t.initialNonSelectable, options)
 	return nil
 }
 
@@ -567,6 +576,60 @@ func (t *tunnel) addOutboundsLocked(list servers.ServerList) (err error) {
 	return errors.Join(errs...)
 }
 
+// updateNonSelectableOutbounds reconciles the tunnel's non-selectable outbounds
+// against list. Each is created directly through the outbound manager and never
+// joined to a selection group, so it is dialable by tag but can never carry user
+// traffic. Endpoints are out of scope; a non-selectable endpoint stays build-time
+// only.
+func (t *tunnel) updateNonSelectableOutbounds(list servers.ServerList) error {
+	t.outboundMu.Lock()
+	defer t.outboundMu.Unlock()
+	return t.updateNonSelectableOutboundsLocked(list)
+}
+
+// updateNonSelectableOutboundsLocked implements updateNonSelectableOutbounds. The
+// caller must hold t.outboundMu.
+func (t *tunnel) updateNonSelectableOutboundsLocked(list servers.ServerList) error {
+	ctx := t.ctx
+	router := service.FromContext[adapter.Router](ctx)
+
+	next := make(map[string]struct{}, len(list.Servers))
+	for _, srv := range list.Servers {
+		next[srv.Tag] = struct{}{}
+	}
+
+	var errs []error
+	for tag := range t.nonSelectableTags {
+		if _, keep := next[tag]; keep {
+			continue
+		}
+		if err := t.outboundMgr.Remove(tag); err != nil {
+			// Keep the tag tracked and its optsMap entry intact so the next
+			// reconcile retries the removal instead of leaking a stale outbound.
+			slog.Warn("Failed to remove non-selectable outbound", "tag", tag, "error", err)
+			errs = append(errs, err)
+			next[tag] = struct{}{}
+			continue
+		}
+		t.optsMap.Delete(tag)
+	}
+
+	for _, outbound := range removeDuplicates(ctx, t.optsMap, list).Outbounds() {
+		logger := t.logFactory.NewLogger("outbound/" + outbound.Tag + "[" + outbound.Type + "]")
+		if err := t.outboundMgr.Create(ctx, router, logger, outbound.Tag, outbound.Type, outbound.Options); err != nil {
+			slog.Warn("Failed to load non-selectable outbound",
+				"tag", outbound.Tag, "type", outbound.Type, "error", err)
+			errs = append(errs, err)
+			continue
+		}
+		b, _ := json.MarshalContext(ctx, outbound)
+		t.optsMap.Store(outbound.Tag, b)
+	}
+
+	t.nonSelectableTags = next
+	return errors.Join(errs...)
+}
+
 func (t *tunnel) removeOutbounds(tags []string) error {
 	t.outboundMu.Lock()
 	defer t.outboundMu.Unlock()
@@ -723,6 +786,25 @@ func makeOutboundOptsMap(ctx context.Context, options O.Options) *lsync.TypedMap
 		optsMap.Store(ep.Tag, b)
 	}
 	return &optsMap
+}
+
+// makeNonSelectableTagSet returns the non-selectable tags that are outbounds in
+// options. Endpoints are excluded because the reconcile manages outbounds only.
+func makeNonSelectableTagSet(nonSelectable []string, options O.Options) map[string]struct{} {
+	if len(nonSelectable) == 0 {
+		return nil
+	}
+	want := make(map[string]struct{}, len(nonSelectable))
+	for _, tag := range nonSelectable {
+		want[tag] = struct{}{}
+	}
+	seeded := make(map[string]struct{})
+	for _, out := range options.Outbounds {
+		if _, ok := want[out.Tag]; ok {
+			seeded[out.Tag] = struct{}{}
+		}
+	}
+	return seeded
 }
 
 type closerFunc func() error

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -186,6 +186,7 @@ func (c *VPNClient) start(ctx context.Context, boxOptions BoxOptions, options op
 		dataPath:             boxOptions.BasePath,
 		selectionHistorySeed: boxOptions.SelectionHistorySeed,
 		initialLanternTags:   boxOptions.LanternServerTags,
+		initialNonSelectable: boxOptions.NonSelectableOutbounds,
 		connObserver:         c.connObserver,
 	}
 	if err := t.start(ctx, options, c.platformIfce, isRestart); err != nil {
@@ -344,6 +345,19 @@ func (c *VPNClient) AddOutbounds(list servers.ServerList) error {
 		return ErrTunnelNotConnected
 	}
 	return c.tunnel.addOutbounds(list)
+}
+
+// UpdateNonSelectableOutbounds reconciles the non-selectable outbounds on the running
+// tunnel. They are created directly through the outbound manager, never joined to a
+// selection group, so they are dialable by tag but never carry user traffic. Returns
+// ErrTunnelNotConnected when no tunnel is up.
+func (c *VPNClient) UpdateNonSelectableOutbounds(list servers.ServerList) error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.tunnel == nil {
+		return ErrTunnelNotConnected
+	}
+	return c.tunnel.updateNonSelectableOutbounds(list)
 }
 
 func (c *VPNClient) RemoveOutbounds(tags []string) error {


### PR DESCRIPTION
## What

Server-declared non-selectable outbounds (`NonSelectableOutbounds`) were treated as ordinary managed servers, so on a live config update they could be probed by offline URL tests, appear in the IPC server list, and join the selection groups — where they could carry user traffic. They were only kept out of the groups at initial tunnel build, not afterward.

This makes non-selectable outbounds dialable-by-tag but never selectable and never managed, at connect **and** on live updates. Groundwork for a non-selectable testing outbound.

## How

- `serverListFromConfig` filters out non-selectable tags, so they never enter the server manager. The four leak surfaces (server list, offline probe, selection-group join, managed-server retention) all read that manager, so the filter closes them at their shared root.
- Non-selectable outbounds get a dedicated tunnel lifecycle via the sing-box outbound manager (`OutboundManager.Create`/`Remove`), never joined to a group. Options are deduplicated against the connect-seeded `optsMap`, so there is no churn at connect; a changed outbound rebuilds, a new one is hot-added while connected, and a dropped one is removed.
- `nonSelectableTags` is seeded at connect so an outbound dropped before the first reconcile is still torn down; a failed `Remove` keeps the tag tracked so a later reconcile retries.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - VPN-only outbounds can be managed independently from selectable servers.
  - Non-selectable outbounds remain available for tunnel use without appearing in server lists, probing, or automatic selection.
  - Active VPN connections update these outbounds when configuration changes.

- **Bug Fixes**
  - Configuration updates no longer fail when the VPN tunnel is not connected.
  - Endpoint entries are excluded from VPN-only server lists while selectable endpoints remain available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->