### PR TITLE
feat(vpn): pause domain fronting while the network is unavailable

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -461,6 +461,14 @@ func (r *LocalBackend) startVPNStatusListeners() {
 	events.SubscribeContext(r.ctx, func(vpn.ExhaustionEvent) {
 		r.refetchOnExhaustion()
 	})
+	events.SubscribeContext(r.ctx, func(evt vpn.NetworkEvent) {
+		switch evt.EventType {
+		case vpn.NetworkEventPaused:
+			kindling.Pause()
+		case vpn.NetworkEventWake:
+			kindling.Resume()
+		}
+	})
 	events.SubscribeContext(r.ctx, func(evt vpn.StatusUpdateEvent) {
 		switch evt.Status {
 		case vpn.Disconnected, vpn.ErrorStatus, vpn.Restarting:

--- a/kindling/client.go
+++ b/kindling/client.go
@@ -121,7 +121,33 @@ func Close() error {
 	return nil
 }
 
+// Pause suspends background work in the shared kindling instance's pausable
+// transports. No-op if kindling isn't initialized. Safe to call while paused.
+func Pause() {
+	mu.Lock()
+	defer mu.Unlock()
+	if k != nil {
+		k.Pause()
+	}
+}
+
+// Resume restarts the background work suspended by Pause. No-op if kindling
+// isn't initialized.
+func Resume() {
+	mu.Lock()
+	defer mu.Unlock()
+	if k != nil {
+		k.Resume()
+	}
+}
+
 const tracerName = "github.com/getlantern/radiance/kindling"
+
+// pausable is a transport whose background work can be suspended and resumed.
+type pausable interface {
+	Pause()
+	Resume()
+}
 
 // Client is a kindling instance together with the transport resources its
 // construction created (config updaters, fronted/dnstt state).
@@ -129,7 +155,23 @@ type Client struct {
 	kindling.Kindling
 	cancel    context.CancelFunc
 	closers   []func() error
+	pausers   []pausable
 	closeOnce sync.Once
+}
+
+// Pause suspends the pausable transports' background work. Safe to call while
+// paused; a matching Resume restarts them.
+func (c *Client) Pause() {
+	for _, p := range c.pausers {
+		p.Pause()
+	}
+}
+
+// Resume restarts the background work suspended by Pause.
+func (c *Client) Resume() {
+	for _, p := range c.pausers {
+		p.Resume()
+	}
 }
 
 // Close cancels the transports' config updaters and releases their resources.
@@ -179,6 +221,7 @@ func NewKindling(dataDir string) (*Client, error) {
 	}
 
 	var closers []func() error
+	var pausers []pausable
 	kindlingOptions := []kindling.Option{
 		kindling.WithPanicListener(reporting.PanicListener),
 		kindling.WithLogWriter(logger),
@@ -195,6 +238,7 @@ func NewKindling(dataDir string) (*Client, error) {
 		}
 		if f != nil {
 			closers = append(closers, func() error { f.Close(); return nil })
+			pausers = append(pausers, f)
 			kindlingOptions = append(kindlingOptions, kindling.WithDomainFronting(f))
 		}
 	}
@@ -237,7 +281,7 @@ func NewKindling(dataDir string) (*Client, error) {
 		}
 		return nil, errors.Join(errs...)
 	}
-	return &Client{Kindling: newK, cancel: cancel, closers: closers}, nil
+	return &Client{Kindling: newK, cancel: cancel, closers: closers, pausers: pausers}, nil
 }
 
 type slogWriter struct {

--- a/kindling/client_test.go
+++ b/kindling/client_test.go
@@ -46,3 +46,27 @@ func TestNewClient(t *testing.T) {
 		})
 	}
 }
+
+type fakePausable struct{ paused, resumed int }
+
+func (f *fakePausable) Pause()  { f.paused++ }
+func (f *fakePausable) Resume() { f.resumed++ }
+
+func TestClientPauseResumeDelegates(t *testing.T) {
+	p := &fakePausable{}
+	c := &Client{pausers: []pausable{p}}
+
+	c.Pause()
+	c.Pause()
+	c.Resume()
+
+	assert.Equal(t, 2, p.paused)
+	assert.Equal(t, 1, p.resumed)
+}
+
+func TestClientPauseResumeNoPausers(t *testing.T) {
+	c := &Client{}
+	// Must not panic with no pausable transports (e.g. the staging, proxyless build).
+	c.Pause()
+	c.Resume()
+}

