### PR TITLE
fix(vpn): set NoDrop on reject rule action

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 
 - Prefer clearer names and smaller functions over explanatory comments.
 - Delete or shorten verbose comments in code you touch.
+- A comment that documents a real invariant, race, or rationale still fails if it includes more detail than needed to preserve that contract.
 - Do not narrate code, repeat the identifier, list visible branches, mention tickets/people, or praise the implementation.
 - Documentation should only document the declaration's own contract: side effects, blocking/zero-value behavior, errors, ownership, cancellation, concurrency, or surprising pre/postconditions.
 - Document the caller-relevant semantics of a sentinel error, enum, status, or constant — retryability, permanence, lifecycle — as the value's own contract, phrased as what it means rather than advice: prefer "retryable only after …" over "callers should …". The consumer behavior to avoid is a separate component's policy, not the meaning of a value callers inspect.

--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -613,7 +613,6 @@ func rejectRule(rule O.RawDefaultRule) O.Rule {
 				Action: C.RuleActionTypeReject,
 				RejectOptions: O.RejectActionOptions{
 					Method: C.RuleActionRejectMethodDefault,
-					NoDrop: true,
 				},
 			},
 		},
@@ -634,7 +633,9 @@ func highMemoryRejectRule() O.Rule {
 // RST) makes Happy Eyeballs fail over at once; "drop" would blackhole and stall.
 // Must be appended after the direct-routing rules so intentionally-direct v6 is kept.
 func rejectIPv6Rule() O.Rule {
-	return rejectRule(O.RawDefaultRule{IPCIDR: []string{"::/0"}})
+	rule := rejectRule(O.RawDefaultRule{IPCIDR: []string{"::/0"}})
+	rule.DefaultOptions.RuleAction.RejectOptions.NoDrop = true
+	return rule
 }
 
 func newDNSServerOptions(typ, tag, server, domainResolver string) O.DNSServerOptions {

--- a/vpn/boxoptions.go
+++ b/vpn/boxoptions.go
@@ -613,6 +613,7 @@ func rejectRule(rule O.RawDefaultRule) O.Rule {
 				Action: C.RuleActionTypeReject,
 				RejectOptions: O.RejectActionOptions{
 					Method: C.RuleActionRejectMethodDefault,
+					NoDrop: true,
 				},
 			},
 		},

--- a/vpn/boxoptions_test.go
+++ b/vpn/boxoptions_test.go
@@ -526,6 +526,8 @@ func TestRejectIPv6Rule(t *testing.T) {
 	assert.Equal(t, []string{"::/0"}, []string(r.DefaultOptions.RawDefaultRule.IPCIDR))
 	assert.NotEqual(t, C.RuleActionRejectMethodDrop, r.DefaultOptions.RuleAction.RejectOptions.Method,
 		"must not use the drop method — a silent blackhole stalls instead of failing over to IPv4")
+	assert.True(t, r.DefaultOptions.RuleAction.RejectOptions.NoDrop,
+		"NoDrop must be set so the reject returns unreachable instead of dropping")
 }
 
 func TestTunHasIPv6(t *testing.T) {


### PR DESCRIPTION
## Summary

- Set `NoDrop: true` on the reject rule's `RejectActionOptions` in `vpn/boxoptions.go`, so rejected connections return an explicit unreachable response rather than being silently dropped.
- Add a comment-guidance line to `AGENTS.md` on keeping invariant/rationale comments to the minimum detail needed to preserve the contract.

closes https://github.com/getlantern/engineering/issues/3828

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Rejected IPv6 traffic now returns an unreachable response instead of being silently dropped.
  - Catch-all and high-memory rejection rules now follow the standard default behavior, rather than forcing non-drop handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->