### PR TITLE
refactor(usermessage): simplify polling and reuse common.Backoff

### DIFF
--- a/common/backoff.go
+++ b/common/backoff.go
@@ -30,20 +30,32 @@ func NewBackoff(baseWait, maxWait time.Duration) *Backoff {
 
 // Wait pauses for the next backoff interval or returns early if the context is done.
 func (b *Backoff) Wait(ctx context.Context) {
+	b.WaitOn(ctx, nil)
+}
+
+// WaitOn pauses for the next backoff interval, returning early if ctx is done or
+// a value is received on wake. An early wake still advances the interval; an
+// already-cancelled ctx does not.
+func (b *Backoff) WaitOn(ctx context.Context, wake <-chan struct{}) {
 	if ctx.Err() != nil {
 		return
 	}
 
-	b.n++
-	wait := b.baseWait * time.Duration(b.n*b.n)
-
-	// add jitter between 80% and 120% of wait time to avoid thundering herd
-	jitter := 0.8 + 0.4*rand.Float64()
-	wait = min(b.maxWait, time.Duration(float64(wait)*jitter))
+	wait := b.nextDelay(rand.Float64())
 	select {
 	case <-ctx.Done():
+	case <-wake:
 	case <-time.After(wait):
 	}
+}
+
+// nextDelay counts a failure and returns the interval to wait for it, jittered
+// by random (expected in [0, 1)), capped at maxWait.
+func (b *Backoff) nextDelay(random float64) time.Duration {
+	b.n++
+	wait := b.baseWait * time.Duration(b.n*b.n)
+	jitter := 0.8 + 0.4*random
+	return min(b.maxWait, time.Duration(float64(wait)*jitter))
 }
 
 // Reset resets the backoff counter.

--- a/common/backoff_test.go
+++ b/common/backoff_test.go
@@ -1,0 +1,63 @@
+package common
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackoffNextDelay(t *testing.T) {
+	backoff := NewBackoff(time.Second, time.Minute)
+	for _, expected := range []time.Duration{
+		1 * time.Second,
+		4 * time.Second,
+		9 * time.Second,
+		16 * time.Second,
+		25 * time.Second,
+		36 * time.Second,
+		49 * time.Second,
+		time.Minute,
+		time.Minute,
+	} {
+		require.Equal(t, expected, backoff.nextDelay(0.5))
+	}
+
+	backoff.Reset()
+	require.Equal(t, time.Second, backoff.nextDelay(0.5))
+}
+
+func TestBackoffNextDelayJitter(t *testing.T) {
+	require.Equal(t, 800*time.Millisecond, NewBackoff(time.Second, time.Minute).nextDelay(0))
+	require.Equal(t, time.Second, NewBackoff(time.Second, time.Minute).nextDelay(0.5))
+	require.Equal(t, 1200*time.Millisecond, NewBackoff(time.Second, time.Minute).nextDelay(1))
+
+	// Jitter cannot push a wait past maxWait.
+	require.Equal(t, time.Minute, NewBackoff(time.Minute, time.Minute).nextDelay(1))
+}
+
+func TestBackoffDefaultBaseWait(t *testing.T) {
+	require.Equal(t, defaultBaseWait, NewBackoff(0, time.Minute).nextDelay(0.5))
+	require.Equal(t, defaultBaseWait, NewBackoff(-time.Second, time.Minute).nextDelay(0.5))
+}
+
+func TestBackoffWaitOnDoneContextDoesNotCountFailure(t *testing.T) {
+	backoff := NewBackoff(time.Second, time.Minute)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	backoff.Wait(ctx)
+	require.Equal(t, time.Second, backoff.nextDelay(0.5))
+}
+
+func TestBackoffWaitOnReturnsOnWake(t *testing.T) {
+	// A wait long enough that only the wake channel can end it.
+	backoff := NewBackoff(time.Hour, time.Hour)
+	wake := make(chan struct{}, 1)
+	wake <- struct{}{}
+
+	started := time.Now()
+	backoff.WaitOn(context.Background(), wake)
+	require.Less(t, time.Since(started), time.Second)
+}

--- a/usermessage/service.go
+++ b/usermessage/service.go
@@ -4,71 +4,60 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"math/rand"
 	"sync"
 	"time"
 
 	wire "github.com/getlantern/common/usermessage"
+
+	"github.com/getlantern/radiance/common"
 )
 
 const (
-	credentialRecheckInterval = time.Second
-	initialFailureBackoff     = 5 * time.Second
-	maxFailureBackoff         = 5 * time.Minute
-	localStateRetryInterval   = 5 * time.Minute
+	initialFailureBackoff = 5 * time.Second
+	maxFailureBackoff     = 5 * time.Minute
 )
 