--- a/vpn/pause_test.go
+++ b/vpn/pause_test.go
@@ -1,0 +1,52 @@
+package vpn
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sagernet/sing/service/pause"
+	"github.com/stretchr/testify/require"
+
+	"github.com/getlantern/radiance/events"
+)
+
+func TestOnPauseUpdate(t *testing.T) {
+	// want == "" means no NetworkEvent should be emitted.
+	cases := []struct {
+		name string
+		evt  int
+		want NetworkEventType
+	}{
+		{"device paused", pause.EventDevicePaused, NetworkEventPaused},
+		{"network paused", pause.EventNetworkPause, NetworkEventPaused},
+		{"network wake", pause.EventNetworkWake, NetworkEventWake},
+		{"device wake ignored", pause.EventDeviceWake, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			got := make(chan NetworkEventType, 1)
+			events.SubscribeContext(ctx, func(evt NetworkEvent) { got <- evt.EventType })
+
+			(&tunnel{}).onPauseUpdate(tc.evt)
+
+			if tc.want == "" {
+				select {
+				case ev := <-got:
+					t.Fatalf("expected no NetworkEvent, got %q", ev)
+				case <-time.After(100 * time.Millisecond):
+				}
+				return
+			}
+			select {
+			case ev := <-got:
+				require.Equal(t, tc.want, ev)
+			case <-time.After(2 * time.Second):
+				t.Fatal("no NetworkEvent emitted")
+			}
+		})
+	}
+}

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -21,6 +21,7 @@ import (
 	O "github.com/sagernet/sing-box/option"
 	"github.com/sagernet/sing/common/json"
 	"github.com/sagernet/sing/service"
+	"github.com/sagernet/sing/service/pause"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -305,6 +306,23 @@ func (t *tunnel) connect(ctx context.Context) (err error) {
 	t.clashServer = service.FromContext[adapter.ClashServer](t.ctx).(*clashServer)
 	t.outboundMgr = service.FromContext[adapter.OutboundManager](t.ctx)
 	t.clashServer.connTracker.SetObserver(t.connObserver)
+	if pm := service.FromContext[pause.Manager](t.ctx); pm != nil {
+		cb := pm.RegisterCallback(t.onPauseUpdate)
+		// A pause can already be in effect before this registration, so seed it
+		// once. Only the paused case is emitted: not emitting a wake keeps this
+		// off-lock read from racing a real pause into the wrong final state.
+		if pm.IsDevicePaused() || pm.IsNetworkPaused() {
+			events.Emit(NetworkEvent{EventType: NetworkEventPaused})
+		}
+		t.closers = append(t.closers, closerFunc(func() error {
+			pm.UnregisterCallback(cb)
+			// No further events arrive after unregister, so force a wake to release
+			// a consumer left paused at teardown. UnregisterCallback serializes
+			// with in-flight callbacks via the manager lock, so this wake lands last.
+			events.Emit(NetworkEvent{EventType: NetworkEventWake})
+			return nil
+		}))
+	}
 
 	if common.IsIOS() {
 		// Only iOS enforces a hard memory cap, so only it gets reclaim and
@@ -332,6 +350,18 @@ func (t *tunnel) connect(ctx context.Context) (err error) {
 
 	slog.Info("Tunnel connection established")
 	return nil
+}
+
+// onPauseUpdate mirrors the pause manager's transitions onto NetworkEvent.
+// Only NetworkWake emits a wake: it confirms the default route is back, whereas
+// a DeviceWake says only that the device resumed.
+func (t *tunnel) onPauseUpdate(evt int) {
+	switch evt {
+	case pause.EventDevicePaused, pause.EventNetworkPause:
+		events.Emit(NetworkEvent{EventType: NetworkEventPaused})
+	case pause.EventNetworkWake:
+		events.Emit(NetworkEvent{EventType: NetworkEventWake})
+	}
 }
 
 // subscribeExhaustionSignal bridges the auto group's exhaustion

--- a/vpn/types.go
+++ b/vpn/types.go
@@ -24,6 +24,24 @@ type ExhaustionEvent struct {
 	events.Event
 }
 
+// NetworkEventType is the availability state carried by a NetworkEvent.
+type NetworkEventType string
+
+const (
+	// NetworkEventPaused means the network is unusable: no default route, or the
+	// device suspended.
+	NetworkEventPaused NetworkEventType = "network_paused"
+	// NetworkEventWake means the default route is back.
+	NetworkEventWake NetworkEventType = "network_wake"
+)
+
+// NetworkEvent reports a change in network availability derived from the tunnel's
+// pause manager.
+type NetworkEvent struct {
+	events.Event
+	EventType NetworkEventType `json:"event_type"`
+}
+
 // Selector is helper interface to check if an outbound is a selector or wrapper of selector.
 type Selector interface {
 	adapter.OutboundGroup


### PR DESCRIPTION
## What

Wires the box's pause manager to suspend the domainfront front crawler while there is no usable network, so it stops sweeping and mark-failing the whole front pool when the default interface disappears.

- `vpn/tunnel.go` registers a pause-manager callback at connect. `onPauseUpdate` mirrors transitions onto a `NetworkEvent`: **pause** on either `EventDevicePaused`/`EventNetworkPause`, **wake** only on `EventNetworkWake` — `NetworkWake` is the authoritative "default route is back" signal, whereas `DeviceWake` only says the device resumed, so resuming on it could restart work into a still-dead network.
- An initial sync seeds the paused state at connect (a pause can already be in effect before registration); a forced wake at teardown keeps kindling from being left paused after the tunnel closes.
- `backend` subscribes to `NetworkEvent` and calls `kindling.Pause()` / `kindling.Resume()`.
- `kindling` exposes package-level `Pause` / `Resume` delegating to its pausable transports (the domainfront client).

## Why

Addresses the domainfront crawler's no-backoff, no-deadline sweeps exhausting host ephemeral ports on Windows when the default interface disappears — black-holing all host networking while the app still shows "Connected". The pause manager fires `NetworkPause` on exactly that "missing default interface" condition, so gating the crawler on it closes the observed trigger.

## Requires domainfront changes first — do not merge yet

This branch calls a new `Pause` / `Resume` API on `domainfront.Client` that is not in the pinned dependency yet. **It does not build until the domainfront PR is merged and `go.mod` is bumped to that version.** Keep as draft until then.

domainfront PR: _to follow (pending push access)._

## Scope

This is the interface-churn gate. The crawler's own hardening — backoff, per-round deadline, failure quarantine — is a separate follow-up in domainfront for the routed-but-blocked case.

closes https://github.com/getlantern/engineering/issues/3873


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network pause and wake events now automatically pause and resume network-dependent services.
  * Existing paused states are recognized when connecting, with appropriate state updates during teardown.

* **Bug Fixes**
  * Prevents network-dependent activity from continuing while the VPN network is paused.

* **Tests**
  * Added coverage for pause, wake, event propagation, and safe no-op behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->