-// Clock creates timers and reports the current time.
-type Clock interface {
-	Now() time.Time
-	NewTimer(time.Duration) Timer
+// failureBackoff paces retries between failed fetches. Used for
+// deterministic testing of the poll loop.
+type failureBackoff interface {
+	WaitOn(ctx context.Context, wake <-chan struct{})
+	Reset()
 }
 
-// Timer is the subset of time.Timer used by Service.
-type Timer interface {
-	C() <-chan time.Time
-	Stop() bool
+var newFailureBackoff = func() failureBackoff {
+	return common.NewBackoff(initialFailureBackoff, maxFailureBackoff)
 }
-
-type realClock struct{}
-
-func (realClock) Now() time.Time                 { return time.Now() }
-func (realClock) NewTimer(d time.Duration) Timer { return realTimer{time.NewTimer(d)} }
-
-type realTimer struct{ *time.Timer }
-
-func (t realTimer) C() <-chan time.Time { return t.Timer.C }
 
 // Options configures a Service.
 type Options struct {
 	DataDir         string
 	Fetcher         Fetcher
 	ContextProvider func() ClientContext
-	Clock           Clock
-	Jitter          func(time.Duration) time.Duration
-	// Logger receives service diagnostics. New uses a service-scoped default
-	// logger when Logger is nil.
-	Logger *slog.Logger
+	Logger          *slog.Logger
 }
 
 // Service owns polling, per-account presentation state, and display acknowledgment.
 type Service struct {
 	fetcher         Fetcher
 	contextProvider func() ClientContext
-	clock           Clock
-	jitter          func(time.Duration) time.Duration
 	logger          *slog.Logger
 	store           *store
-	wake            chan struct{}
 
-	mu      sync.Mutex
-	started bool
-	active  bool
-	online  bool
-	// refreshGeneration lets us discard a response if a refresh arrived while it was in flight.
-	refreshGeneration uint64
-	requestID         uint64
-	requestCancel     context.CancelFunc
+	// fetchMu keeps one fetch in flight at a time so the poll loop and a
+	// concurrent refresh do not issue duplicate requests off the same seen list.
+	fetchMu sync.Mutex
+
+	mu            sync.Mutex
+	started       bool
+	parent        context.Context
+	pollCtx       context.Context
+	cancelPolling context.CancelFunc
+	// fetchCancel aborts the in-flight fetch so a refresh re-fetches with fresh
+	// context instead of waiting for the current request to return.
+	fetchCancel context.CancelFunc
+	active      bool
+	online      bool
+	refresh     chan struct{}
 }
 
 // New creates a user-message service and loads its durable state.
@@ -86,14 +75,6 @@ func New(opts Options) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	clock := opts.Clock
-	if clock == nil {
-		clock = realClock{}
-	}
-	jitter := opts.Jitter
-	if jitter == nil {
-		jitter = defaultJitter
-	}
 	logger := opts.Logger
 	if logger == nil {
 		logger = slog.Default().With("service", "user_messages")
@@ -101,26 +82,25 @@ func New(opts Options) (*Service, error) {
 	return &Service{
 		fetcher:         opts.Fetcher,
 		contextProvider: opts.ContextProvider,
-		clock:           clock,
-		jitter:          jitter,
 		logger:          logger,
 		store:           state,
-		wake:            make(chan struct{}, 1),
 		active:          true,
 		online:          true,
+		refresh:         make(chan struct{}, 1),
 	}, nil
 }
 
-// Start begins with an immediate fetch and is idempotent.
+// Start begins with an immediate fetch and is idempotent. Polling runs only
+// while the host app is active and online; see [Service.SetActivity].
 func (s *Service) Start(ctx context.Context) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.started {
-		s.mu.Unlock()
 		return
 	}
 	s.started = true
-	s.mu.Unlock()
-	go s.run(ctx)
+	s.parent = ctx
+	s.startPollingLocked()
 }
 
 // Current returns the pending, unexpired message for the current account.
@@ -129,24 +109,18 @@ func (s *Service) Current() (*wire.ResolvedUserMessage, error) {
 	if clientContext.UserID == "" {
 		return nil, nil
 	}
-	return s.store.current(clientContext.UserID, s.clock.Now())
+	return s.store.current(clientContext.UserID, time.Now())
 }
 
-// Refresh requests an immediate fetch. Concurrent requests are coalesced.
 func (s *Service) Refresh() {
 	s.mu.Lock()
-	s.refreshGeneration++
-	cancel := s.requestCancel
+	cancel := s.fetchCancel
 	s.mu.Unlock()
 	if cancel != nil {
 		cancel()
 	}
-	s.signalRefresh()
-}
-
-func (s *Service) signalRefresh() {
 	select {
-	case s.wake <- struct{}{}:
+	case s.refresh <- struct{}{}:
 	default:
 	}
 }
@@ -157,7 +131,7 @@ func (s *Service) Acknowledge(displayID string) error {
 	if clientContext.UserID == "" {
 		return ErrMessageNotPending
 	}
-	if err := s.store.acknowledge(clientContext.UserID, displayID, s.clock.Now()); err != nil {
+	if err := s.store.acknowledge(clientContext.UserID, displayID, time.Now()); err != nil {
 		return err
 	}
 	s.Refresh()
@@ -165,114 +139,159 @@ func (s *Service) Acknowledge(displayID string) error {
 }
 
 // SetActivity controls polling while the host app is active and online.
+// Resuming begins with an immediate fetch; suspending cancels any request in
+// flight.
 func (s *Service) SetActivity(active, online bool) {
 	s.mu.Lock()
-	changed := s.active != active || s.online != online
+	defer s.mu.Unlock()
+	if s.active == active && s.online == online {
+		return
+	}
 	s.active = active
 	s.online = online
-	s.mu.Unlock()
-	if changed {
-		s.Refresh()
+	if active && online {
+		s.startPollingLocked()
+		return
 	}
+	s.stopPollingLocked()
+}
+
+func (s *Service) startPollingLocked() {
+	if !s.started || !s.active || !s.online || s.pollCtx != nil || s.parent.Err() != nil {
+		return
+	}
+	// Drop a refresh queued while stopped; the run below already fetches
+	// immediately, so a stale wake would only trigger a second fetch.
+	select {
+	case <-s.refresh:
+	default:
+	}
+	ctx, cancel := context.WithCancel(s.parent)
+	s.pollCtx, s.cancelPolling = ctx, cancel
+	go s.run(ctx)
+}
+
+func (s *Service) stopPollingLocked() {
+	if s.cancelPolling == nil {
+		return
+	}
+	s.cancelPolling()
+	s.pollCtx, s.cancelPolling = nil, nil
 }
 
 func (s *Service) run(ctx context.Context) {
-	var delay time.Duration
 	var failures uint
-	var credentialsDeferred bool
-	for s.wait(ctx, delay) {
-		requestContext, requestID, refreshGeneration, ok := s.beginRequest(ctx)
-		if !ok {
-			delay = 0
-			continue
+	backoff := newFailureBackoff()
+	for ctx.Err() == nil {
+		delay, err := s.fetchAndStore(ctx)
+		// Checked ahead of err so a fetch aborted by a stopped poll context
+		// (shutdown or suspend) is not counted as a fetch failure.
+		if ctx.Err() != nil {
+			break
 		}
-		clientContext := s.contextProvider()
-		if !clientContext.valid() {
-			s.endRequest(requestID)
-			failures = 0
-			// Account creation normally wakes us through Refresh, but first-run
-			// identity creation has historically not emitted that signal. Recheck
-			// the in-memory context so a missed edge cannot stall messaging until
-			// the next app launch. No network request is made until it is valid.
-			delay = credentialRecheckInterval
-			if !credentialsDeferred {
-				s.logger.Debug("User-message fetch deferred", "reason", "credentials_unavailable")
-				credentialsDeferred = true
-			}
-			continue
-		}
-		credentialsDeferred = false
-		seen := s.store.seen(clientContext.UserID)
-		response, err := s.fetcher.Fetch(requestContext, clientContext, seen)
-		s.endRequest(requestID)
 		if errors.Is(err, context.Canceled) {
-			s.consumeRefresh()
-			delay = 0
+			// A refresh aborted the in-flight fetch; drop its wake and re-fetch now.
+			select {
+			case <-s.refresh:
+			default:
+			}
 			continue
-		}
-		if err == nil {
-			pollOnly := response
-			pollOnly.Message = nil
-			err = pollOnly.Validate()
-			if err != nil {
-				failures++
-				delay = s.jitter(failureBackoff(failures))
-				s.logger.Warn(
-					"User-message response rejected",
-					"category", "invalid_response",
-					"failure_count", failures,
-					"retry_in", delay,
-				)
-				continue
-			}
-			if response.Message != nil && response.Message.Validate() != nil {
-				s.logger.Warn("User-message response discarded", "category", "invalid_message")
-				response.Message = nil
-			}
 		}
 		if err != nil {
 			failures++
-			delay = s.jitter(failureBackoff(failures))
-			s.logFetchFailure(err, failures, delay)
-			continue
-		}
-		if s.refreshGenerationChanged(refreshGeneration) || s.contextProvider() != clientContext {
-			s.consumeRefresh()
-			delay = 0
-			continue
-		}
-		if err := s.store.offer(clientContext.UserID, response.Message, s.clock.Now()); err != nil {
-			failures = 0
-			delay = localStateRetryInterval
-			s.logger.Warn(
-				"User-message fetch result could not be persisted",
-				"category", "local_state",
-				"retry_in", delay,
-			)
+			s.logFetchFailure(err, failures)
+			backoff.WaitOn(ctx, s.refresh)
 			continue
 		}
 		failures = 0
-		delay = time.Duration(response.PollIntervalSeconds) * time.Second
-		s.logFetchResult(response.Message, delay)
+		backoff.Reset()
+
+		select {
+		case <-ctx.Done():
+		case <-time.After(delay):
+		case <-s.refresh:
+		}
 	}
+	s.logger.Debug("User-message polling stopped", "reason", ctx.Err())
 }
 
-func (s *Service) logFetchFailure(err error, failures uint, retryIn time.Duration) {
+// fetchAndStore returns the delay the server recommends before the next fetch.
+// A zero delay with a nil error means the response was discarded because the
+// account changed while it was in flight.
+func (s *Service) fetchAndStore(ctx context.Context) (time.Duration, error) {
+	s.fetchMu.Lock()
+	defer s.fetchMu.Unlock()
+
+	clientContext := s.contextProvider()
+	if !clientContext.valid() {
+		return 0, errCredentialsUnavailable
+	}
+	seen := s.store.seen(clientContext.UserID)
+
+	fetchCtx, cancel := context.WithCancel(ctx)
+	s.mu.Lock()
+	s.fetchCancel = cancel
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.fetchCancel = nil
+		s.mu.Unlock()
+		cancel()
+	}()
+
+	response, err := s.fetcher.Fetch(fetchCtx, clientContext, seen)
+	if err != nil {
+		return 0, err
+	}
+	pollOnly := response
+	pollOnly.Message = nil
+	if err := pollOnly.Validate(); err != nil {
+		return 0, invalidResponseError{err: err}
+	}
+	if response.Message != nil && response.Message.Validate() != nil {
+		s.logger.Warn("User-message response discarded", "category", "invalid_message")
+		response.Message = nil
+	}
+	if s.contextProvider() != clientContext {
+		return 0, nil
+	}
+	delay := time.Duration(response.PollIntervalSeconds) * time.Second
+	if err := s.store.offer(clientContext.UserID, response.Message, time.Now()); err != nil {
+		s.logger.Warn(
+			"User-message fetch result could not be persisted",
+			"category", "local_state",
+		)
+		return delay, nil
+	}
+	s.logFetchResult(response.Message, delay)
+	return delay, nil
+}
+
+func (s *Service) logFetchFailure(err error, failures uint) {
 	category, statusCode := fetchFailureDetails(err)
-	attributes := []any{
-		"category", category,
-		"failure_count", failures,
-		"retry_in", retryIn,
+	// Do not attach err here. Transport errors can contain request URLs, and
+	// future error wrappers might include credentials or localized content.
+	attributes := []any{"category", category}
+	if failures > 0 {
+		attributes = append(attributes, "failure_count", failures)
 	}
 	if statusCode != 0 {
 		attributes = append(attributes, "http_status", statusCode)
 	}
-	// Do not attach err here. Transport errors can contain request URLs, and
-	// future error wrappers might include credentials or localized content.
-	s.logger.Warn("User-message fetch failed", attributes...)
+	level := slog.LevelWarn
+	if errors.Is(err, errCredentialsUnavailable) {
+		// A signed-out client retries on the same ladder as a real failure, so
+		// this recurs indefinitely and is not actionable.
+		level = slog.LevelDebug
+	}
+	s.logger.Log(context.Background(), level, "User-message fetch failed", attributes...)
 }
 
 func fetchFailureDetails(err error) (category string, statusCode int) {
+	var invalidResponse invalidResponseError
+	if errors.As(err, &invalidResponse) {
+		return "invalid_response", 0
+	}
 	if errors.Is(err, errCredentialsUnavailable) {
 		return "credentials_unavailable", 0
 	}
@@ -321,101 +340,14 @@ func (s *Service) logFetchResult(message *wire.ResolvedUserMessage, pollIn time.
 	)
 }
 
-func (s *Service) beginRequest(parent context.Context) (context.Context, uint64, uint64, bool) {
-	requestContext, cancel := context.WithCancel(parent)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if !s.active || !s.online {
-		cancel()
-		return nil, 0, 0, false
-	}
-	s.requestID++
-	s.requestCancel = cancel
-	return requestContext, s.requestID, s.refreshGeneration, true
+type invalidResponseError struct {
+	err error
 }
 
-func (s *Service) endRequest(requestID uint64) {
-	s.mu.Lock()
-	var cancel context.CancelFunc
-	if s.requestID == requestID {
-		cancel = s.requestCancel
-		s.requestCancel = nil
-	}
-	s.mu.Unlock()
-	if cancel != nil {
-		cancel()
-	}
+func (e invalidResponseError) Error() string {
+	return "invalid user-message response"
 }
 
-func (s *Service) refreshGenerationChanged(refreshGeneration uint64) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.refreshGeneration != refreshGeneration
-}
-
-func (s *Service) consumeRefresh() {
-	select {
-	case <-s.wake:
-	default:
-	}
-}
-
-func (s *Service) wait(ctx context.Context, delay time.Duration) bool {
-	for {
-		if ctx.Err() != nil {
-			return false
-		}
-		if !s.ready() {
-			select {
-			case <-ctx.Done():
-				return false
-			case <-s.wake:
-				if s.ready() {
-					return true
-				}
-				continue
-			}
-		}
-		if delay <= 0 {
-			return true
-		}
-		timer := s.clock.NewTimer(delay)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return false
-		case <-s.wake:
-			timer.Stop()
-			if s.ready() {
-				return true
-			}
-			continue
-		case <-timer.C():
-			return true
-		}
-	}
-}
-
-func (s *Service) ready() bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.active && s.online
-}
-
-func failureBackoff(failures uint) time.Duration {
-	delay := initialFailureBackoff
-	for i := uint(1); i < failures && delay < maxFailureBackoff; i++ {
-		delay *= 2
-		if delay >= maxFailureBackoff {
-			return maxFailureBackoff
-		}
-	}
-	return delay
-}
-
-func defaultJitter(delay time.Duration) time.Duration {
-	if delay <= 0 {
-		return 0
-	}
-	return time.Duration(float64(delay) * (0.9 + rand.Float64()*0.1))
+func (e invalidResponseError) Unwrap() error {
+	return e.err
 }

--- a/usermessage/service_test.go
+++ b/usermessage/service_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -14,280 +15,232 @@ import (
 	"github.com/stretchr/testify/require"
 
 	wire "github.com/getlantern/common/usermessage"
+
+	"github.com/getlantern/radiance/common"
 )
 
-func TestServicePollingBackoffAndSuccessReset(t *testing.T) {
-	clock := newFakeClock(time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC))
+func TestServiceBackoffAndReset(t *testing.T) {
+	backoff := newRecordingBackoff()
+	useFailureBackoff(t, backoff)
 	fetcher := newScriptedFetcher()
-	service := newTestService(t, clock, fetcher, func() ClientContext { return testClientContext() })
+	var logs safeBuffer
+	service := newTestServiceWithLogger(
+		t,
+		fetcher,
+		func() ClientContext { return testClientContext() },
+		slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})),
+	)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	service.Start(ctx)
 
 	receiveFetch(t, fetcher)
 	fetcher.results <- fetchResult{err: errors.New("offline")}
-	require.Equal(t, 5*time.Second, receiveTimer(t, clock))
-	clock.Advance(5 * time.Second)
+	require.Equal(t, "wait", receiveBackoffCall(t, backoff))
+	requireLogContains(t, &logs, "failure_count=1")
 
 	receiveFetch(t, fetcher)
 	fetcher.results <- fetchResult{err: errors.New("still offline")}
-	require.Equal(t, 10*time.Second, receiveTimer(t, clock))
-	clock.Advance(10 * time.Second)
+	require.Equal(t, "wait", receiveBackoffCall(t, backoff))
+	requireLogContains(t, &logs, "failure_count=2")
 
 	receiveFetch(t, fetcher)
 	fetcher.results <- fetchResult{response: wire.UserMessageResponse{PollIntervalSeconds: 300}}
-	require.Equal(t, 5*time.Minute, receiveTimer(t, clock))
-	clock.Advance(5 * time.Minute)
+	require.Equal(t, "reset", receiveBackoffCall(t, backoff))
+	requireLogContains(t, &logs, "result=no_message")
+	logs.Reset()
 
+	// The success parked the loop on the server's interval, so wake it instead
+	// of waiting that out.
+	service.Refresh()
 	receiveFetch(t, fetcher)
 	fetcher.results <- fetchResult{err: errors.New("failed after success")}
-	require.Equal(t, 5*time.Second, receiveTimer(t, clock))
+	require.Equal(t, "wait", receiveBackoffCall(t, backoff))
+	requireLogContains(t, &logs, "failure_count=1")
 }
 
-func TestServiceRespectsSuccessfulPollIntervalWithoutJitter(t *testing.T) {
-	clock := newFakeClock(time.Now())
+func TestServiceUsesServerInterval(t *testing.T) {
 	fetcher := newScriptedFetcher()
-	service, err := New(Options{
-		DataDir:         t.TempDir(),
-		Fetcher:         fetcher,
-		ContextProvider: func() ClientContext { return testClientContext() },
-		Clock:           clock,
-		Jitter:          func(delay time.Duration) time.Duration { return delay / 2 },
-		Logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
-	})
-	require.NoError(t, err)
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	service.Start(ctx)
+	service := newTestService(t, fetcher, func() ClientContext { return testClientContext() })
 
-	receiveFetch(t, fetcher)
 	fetcher.results <- fetchResult{response: wire.UserMessageResponse{PollIntervalSeconds: 300}}
-	require.Equal(t, 5*time.Minute, receiveTimer(t, clock))
-	clock.Advance(5 * time.Minute)
-
-	receiveFetch(t, fetcher)
-	fetcher.results <- fetchResult{err: errors.New("offline")}
-	require.Equal(t, 2500*time.Millisecond, receiveTimer(t, clock))
+	delay, err := service.fetchAndStore(context.Background())
+	require.NoError(t, err)
+	// Spreading load across clients is the server's job, so the interval is
+	// used as sent.
+	require.Equal(t, 5*time.Minute, delay)
 }
 
-func TestServiceImmediateRefreshForContextAndActivityChanges(t *testing.T) {
-	clock := newFakeClock(time.Now())
-	fetcher := newScriptedFetcher()
-	var mu sync.Mutex
-	clientContext := testClientContext()
-	provider := func() ClientContext {
-		mu.Lock()
-		defer mu.Unlock()
-		return clientContext
-	}
-	service := newTestService(t, clock, fetcher, provider)
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	service.Start(ctx)
+func TestServiceRefreshAndActivity(t *testing.T) {
+	service, fetcher, setContext := startService(t, testClientContext())
 
 	require.Equal(t, "fa-IR", receiveFetch(t, fetcher).clientContext.Locale)
 	fetcher.results <- fetchResult{response: wire.UserMessageResponse{PollIntervalSeconds: 300}}
-	receiveTimer(t, clock)
+	requireNoFetch(t, fetcher)
 
-	mu.Lock()
-	clientContext.Locale = "en-US"
-	mu.Unlock()
+	setContext(func(c *ClientContext) { c.Locale = "en-US" })
 	service.Refresh()
 	require.Equal(t, "en-US", receiveFetch(t, fetcher).clientContext.Locale)
 	fetcher.results <- fetchResult{response: wire.UserMessageResponse{PollIntervalSeconds: 300}}
-	receiveTimer(t, clock)
 
 	service.SetActivity(false, true)
-	require.Never(t, func() bool {
-		select {
-		case <-fetcher.requests:
-			return true
-		default:
-			return false
-		}
-	}, 50*time.Millisecond, time.Millisecond)
+	requireNoFetch(t, fetcher)
 	service.SetActivity(true, true)
 	require.Equal(t, "en-US", receiveFetch(t, fetcher).clientContext.Locale)
 }
 
-func TestServiceSeenFilteringAccountSwitchAndExpiration(t *testing.T) {
-	clock := newFakeClock(time.Now())
-	fetcher := newScriptedFetcher()
-	var mu sync.Mutex
-	clientContext := testClientContext()
-	provider := func() ClientContext {
-		mu.Lock()
-		defer mu.Unlock()
-		return clientContext
-	}
-	service := newTestService(t, clock, fetcher, provider)
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	service.Start(ctx)
+func TestServiceSeenAndExpiry(t *testing.T) {
+	service, fetcher, setContext := startService(t, testClientContext())
 
 	first := receiveFetch(t, fetcher)
 	require.Empty(t, first.seen)
 	fetcher.results <- fetchResult{response: wire.UserMessageResponse{
 		PollIntervalSeconds: 300,
-		Message:             testMessage("display-1", clock.Now().Add(time.Minute)),
+		Message:             testMessage("display-1", time.Now().Add(time.Hour)),
 	}}
-	receiveTimer(t, clock)
-	message, err := service.Current()
-	require.NoError(t, err)
-	require.Equal(t, "display-1", message.DisplayID)
+	requireCurrentDisplayID(t, service, "display-1")
 	require.NoError(t, service.Acknowledge("display-1"))
 	request := receiveFetch(t, fetcher)
 	require.Equal(t, []string{"display-1"}, request.seen)
 	fetcher.results <- fetchResult{response: wire.UserMessageResponse{PollIntervalSeconds: 300}}
-	receiveTimer(t, clock)
 
-	mu.Lock()
-	clientContext.UserID = "67890"
-	mu.Unlock()
+	setContext(func(c *ClientContext) { c.UserID = "67890" })
 	service.Refresh()
 	request = receiveFetch(t, fetcher)
 	require.Empty(t, request.seen)
 	fetcher.results <- fetchResult{response: wire.UserMessageResponse{
 		PollIntervalSeconds: 300,
-		Message:             testMessage("display-2", clock.Now().Add(time.Minute)),
+		Message:             testMessage("display-2", time.Now().Add(50*time.Millisecond)),
 	}}
-	receiveTimer(t, clock)
-	clock.Advance(time.Minute)
+	requireCurrentDisplayID(t, service, "display-2")
+	require.Eventually(t, func() bool {
+		message, err := service.Current()
+		return err == nil && message == nil
+	}, time.Second, time.Millisecond)
+}
+
+func TestServiceDiscardsStaleResponse(t *testing.T) {
+	// Regression guard: a response fetched under one account must never be
+	// surfaced after the account changed while the fetch was in flight.
+	service, fetcher, setContext := startService(t, testClientContext())
+
+	require.Equal(t, "12345", receiveFetch(t, fetcher).clientContext.UserID)
+	setContext(func(c *ClientContext) { c.UserID = "67890" })
+	fetcher.results <- fetchResult{response: wire.UserMessageResponse{
+		PollIntervalSeconds: 300,
+		Message:             testMessage("display-1", time.Now().Add(time.Hour)),
+	}}
+
+	require.Equal(t, "67890", receiveFetch(t, fetcher).clientContext.UserID)
+	fetcher.results <- fetchResult{response: wire.UserMessageResponse{PollIntervalSeconds: 300}}
+	requireNoFetch(t, fetcher)
+
+	message, err := service.Current()
+	require.NoError(t, err)
+	require.Nil(t, message)
+
+	setContext(func(c *ClientContext) { c.UserID = "12345" })
 	message, err = service.Current()
 	require.NoError(t, err)
 	require.Nil(t, message)
 }
 
-func TestServiceCancelsFetchAfterAccountReplacement(t *testing.T) {
-	clock := newFakeClock(time.Now())
-	fetcher := newScriptedFetcher()
-	var mu sync.Mutex
-	clientContext := testClientContext()
-	provider := func() ClientContext {
-		mu.Lock()
-		defer mu.Unlock()
-		return clientContext
-	}
-	service := newTestService(t, clock, fetcher, provider)
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	service.Start(ctx)
+func TestServiceRefreshCancelsInFlightFetch(t *testing.T) {
+	// Regression guard: Refresh must abort the in-flight fetch so a context
+	// change is picked up immediately, not after the current request returns.
+	service, fetcher, setContext := startService(t, testClientContext())
 
 	require.Equal(t, "12345", receiveFetch(t, fetcher).clientContext.UserID)
-	mu.Lock()
-	clientContext.UserID = "67890"
-	mu.Unlock()
+
+	// Refresh while the first fetch is still blocked: it must be cancelled, not
+	// awaited. The next fetch runs without any result delivered to the first.
+	setContext(func(c *ClientContext) { c.UserID = "67890" })
 	service.Refresh()
-
 	require.Equal(t, "67890", receiveFetch(t, fetcher).clientContext.UserID)
-	fetcher.results <- fetchResult{response: wire.UserMessageResponse{PollIntervalSeconds: 300}}
-	receiveTimer(t, clock)
-	require.Never(t, func() bool {
-		select {
-		case <-fetcher.requests:
-			return true
-		default:
-			return false
-		}
-	}, 50*time.Millisecond, time.Millisecond)
+}
 
-	mu.Lock()
-	clientContext.UserID = "12345"
-	mu.Unlock()
+func TestServiceDiscardsAckedReoffer(t *testing.T) {
+	// Regression guard: a message acknowledged while a fetch is in flight must
+	// not be resurfaced when that fetch re-offers it.
+	service, fetcher, _ := startService(t, testClientContext())
+
+	receiveFetch(t, fetcher)
+	fetcher.results <- fetchResult{response: wire.UserMessageResponse{
+		PollIntervalSeconds: 300,
+		Message:             testMessage("display-1", time.Now().Add(time.Hour)),
+	}}
+	requireCurrentDisplayID(t, service, "display-1")
+
+	// Put a second fetch in flight, then acknowledge display-1 before it returns.
+	service.Refresh()
+	require.Empty(t, receiveFetch(t, fetcher).seen)
+	require.NoError(t, service.Acknowledge("display-1"))
+	fetcher.results <- fetchResult{response: wire.UserMessageResponse{
+		PollIntervalSeconds: 300,
+		Message:             testMessage("display-1", time.Now().Add(time.Hour)),
+	}}
+
+	// The ack's own refresh drives a third fetch that now reports display-1 seen.
+	require.Equal(t, []string{"display-1"}, receiveFetch(t, fetcher).seen)
+	fetcher.results <- fetchResult{response: wire.UserMessageResponse{PollIntervalSeconds: 300}}
+
 	message, err := service.Current()
 	require.NoError(t, err)
 	require.Nil(t, message)
 }
 
-func TestServiceRechecksCredentialsWhenFirstRunSignalIsMissed(t *testing.T) {
-	clock := newFakeClock(time.Now())
-	fetcher := newScriptedFetcher()
-	var mu sync.Mutex
-	clientContext := ClientContext{}
-	provider := func() ClientContext {
-		mu.Lock()
-		defer mu.Unlock()
-		return clientContext
-	}
-	service := newTestService(t, clock, fetcher, provider)
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	service.Start(ctx)
-
-	require.Equal(t, credentialRecheckInterval, receiveTimer(t, clock))
-	require.Never(t, func() bool {
-		select {
-		case <-fetcher.requests:
-			return true
-		default:
-			return false
+func TestServiceRecoversWhenCredentialsBecomeAvailable(t *testing.T) {
+	// Regression guard: while credentials are incomplete the loop issues no
+	// request; once they become valid it fetches — on its own with nothing
+	// waking it (self-recheck), and immediately on an explicit refresh.
+	for _, wake := range []bool{false, true} {
+		name := "self-recheck"
+		if wake {
+			name = "on refresh"
 		}
-	}, 50*time.Millisecond, time.Millisecond)
+		t.Run(name, func(t *testing.T) {
+			if !wake {
+				// Nothing wakes the loop, so a short backoff keeps the
+				// self-recheck from spinning on real time.
+				useFailureBackoff(t, common.NewBackoff(time.Millisecond, 10*time.Millisecond))
+			}
+			service, fetcher, setContext := startService(t, ClientContext{})
 
-	mu.Lock()
-	clientContext = testClientContext()
-	mu.Unlock()
-	clock.Advance(credentialRecheckInterval)
-	require.Equal(t, "12345", receiveFetch(t, fetcher).clientContext.UserID)
-}
+			// Invalid credentials short-circuit before the fetcher, so no
+			// request is made until they become valid.
+			requireNoFetch(t, fetcher)
 
-func TestServiceStillRefreshesImmediatelyWhenCredentialsBecomeAvailable(t *testing.T) {
-	clock := newFakeClock(time.Now())
-	fetcher := newScriptedFetcher()
-	var mu sync.Mutex
-	clientContext := ClientContext{}
-	provider := func() ClientContext {
-		mu.Lock()
-		defer mu.Unlock()
-		return clientContext
+			setContext(func(c *ClientContext) { *c = testClientContext() })
+			if wake {
+				service.Refresh()
+			}
+			require.Equal(t, "12345", receiveFetch(t, fetcher).clientContext.UserID)
+		})
 	}
-	service := newTestService(t, clock, fetcher, provider)
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	service.Start(ctx)
-
-	require.Equal(t, credentialRecheckInterval, receiveTimer(t, clock))
-	mu.Lock()
-	clientContext = testClientContext()
-	mu.Unlock()
-	service.Refresh()
-
-	require.Equal(t, "12345", receiveFetch(t, fetcher).clientContext.UserID)
 }
 
-func TestServiceUsesLocalStateRetryWithoutAdvancingFetchBackoff(t *testing.T) {
-	clock := newFakeClock(time.Now())
-	fetcher := newScriptedFetcher()
-	service := newTestService(t, clock, fetcher, func() ClientContext { return testClientContext() })
-	service.store.path = t.TempDir()
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	service.Start(ctx)
-
-	receiveFetch(t, fetcher)
-	fetcher.results <- fetchResult{response: wire.UserMessageResponse{
-		PollIntervalSeconds: 60,
-		Message:             testMessage("display-1", clock.Now().Add(time.Hour)),
-	}}
-	require.Equal(t, localStateRetryInterval, receiveTimer(t, clock))
-	clock.Advance(localStateRetryInterval)
+func TestServiceRefreshDuringBackoff(t *testing.T) {
+	service, fetcher, _ := startService(t, testClientContext())
 
 	receiveFetch(t, fetcher)
 	fetcher.results <- fetchResult{err: errors.New("offline")}
-	require.Equal(t, initialFailureBackoff, receiveTimer(t, clock))
+
+	// The loop is now parked on the default ladder, whose first rung is far
+	// longer than this test waits.
+	requireNoFetch(t, fetcher)
+	service.Refresh()
+	receiveFetch(t, fetcher)
 }
 
-func TestServiceLogsSafeFetchOutcomes(t *testing.T) {
-	clock := newFakeClock(time.Now())
+func TestServiceSafeLogging(t *testing.T) {
+	useFailureBackoff(t, immediateBackoff{})
 	fetcher := newScriptedFetcher()
-	var logs bytes.Buffer
+	var logs safeBuffer
 	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	service, err := New(Options{
 		DataDir:         t.TempDir(),
 		Fetcher:         fetcher,
 		ContextProvider: func() ClientContext { return testClientContext() },
-		Clock:           clock,
-		Jitter:          func(delay time.Duration) time.Duration { return delay },
 		Logger:          logger,
 	})
 	require.NoError(t, err)
@@ -297,40 +250,30 @@ func TestServiceLogsSafeFetchOutcomes(t *testing.T) {
 
 	receiveFetch(t, fetcher)
 	fetcher.results <- fetchResult{err: &httpStatusError{statusCode: http.StatusUnauthorized}}
-	require.Equal(t, 5*time.Second, receiveTimer(t, clock))
-	require.Contains(t, logs.String(), "category=authentication")
-	require.Contains(t, logs.String(), "http_status=401")
+	requireLogContains(t, &logs, "category=authentication")
+	requireLogContains(t, &logs, "http_status=401")
+	service.Refresh()
 
-	clock.Advance(5 * time.Second)
 	receiveFetch(t, fetcher)
 	fetcher.results <- fetchResult{response: wire.UserMessageResponse{
 		PollIntervalSeconds: 300,
-		Message:             testMessage("display-1", clock.Now().Add(time.Hour)),
+		Message:             testMessage("display-1", time.Now().Add(time.Hour)),
 	}}
-	require.Equal(t, 5*time.Minute, receiveTimer(t, clock))
-	require.Contains(t, logs.String(), "result=message_available")
+	requireLogContains(t, &logs, "result=message_available")
 	require.NotContains(t, logs.String(), "12345")
 	require.NotContains(t, logs.String(), "secret-token")
 	require.NotContains(t, logs.String(), "A safe localized message")
 }
 
-func TestServiceStopsAfterParentContextCancellation(t *testing.T) {
-	clock := newFakeClock(time.Now())
+func TestServiceStopsOnCancel(t *testing.T) {
 	fetcher := newScriptedFetcher()
-	service := newTestService(t, clock, fetcher, func() ClientContext { return testClientContext() })
+	service := newTestService(t, fetcher, func() ClientContext { return testClientContext() })
 	ctx, cancel := context.WithCancel(context.Background())
 	service.Start(ctx)
 	receiveFetch(t, fetcher)
 	cancel()
 
-	require.Never(t, func() bool {
-		select {
-		case <-fetcher.requests:
-			return true
-		default:
-			return false
-		}
-	}, 50*time.Millisecond, time.Millisecond)
+	requireNoFetch(t, fetcher)
 }
 
 func TestContextNormalization(t *testing.T) {
@@ -338,23 +281,6 @@ func TestContextNormalization(t *testing.T) {
 	require.Equal(t, "windows", NormalizePlatform(" Windows "))
 	require.Equal(t, "fa-IR", NormalizeLocale("fa-ir"))
 	require.Equal(t, "en-US", NormalizeLocale("not a locale"))
-}
-
-func TestFailureJitterAndBackoffCap(t *testing.T) {
-	for range 100 {
-		delay := defaultJitter(5 * time.Minute)
-		require.GreaterOrEqual(t, delay, 270*time.Second)
-		require.LessOrEqual(t, delay, 5*time.Minute)
-	}
-	require.Equal(t, 5*time.Minute, failureBackoff(100))
-}
-
-func TestServiceRequiresDataDirectory(t *testing.T) {
-	_, err := New(Options{
-		Fetcher:         newScriptedFetcher(),
-		ContextProvider: func() ClientContext { return testClientContext() },
-	})
-	require.EqualError(t, err, "user-message data directory is required")
 }
 
 type fetchCall struct {
@@ -399,18 +325,49 @@ func (f *scriptedFetcher) Fetch(
 
 func newTestService(
 	t *testing.T,
-	clock Clock,
 	fetcher Fetcher,
 	provider func() ClientContext,
+) *Service {
+	t.Helper()
+	return newTestServiceWithLogger(t, fetcher, provider, slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+// startService returns a started service and its scripted fetcher, with the
+// client context seeded to initial. setContext mutates that context under the
+// provider's lock, for tests that change account or credentials mid-run.
+func startService(t *testing.T, initial ClientContext) (*Service, *scriptedFetcher, func(func(*ClientContext))) {
+	t.Helper()
+	fetcher := newScriptedFetcher()
+	var mu sync.Mutex
+	current := initial
+	service := newTestService(t, fetcher, func() ClientContext {
+		mu.Lock()
+		defer mu.Unlock()
+		return current
+	})
+	setContext := func(mutate func(*ClientContext)) {
+		mu.Lock()
+		mutate(&current)
+		mu.Unlock()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	service.Start(ctx)
+	return service, fetcher, setContext
+}
+
+func newTestServiceWithLogger(
+	t *testing.T,
+	fetcher Fetcher,
+	provider func() ClientContext,
+	logger *slog.Logger,
 ) *Service {
 	t.Helper()
 	service, err := New(Options{
 		DataDir:         t.TempDir(),
 		Fetcher:         fetcher,
 		ContextProvider: provider,
-		Clock:           clock,
-		Jitter:          func(delay time.Duration) time.Duration { return delay },
-		Logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Logger:          logger,
 	})
 	require.NoError(t, err)
 	return service
@@ -427,70 +384,87 @@ func receiveFetch(t *testing.T, fetcher *scriptedFetcher) fetchCall {
 	}
 }
 
-func receiveTimer(t *testing.T, clock *fakeClock) time.Duration {
+func requireNoFetch(t *testing.T, fetcher *scriptedFetcher) {
+	t.Helper()
+	require.Never(t, func() bool {
+		select {
+		case <-fetcher.requests:
+			return true
+		default:
+			return false
+		}
+	}, 50*time.Millisecond, time.Millisecond)
+}
+
+func requireLogContains(t *testing.T, logs interface{ String() string }, substring string) {
+	t.Helper()
+	require.Eventuallyf(t, func() bool {
+		return strings.Contains(logs.String(), substring)
+	}, time.Second, time.Millisecond, "logs:\n%s", logs.String())
+}
+
+func requireCurrentDisplayID(t *testing.T, service *Service, displayID string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		message, err := service.Current()
+		return err == nil && message != nil && message.DisplayID == displayID
+	}, time.Second, time.Millisecond)
+}
+
+func useFailureBackoff(t *testing.T, backoff failureBackoff) {
+	t.Helper()
+	previous := newFailureBackoff
+	newFailureBackoff = func() failureBackoff { return backoff }
+	t.Cleanup(func() { newFailureBackoff = previous })
+}
+
+type immediateBackoff struct{}
+
+func (immediateBackoff) WaitOn(context.Context, <-chan struct{}) {}
+func (immediateBackoff) Reset()                                  {}
+
+type recordingBackoff struct {
+	calls chan string
+}
+
+func newRecordingBackoff() *recordingBackoff {
+	return &recordingBackoff{calls: make(chan string, 16)}
+}
+
+func (b *recordingBackoff) WaitOn(context.Context, <-chan struct{}) { b.calls <- "wait" }
+
+func (b *recordingBackoff) Reset() { b.calls <- "reset" }
+
+func receiveBackoffCall(t *testing.T, backoff *recordingBackoff) string {
 	t.Helper()
 	select {
-	case delay := <-clock.created:
-		return delay
+	case call := <-backoff.calls:
+		return call
 	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for timer")
-		return 0
+		t.Fatal("timed out waiting for backoff call")
+		return ""
 	}
 }
 
-type fakeClock struct {
-	mu      sync.Mutex
-	now     time.Time
-	timers  []*fakeTimer
-	created chan time.Duration
+type safeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
 }
 
-func newFakeClock(now time.Time) *fakeClock {
-	return &fakeClock{now: now, created: make(chan time.Duration, 16)}
+func (b *safeBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
 }
 
-func (c *fakeClock) Now() time.Time {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.now
+func (b *safeBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }
 
-func (c *fakeClock) NewTimer(delay time.Duration) Timer {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	timer := &fakeTimer{clock: c, due: c.now.Add(delay), ch: make(chan time.Time, 1)}
-	c.timers = append(c.timers, timer)
-	c.created <- delay
-	return timer
-}
-
-func (c *fakeClock) Advance(delay time.Duration) {
-	c.mu.Lock()
-	c.now = c.now.Add(delay)
-	now := c.now
-	for _, timer := range c.timers {
-		if !timer.stopped && !timer.fired && !timer.due.After(now) {
-			timer.fired = true
-			timer.ch <- now
-		}
-	}
-	c.mu.Unlock()
-}
-
-type fakeTimer struct {
-	clock   *fakeClock
-	due     time.Time
-	ch      chan time.Time
-	stopped bool
-	fired   bool
-}
-
-func (t *fakeTimer) C() <-chan time.Time { return t.ch }
-
-func (t *fakeTimer) Stop() bool {
-	t.clock.mu.Lock()
-	defer t.clock.mu.Unlock()
-	wasActive := !t.stopped && !t.fired
-	t.stopped = true
-	return wasActive
+func (b *safeBuffer) Reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buf.Reset()
 }


### PR DESCRIPTION
## Summary

Redesigns the user-message polling loop, replacing the `Clock`/`Timer` test seam and the `refreshGeneration`/`requestID` bookkeeping with a simpler loop built on a wake-aware `common.Backoff`.

## Changes

- **`common.Backoff`**: adds `WaitOn(ctx, wake)` (with `Wait` delegating to it) so a wait can be interrupted by a refresh signal, and splits the retry-curve computation into a pure `nextDelay(random)`. Adds the first unit tests for `common.Backoff`.
- **Polling loop**: honors the server `poll_interval_seconds` verbatim, rides the failure backoff when credentials are unavailable (recovering on its own with no wake signal), and cancels the in-flight fetch on `Refresh` so an account/context change is picked up immediately rather than after the current request returns.
- Removes the exported `Clock`/`Jitter` options, the bespoke exponential `failureBackoff` ladder, and the `refreshGeneration`/`requestID`/credential-recheck machinery.

## Testing

- Regression guards added for: credential self-recovery (with and without a refresh), stale-context discard, refresh-cancels-in-flight, and acknowledged-message reoffer.

