### PR TITLE
feat(vpn): recover the tunnel from a latched network pause

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -1398,6 +1398,15 @@ func (r *LocalBackend) RestartVPN() error {
 	return r.vpnClient.Restart(bOptions)
 }
 
+// ResetNetwork drops the VPN's connections and re-seeds its interface state.
+func (r *LocalBackend) ResetNetwork() { r.vpnClient.ResetNetwork() }
+
+// Pause pauses the VPN for a device sleep.
+func (r *LocalBackend) Pause() { r.vpnClient.Pause() }
+
+// Wake wakes the VPN after a device sleep.
+func (r *LocalBackend) Wake() { r.vpnClient.Wake() }
+
 // SelectServer selects the server identified by tag. The empty string is treated as [vpn.AutoSelectTag].
 func (r *LocalBackend) SelectServer(tag string) error {
 	if tag == "" {

--- a/common/backoff.go
+++ b/common/backoff.go
@@ -30,20 +30,32 @@ func NewBackoff(baseWait, maxWait time.Duration) *Backoff {
 
 // Wait pauses for the next backoff interval or returns early if the context is done.
 func (b *Backoff) Wait(ctx context.Context) {
+	b.WaitOn(ctx, nil)
+}
+
+// WaitOn pauses for the next backoff interval, returning early if ctx is done or
+// a value is received on wake. An early wake still advances the interval; an
+// already-cancelled ctx does not.
+func (b *Backoff) WaitOn(ctx context.Context, wake <-chan struct{}) {
 	if ctx.Err() != nil {
 		return
 	}
 
-	b.n++
-	wait := b.baseWait * time.Duration(b.n*b.n)
-
-	// add jitter between 80% and 120% of wait time to avoid thundering herd
-	jitter := 0.8 + 0.4*rand.Float64()
-	wait = min(b.maxWait, time.Duration(float64(wait)*jitter))
+	wait := b.nextDelay(rand.Float64())
 	select {
 	case <-ctx.Done():
+	case <-wake:
 	case <-time.After(wait):
 	}
+}
+
+// nextDelay counts a failure and returns the interval to wait for it, jittered
+// by random (expected in [0, 1]), capped at maxWait.
+func (b *Backoff) nextDelay(random float64) time.Duration {
+	b.n++
+	wait := b.baseWait * time.Duration(b.n*b.n)
+	jitter := 0.8 + 0.4*random
+	return min(b.maxWait, time.Duration(float64(wait)*jitter))
 }
 
 // Reset resets the backoff counter.

--- a/common/backoff_test.go
+++ b/common/backoff_test.go
@@ -1,0 +1,63 @@
+package common
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackoffNextDelay(t *testing.T) {
+	backoff := NewBackoff(time.Second, time.Minute)
+	for _, expected := range []time.Duration{
+		1 * time.Second,
+		4 * time.Second,
+		9 * time.Second,
+		16 * time.Second,
+		25 * time.Second,
+		36 * time.Second,
+		49 * time.Second,
+		time.Minute,
+		time.Minute,
+	} {
+		require.Equal(t, expected, backoff.nextDelay(0.5))
+	}
+
+	backoff.Reset()
+	require.Equal(t, time.Second, backoff.nextDelay(0.5))
+}
+
+func TestBackoffNextDelayJitter(t *testing.T) {
+	require.Equal(t, 800*time.Millisecond, NewBackoff(time.Second, time.Minute).nextDelay(0))
+	require.Equal(t, time.Second, NewBackoff(time.Second, time.Minute).nextDelay(0.5))
+	require.Equal(t, 1200*time.Millisecond, NewBackoff(time.Second, time.Minute).nextDelay(1))
+
+	// Jitter cannot push a wait past maxWait.
+	require.Equal(t, time.Minute, NewBackoff(time.Minute, time.Minute).nextDelay(1))
+}
+
+func TestBackoffDefaultBaseWait(t *testing.T) {
+	require.Equal(t, defaultBaseWait, NewBackoff(0, time.Minute).nextDelay(0.5))
+	require.Equal(t, defaultBaseWait, NewBackoff(-time.Second, time.Minute).nextDelay(0.5))
+}
+
+func TestBackoffWaitOnDoneContextDoesNotCountFailure(t *testing.T) {
+	backoff := NewBackoff(time.Second, time.Minute)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	backoff.Wait(ctx)
+	require.Equal(t, time.Second, backoff.nextDelay(0.5))
+}
+
+func TestBackoffWaitOnReturnsOnWake(t *testing.T) {
+	// A wait long enough that only the wake channel can end it.
+	backoff := NewBackoff(time.Hour, time.Hour)
+	wake := make(chan struct{}, 1)
+	wake <- struct{}{}
+
+	started := time.Now()
+	backoff.WaitOn(context.Background(), wake)
+	require.Less(t, time.Since(started), time.Second)
+}

--- a/ipc/client.go
+++ b/ipc/client.go
@@ -138,6 +138,24 @@ func (c *Client) RestartVPN(ctx context.Context) error {
 	return err
 }
 
+// ResetNetwork asks the daemon to drop VPN connections and re-seed interface state.
+func (c *Client) ResetNetwork(ctx context.Context) error {
+	_, err := c.do(ctx, http.MethodPost, vpnResetNetworkEndpoint, nil)
+	return err
+}
+
+// Pause asks the daemon to pause the VPN for a device sleep.
+func (c *Client) Pause(ctx context.Context) error {
+	_, err := c.do(ctx, http.MethodPost, vpnPauseEndpoint, nil)
+	return err
+}
+
+// Wake asks the daemon to wake the VPN after a device sleep.
+func (c *Client) Wake(ctx context.Context) error {
+	_, err := c.do(ctx, http.MethodPost, vpnWakeEndpoint, nil)
+	return err
+}
+
 // VPNConnections returns the active VPN connections.
 func (c *Client) VPNConnections(ctx context.Context) ([]vpn.Connection, error) {
 	var conns []vpn.Connection

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -42,6 +42,9 @@ const (
 	vpnStatusEventsEndpoint     = "/vpn/status/events"
 	vpnSessionsEndpoint         = "/vpn/sessions"
 	vpnClearTunnelCacheEndpoint = "/vpn/cache/clear"
+	vpnResetNetworkEndpoint     = "/vpn/network/reset"
+	vpnPauseEndpoint            = "/vpn/pause"
+	vpnWakeEndpoint             = "/vpn/wake"
 
 	// Server selection endpoints
 	serverSelectedEndpoint           = "/server/selected"
@@ -223,6 +226,9 @@ func newLocalAPI(b *backend.LocalBackend, withAuth bool) *localapi {
 	mux.HandleFunc("POST "+vpnOfflineTestsEndpoint, traced(s.vpnOfflineTestsHandler))
 	mux.HandleFunc("GET "+vpnSessionsEndpoint, traced(s.vpnSessionsHandler))
 	mux.HandleFunc("POST "+vpnClearTunnelCacheEndpoint, traced(s.vpnClearTunnelCacheHandler))
+	mux.HandleFunc("POST "+vpnResetNetworkEndpoint, traced(s.vpnResetNetworkHandler))
+	mux.HandleFunc("POST "+vpnPauseEndpoint, traced(s.vpnPauseHandler))
+	mux.HandleFunc("POST "+vpnWakeEndpoint, traced(s.vpnWakeHandler))
 
 	// SSE routes skip the tracer middleware since it buffers the entire response body.
 	mux.HandleFunc("GET "+vpnStatusEventsEndpoint, s.vpnStatusEventsHandler)
@@ -403,6 +409,21 @@ func (s *localapi) vpnRestartHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *localapi) vpnResetNetworkHandler(w http.ResponseWriter, r *http.Request) {
+	s.backend(r.Context()).ResetNetwork()
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *localapi) vpnPauseHandler(w http.ResponseWriter, r *http.Request) {
+	s.backend(r.Context()).Pause()
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *localapi) vpnWakeHandler(w http.ResponseWriter, r *http.Request) {
+	s.backend(r.Context()).Wake()
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/vpn/recovery.go
+++ b/vpn/recovery.go
@@ -28,7 +28,6 @@ type boxNetwork interface {
 }
 
 // netRecovery re-polls interfaces while the pause manager reports the network paused.
-// When the interface list transitions from empty to non-empty, it resets the network once and disarms.
 type netRecovery struct {
 	network       boxNetwork
 	networkPaused func() bool // authoritative pause state
@@ -96,7 +95,6 @@ func (r *netRecovery) run(ctx context.Context) {
 			}
 			if r.attempt() {
 				slog.Debug("Network recovery: interfaces returned, network reset")
-				break
 			}
 		}
 	}

--- a/vpn/recovery.go
+++ b/vpn/recovery.go
@@ -15,9 +15,6 @@ const (
 	// attempts while the network stays paused.
 	recoveryBaseWait = 3 * time.Second
 	recoveryMaxWait  = 30 * time.Second
-	// recoveryStopTimeout bounds how long stop waits for an in-flight attempt so
-	// teardown cannot hang on one.
-	recoveryStopTimeout = 5 * time.Second
 )
 
 // boxNetwork is the subset of the box's network manager that netRecovery drives.
@@ -116,11 +113,7 @@ func (r *netRecovery) attempt() (recovered bool) {
 	return false
 }
 
-// stop waits for an in-flight attempt to finish. The caller must cancel run's
-// context first; stop only bounds the wait so teardown cannot hang.
+// stop waits for run to exit after its context is canceled.
 func (r *netRecovery) stop() {
-	select {
-	case <-r.done:
-	case <-time.After(recoveryStopTimeout):
-	}
+	<-r.done
 }

--- a/vpn/recovery.go
+++ b/vpn/recovery.go
@@ -27,14 +27,8 @@ type boxNetwork interface {
 	ResetNetwork()
 }
 
-// netRecovery re-seeds the interface list while the network stays paused.
-//
-// A platform default-interface monitor can report an unsatisfied path and then
-// never fire again, leaving the box network-paused with no default route. A dial
-// falls back to the interface list when there is no default interface, so while
-// paused netRecovery re-polls that list on a backoff to surface a route that
-// returned without a fresh platform callback. On the empty→refilled transition it
-// resets the network once to rebind stale connections, then stops.
+// netRecovery re-polls interfaces while the pause manager reports the network paused.
+// When the interface list transitions from empty to non-empty, it resets the network once and disarms.
 type netRecovery struct {
 	network       boxNetwork
 	networkPaused func() bool // authoritative pause state

--- a/vpn/recovery.go
+++ b/vpn/recovery.go
@@ -1,0 +1,134 @@
+package vpn
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/sagernet/sing-box/adapter"
+
+	"github.com/getlantern/radiance/common"
+)
+
+const (
+	// recoveryBaseWait and recoveryMaxWait bound the interval between re-poll
+	// attempts while the network stays paused.
+	recoveryBaseWait = 3 * time.Second
+	recoveryMaxWait  = 30 * time.Second
+	// recoveryStopTimeout bounds how long stop waits for an in-flight attempt so
+	// teardown cannot hang on one.
+	recoveryStopTimeout = 5 * time.Second
+)
+
+// boxNetwork is the subset of the box's network manager that netRecovery drives.
+type boxNetwork interface {
+	UpdateInterfaces() error
+	NetworkInterfaces() []adapter.NetworkInterface
+	ResetNetwork()
+}
+
+// netRecovery re-seeds the interface list while the network stays paused.
+//
+// A platform default-interface monitor can report an unsatisfied path and then
+// never fire again, leaving the box network-paused with no default route. A dial
+// falls back to the interface list when there is no default interface, so while
+// paused netRecovery re-polls that list on a backoff to surface a route that
+// returned without a fresh platform callback. On the empty→refilled transition it
+// resets the network once to rebind stale connections, then stops.
+type netRecovery struct {
+	network       boxNetwork
+	networkPaused func() bool // authoritative pause state
+	backoff       *common.Backoff
+	armCh         chan struct{}
+	wakeCh        chan struct{}
+	done          chan struct{}
+}
+
+func newNetRecovery(network boxNetwork, networkPaused func() bool) *netRecovery {
+	return &netRecovery{
+		network:       network,
+		networkPaused: networkPaused,
+		backoff:       common.NewBackoff(recoveryBaseWait, recoveryMaxWait),
+		armCh:         make(chan struct{}, 1),
+		wakeCh:        make(chan struct{}, 1),
+		done:          make(chan struct{}),
+	}
+}
+
+// pause wakes the loop to start recovering. Safe from the pause callback; never blocks.
+func (r *netRecovery) pause() {
+	select {
+	case r.armCh <- struct{}{}:
+	default:
+	}
+}
+
+// wake interrupts a backoff wait so the loop re-checks the pause state. Safe from
+// the pause callback; never blocks.
+func (r *netRecovery) wake() {
+	select {
+	case r.wakeCh <- struct{}{}:
+	default:
+	}
+}
+
+// run drives recovery until ctx is cancelled.
+func (r *netRecovery) run(ctx context.Context) {
+	defer close(r.done)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-r.armCh:
+		}
+		// Drop a stale wake so the first attempt honors the full base interval,
+		// letting a transient pause clear before we act.
+		select {
+		case <-r.wakeCh:
+		default:
+		}
+		if r.networkPaused() {
+			slog.Debug("Network recovery: network paused, re-polling interfaces")
+		}
+		r.backoff.Reset()
+		for r.networkPaused() {
+			r.backoff.WaitOn(ctx, r.wakeCh)
+			if ctx.Err() != nil {
+				return
+			}
+			if !r.networkPaused() {
+				slog.Debug("Network recovery: network unpaused, stopping")
+				break
+			}
+			if r.attempt() {
+				slog.Debug("Network recovery: interfaces returned, network reset")
+				break
+			}
+		}
+	}
+}
+
+// attempt re-polls interfaces and reports whether the list refilled from empty,
+// resetting the network once when it did so stale connections rebind.
+func (r *netRecovery) attempt() (recovered bool) {
+	had := len(r.network.NetworkInterfaces()) > 0
+	if err := r.network.UpdateInterfaces(); err != nil {
+		slog.Debug("Network recovery: update interfaces failed", "error", err)
+	}
+	now := len(r.network.NetworkInterfaces()) > 0
+	slog.Debug("Network recovery: re-polled interfaces", "had", had, "now", now)
+	if !had && now {
+		r.network.ResetNetwork()
+		return true
+	}
+	return false
+}
+
+// stop waits for an in-flight attempt to finish. The caller must cancel run's
+// context first; stop only bounds the wait so teardown cannot hang.
+func (r *netRecovery) stop() {
+	select {
+	case <-r.done:
+	case <-time.After(recoveryStopTimeout):
+	}
+}

--- a/vpn/recovery_test.go
+++ b/vpn/recovery_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing/service"
+	"github.com/sagernet/sing/service/pause"
 	"github.com/stretchr/testify/require"
 
 	"github.com/getlantern/radiance/common"
@@ -98,6 +100,55 @@ func TestNetRecovery_ResetsOnceWhenInterfacesReturn(t *testing.T) {
 	require.Never(t, func() bool {
 		return net.resets.Load() > 1
 	}, 300*time.Millisecond, 20*time.Millisecond, "must not keep resetting after recovery")
+}
+
+func TestNetRecovery_RecoversAgainWhilePauseRemainsLatched(t *testing.T) {
+	ctx, cancel := context.WithCancel(pause.WithDefaultManager(context.Background()))
+	mgr := service.FromContext[pause.Manager](ctx)
+	net := &fakeNetwork{pending: 1}
+	rec := newTestRecovery(net, mgr.IsNetworkPaused, 10*time.Millisecond, 50*time.Millisecond)
+	var pauseEvents atomic.Int32
+	cb := mgr.RegisterCallback(func(evt int) {
+		switch evt {
+		case pause.EventNetworkPause:
+			pauseEvents.Add(1)
+			rec.pause()
+		case pause.EventNetworkWake:
+			rec.wake()
+		}
+	})
+	go rec.run(ctx)
+	t.Cleanup(func() {
+		cancel()
+		rec.stop()
+		mgr.UnregisterCallback(cb)
+	})
+
+	mgr.NetworkPause()
+	require.Eventually(t, func() bool {
+		return net.resets.Load() == 1
+	}, 2*time.Second, 20*time.Millisecond)
+	require.True(t, mgr.IsNetworkPaused())
+
+	net.setPending(0)
+	mgr.NetworkPause()
+	require.EqualValues(t, 1, pauseEvents.Load())
+	require.Eventually(t, func() bool {
+		return len(net.NetworkInterfaces()) == 0
+	}, 2*time.Second, 20*time.Millisecond, "polling must continue while the pause remains latched")
+	net.setPending(1)
+	require.Eventually(t, func() bool {
+		return net.resets.Load() == 2
+	}, 2*time.Second, 20*time.Millisecond, "a second outage must recover without another pause event")
+	require.Never(t, func() bool {
+		return net.resets.Load() > 2
+	}, 300*time.Millisecond, 20*time.Millisecond, "stable interfaces must not trigger repeated resets")
+
+	mgr.NetworkWake()
+	settled := stableCount(t, net.updates.Load)
+	require.Never(t, func() bool {
+		return net.updates.Load() > settled
+	}, 300*time.Millisecond, 20*time.Millisecond, "an actual network wake must stop polling")
 }
 
 func TestNetRecovery_StopsWhenUnpaused(t *testing.T) {

--- a/vpn/recovery_test.go
+++ b/vpn/recovery_test.go
@@ -49,6 +49,69 @@ func (f *fakeNetwork) setPending(n int) {
 	f.mu.Unlock()
 }
 
+type blockedRecoveryNetwork struct {
+	fakeNetwork
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (n *blockedRecoveryNetwork) UpdateInterfaces() error {
+	close(n.entered)
+	<-n.release
+	return n.fakeNetwork.UpdateInterfaces()
+}
+
+func TestNetRecovery_TunnelCloseWaitsForBlockedUpdate(t *testing.T) {
+	net := &blockedRecoveryNetwork{
+		fakeNetwork: fakeNetwork{pending: 1},
+		entered:     make(chan struct{}),
+		release:     make(chan struct{}),
+	}
+	rec := newTestRecovery(net, alwaysPaused, time.Millisecond, time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	release := sync.OnceFunc(func() { close(net.release) })
+	go rec.run(ctx)
+	t.Cleanup(func() {
+		cancel()
+		release()
+		rec.stop()
+	})
+	rec.pause()
+	select {
+	case <-net.entered:
+	case <-time.After(time.Second):
+		t.Fatal("recovery did not start updating interfaces")
+	}
+
+	closed := make(chan struct{})
+	tn := &tunnel{cancel: cancel, netRecovery: rec, closeTimeout: 20 * time.Millisecond}
+	tn.closers = append(tn.closers, closerFunc(func() error {
+		close(closed)
+		return nil
+	}))
+	closeResult := make(chan error, 1)
+	go func() { closeResult <- tn.close() }()
+	select {
+	case err := <-closeResult:
+		require.ErrorContains(t, err, "timeout waiting for tunnel to close")
+	case <-time.After(time.Second):
+		t.Fatal("tunnel close did not honor its timeout")
+	}
+	select {
+	case <-closed:
+		t.Fatal("box resources closed while recovery was still using them")
+	default:
+	}
+
+	release()
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("box resources did not close after recovery exited")
+	}
+	require.EqualValues(t, 1, net.resets.Load())
+}
+
 func newTestRecovery(net boxNetwork, paused func() bool, base, max time.Duration) *netRecovery {
 	return &netRecovery{
 		network:       net,

--- a/vpn/recovery_test.go
+++ b/vpn/recovery_test.go
@@ -1,0 +1,198 @@
+package vpn
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/stretchr/testify/require"
+
+	"github.com/getlantern/radiance/common"
+)
+
+// fakeNetwork models the box network manager: UpdateInterfaces re-polls, applying
+// a pending interface count that a test sets to simulate a route returning.
+type fakeNetwork struct {
+	mu        sync.Mutex
+	current   int
+	pending   int
+	updates   atomic.Int32
+	resets    atomic.Int32
+	updateErr error
+}
+
+func (f *fakeNetwork) UpdateInterfaces() error {
+	f.updates.Add(1)
+	f.mu.Lock()
+	f.current = f.pending
+	f.mu.Unlock()
+	return f.updateErr
+}
+
+func (f *fakeNetwork) NetworkInterfaces() []adapter.NetworkInterface {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return make([]adapter.NetworkInterface, f.current)
+}
+
+func (f *fakeNetwork) ResetNetwork() { f.resets.Add(1) }
+
+func (f *fakeNetwork) setPending(n int) {
+	f.mu.Lock()
+	f.pending = n
+	f.mu.Unlock()
+}
+
+func newTestRecovery(net boxNetwork, paused func() bool, base, max time.Duration) *netRecovery {
+	return &netRecovery{
+		network:       net,
+		networkPaused: paused,
+		backoff:       common.NewBackoff(base, max),
+		armCh:         make(chan struct{}, 1),
+		wakeCh:        make(chan struct{}, 1),
+		done:          make(chan struct{}),
+	}
+}
+
+func alwaysPaused() bool { return true }
+
+// stableCount waits until c stops changing across consecutive polls and returns
+// its settled value, so a test can baseline a loop that may have one attempt in
+// flight.
+func stableCount(t *testing.T, c func() int32) int32 {
+	t.Helper()
+	last := c()
+	require.Eventually(t, func() bool {
+		got := c()
+		if got == last {
+			return true
+		}
+		last = got
+		return false
+	}, 2*time.Second, 20*time.Millisecond, "count never stabilized")
+	return last
+}
+
+func TestNetRecovery_ResetsOnceWhenInterfacesReturn(t *testing.T) {
+	net := &fakeNetwork{} // starts with no interfaces
+	rec := newTestRecovery(net, alwaysPaused, 10*time.Millisecond, 50*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go rec.run(ctx)
+
+	rec.pause()
+	require.Eventually(t, func() bool {
+		return net.updates.Load() >= 2
+	}, 2*time.Second, 20*time.Millisecond, "should keep re-polling while paused with no interfaces")
+	require.Zero(t, net.resets.Load(), "must not reset the network while interfaces are still gone")
+
+	net.setPending(2) // route returns
+	require.Eventually(t, func() bool {
+		return net.resets.Load() == 1
+	}, 2*time.Second, 20*time.Millisecond, "should reset once when interfaces refill")
+	require.Never(t, func() bool {
+		return net.resets.Load() > 1
+	}, 300*time.Millisecond, 20*time.Millisecond, "must not keep resetting after recovery")
+}
+
+func TestNetRecovery_StopsWhenUnpaused(t *testing.T) {
+	net := &fakeNetwork{}
+	var paused atomic.Bool
+	paused.Store(true)
+	rec := newTestRecovery(net, paused.Load, 10*time.Millisecond, 50*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go rec.run(ctx)
+
+	rec.pause()
+	require.Eventually(t, func() bool {
+		return net.updates.Load() >= 1
+	}, 2*time.Second, 20*time.Millisecond, "should be polling while paused")
+
+	paused.Store(false)
+	rec.wake()
+	settled := stableCount(t, net.updates.Load)
+	require.Never(t, func() bool {
+		return net.updates.Load() > settled
+	}, 300*time.Millisecond, 20*time.Millisecond, "should stop polling once unpaused")
+}
+
+func TestNetRecovery_IgnoresStaleArmWhenNotPaused(t *testing.T) {
+	net := &fakeNetwork{pending: 5, current: 5}
+	rec := newTestRecovery(net, func() bool { return false }, 10*time.Millisecond, 50*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go rec.run(ctx)
+
+	rec.pause() // a stale seed arming recovery while the manager is not paused
+	require.Never(t, func() bool {
+		return net.updates.Load() > 0 || net.resets.Load() > 0
+	}, 300*time.Millisecond, 20*time.Millisecond, "a stale arm must not touch the network when not paused")
+}
+
+func TestNetRecovery_SettlesBeforeFirstAttempt(t *testing.T) {
+	net := &fakeNetwork{}
+	var paused atomic.Bool
+	paused.Store(true)
+	// A base long enough that only a wake, not the interval, can end the first wait.
+	rec := newTestRecovery(net, paused.Load, time.Hour, time.Hour)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go rec.run(ctx)
+
+	rec.pause()
+	paused.Store(false)
+	rec.wake()
+	require.Never(t, func() bool {
+		return net.updates.Load() > 0
+	}, 300*time.Millisecond, 20*time.Millisecond, "a pause cleared within the base interval must not re-poll")
+}
+
+func TestNetRecovery_UpdateErrorDoesNotBlockRecovery(t *testing.T) {
+	net := &fakeNetwork{updateErr: errors.New("no interfaces")}
+	rec := newTestRecovery(net, alwaysPaused, 10*time.Millisecond, 50*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go rec.run(ctx)
+
+	rec.pause()
+	net.setPending(2)
+	require.Eventually(t, func() bool {
+		return net.resets.Load() == 1
+	}, 2*time.Second, 20*time.Millisecond, "a failing update must not stop recovery detecting the refilled list")
+}
+
+func TestNetRecovery_ContextCancelStops(t *testing.T) {
+	net := &fakeNetwork{}
+	rec := newTestRecovery(net, alwaysPaused, 10*time.Millisecond, 50*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go rec.run(ctx)
+
+	rec.pause()
+	require.Eventually(t, func() bool {
+		return net.updates.Load() >= 1
+	}, 2*time.Second, 20*time.Millisecond, "should be polling before cancel")
+
+	cancel()
+	rec.stop()
+	select {
+	case <-rec.done:
+	default:
+		t.Fatal("run did not return after context cancel")
+	}
+
+	settled := stableCount(t, net.updates.Load)
+	require.Never(t, func() bool {
+		return net.updates.Load() > settled
+	}, 300*time.Millisecond, 20*time.Millisecond, "stopped supervisor should not poll")
+}

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -21,6 +21,7 @@ import (
 	O "github.com/sagernet/sing-box/option"
 	"github.com/sagernet/sing/common/json"
 	"github.com/sagernet/sing/service"
+	"github.com/sagernet/sing/service/pause"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -43,6 +44,10 @@ import (
 )
 
 const defaultCloseTimeout = 10 * time.Second
+
+// devicePauseTimeout bounds an iOS device pause; iOS may never deliver a wake
+// event to the extension.
+const devicePauseTimeout = time.Minute
 
 type tunnel struct {
 	ctx                  context.Context
@@ -91,6 +96,17 @@ type tunnel struct {
 
 	cancel  context.CancelFunc
 	closers []io.Closer
+
+	// netRecovery re-seeds network state while the pause manager reports the
+	// network paused. Nil when no pause manager is present.
+	netRecovery *netRecovery
+
+	// pauseManager, if non-nil, is retained so the device-lifecycle hooks can
+	// pause and wake the tunnel.
+	pauseManager pause.Manager
+	// endPauseTimer force-wakes an iOS device pause; see devicePause. Guarded by pauseMu.
+	endPauseTimer *time.Timer
+	pauseMu       sync.Mutex
 }
 
 func (t *tunnel) start(ctx context.Context, options O.Options, platformIfce libbox.PlatformInterface, isRestart bool) error {
@@ -305,6 +321,37 @@ func (t *tunnel) connect(ctx context.Context) (err error) {
 	t.clashServer = service.FromContext[adapter.ClashServer](t.ctx).(*clashServer)
 	t.outboundMgr = service.FromContext[adapter.OutboundManager](t.ctx)
 	t.clashServer.connTracker.SetObserver(t.connObserver)
+	if pm := service.FromContext[pause.Manager](t.ctx); pm != nil {
+		t.pauseManager = pm
+		t.netRecovery = newNetRecovery(t.boxInstance.Network(), pm.IsNetworkPaused)
+		go t.netRecovery.run(t.ctx)
+		slog.Debug("Network recovery supervisor started")
+		events.SubscribeContext(t.ctx, func(evt NetworkEvent) {
+			switch evt.EventType {
+			case NetworkEventPaused:
+				t.netRecovery.pause()
+			case NetworkEventWake:
+				t.netRecovery.wake()
+			}
+		})
+
+		cb := pm.RegisterCallback(t.onPauseUpdate)
+		// A network pause can already be in effect before this registration, so
+		// seed it once. Only the paused case is emitted: not emitting a wake keeps
+		// this off-lock read from racing a real pause into the wrong final state.
+		if pm.IsNetworkPaused() {
+			events.Emit(NetworkEvent{EventType: NetworkEventPaused})
+		}
+		t.closers = append(t.closers, closerFunc(func() error {
+			pm.UnregisterCallback(cb)
+			// No further events arrive after unregister, so force a wake to release
+			// a NetworkEvent consumer left paused at teardown. UnregisterCallback
+			// serializes with in-flight callbacks via the manager lock, so this
+			// wake lands last.
+			events.Emit(NetworkEvent{EventType: NetworkEventWake})
+			return nil
+		}))
+	}
 
 	if common.IsIOS() {
 		// Only iOS enforces a hard memory cap, so only it gets reclaim and
@@ -332,6 +379,19 @@ func (t *tunnel) connect(ctx context.Context) (err error) {
 
 	slog.Info("Tunnel connection established")
 	return nil
+}
+
+// onPauseUpdate mirrors the pause manager's network-axis transitions onto
+// NetworkEvent. Device-axis events are ignored: only a missing default route
+// (NetworkPause) leaves the tunnel unable to dial, and on resume the box already
+// resets the network itself.
+func (t *tunnel) onPauseUpdate(evt int) {
+	switch evt {
+	case pause.EventNetworkPause:
+		events.Emit(NetworkEvent{EventType: NetworkEventPaused})
+	case pause.EventNetworkWake:
+		events.Emit(NetworkEvent{EventType: NetworkEventWake})
+	}
 }
 
 // subscribeExhaustionSignal bridges the auto group's exhaustion
@@ -402,6 +462,16 @@ func (t *tunnel) close() error {
 	if t.cancel != nil {
 		t.cancel()
 	}
+	// t.cancel stopped the supervisor's context above; wait for any in-flight
+	// re-seed to finish before closing the box it operates on.
+	if t.netRecovery != nil {
+		t.netRecovery.stop()
+	}
+	t.pauseMu.Lock()
+	if t.endPauseTimer != nil {
+		t.endPauseTimer.Stop()
+	}
+	t.pauseMu.Unlock()
 
 	closers := t.closers
 	t.closers = nil
@@ -429,6 +499,41 @@ func (t *tunnel) close() error {
 		return errors.New("timeout waiting for tunnel to close")
 	case err := <-done:
 		return err
+	}
+}
+
+// devicePause pauses the tunnel for a device sleep. On iOS it also arms a timer to
+// wake after devicePauseTimeout.
+func (t *tunnel) devicePause() {
+	if t.pauseManager == nil {
+		return
+	}
+	t.pauseManager.DevicePause()
+	if common.IsIOS() {
+		t.pauseMu.Lock()
+		if t.endPauseTimer == nil {
+			t.endPauseTimer = time.AfterFunc(devicePauseTimeout, t.pauseManager.DeviceWake)
+		} else {
+			t.endPauseTimer.Reset(devicePauseTimeout)
+		}
+		t.pauseMu.Unlock()
+	}
+}
+
+// deviceWake wakes the tunnel after a device sleep. On iOS the wake is driven by
+// devicePause's timer, so this is a no-op there.
+func (t *tunnel) deviceWake() {
+	if t.pauseManager == nil {
+		return
+	}
+	if !common.IsIOS() {
+		t.pauseManager.DeviceWake()
+	}
+}
+
+func (t *tunnel) resetNetwork() {
+	if t.boxInstance != nil {
+		t.boxInstance.Network().ResetNetwork()
 	}
 }
 

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -462,8 +462,6 @@ func (t *tunnel) close() error {
 	if t.cancel != nil {
 		t.cancel()
 	}
-	// t.cancel stopped the supervisor's context above; wait for any in-flight
-	// re-seed to finish before closing the box it operates on.
 	if t.netRecovery != nil {
 		t.netRecovery.stop()
 	}

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -462,9 +462,6 @@ func (t *tunnel) close() error {
 	if t.cancel != nil {
 		t.cancel()
 	}
-	if t.netRecovery != nil {
-		t.netRecovery.stop()
-	}
 	t.pauseMu.Lock()
 	if t.endPauseTimer != nil {
 		t.endPauseTimer.Stop()
@@ -472,11 +469,15 @@ func (t *tunnel) close() error {
 	t.pauseMu.Unlock()
 
 	closers := t.closers
+	recovery := t.netRecovery
 	t.closers = nil
 	t.boxInstance = nil
 
 	done := make(chan error, 1)
 	go func() {
+		if recovery != nil {
+			recovery.stop()
+		}
 		var errs []error
 		for _, closer := range closers {
 			slog.Log(nil, rlog.LevelTrace, "Closing tunnel resource", "type", fmt.Sprintf("%T", closer))

--- a/vpn/tunnel_test.go
+++ b/vpn/tunnel_test.go
@@ -9,11 +9,38 @@ import (
 	box "github.com/getlantern/lantern-box"
 	O "github.com/sagernet/sing-box/option"
 	"github.com/sagernet/sing/common/json"
+	"github.com/sagernet/sing/service"
+	"github.com/sagernet/sing/service/pause"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/getlantern/radiance/events"
 	"github.com/getlantern/radiance/servers"
 )
+
+// TestTunnelDevicePauseWake covers the non-iOS path: devicePause pauses the
+// manager and deviceWake resumes it. The iOS timer branch depends on
+// common.IsIOS() and is not exercised off-device.
+func TestTunnelDevicePauseWake(t *testing.T) {
+	ctx := pause.WithDefaultManager(context.Background())
+	mgr := service.FromContext[pause.Manager](ctx)
+	require.NotNil(t, mgr)
+
+	tn := &tunnel{pauseManager: mgr}
+	tn.devicePause()
+	require.True(t, mgr.IsDevicePaused())
+	tn.deviceWake()
+	require.False(t, mgr.IsDevicePaused())
+}
+
+func TestTunnelLifecycleNilManager(t *testing.T) {
+	tn := &tunnel{}
+	require.NotPanics(t, func() {
+		tn.devicePause()
+		tn.deviceWake()
+		tn.resetNetwork()
+	})
+}
 
 type errCloser struct{ err error }
 
@@ -164,4 +191,44 @@ func TestNewClientContextInjectorSeedsLanternTags(t *testing.T) {
 		tags[0] = "mutated"
 		assert.Equal(t, []string{"a", "b"}, inj.MatchBounds().Outbound)
 	})
+}
+
+func TestOnPauseUpdate(t *testing.T) {
+	// want == "" means no NetworkEvent should be emitted.
+	cases := []struct {
+		name string
+		evt  int
+		want NetworkEventType
+	}{
+		{"device paused ignored", pause.EventDevicePaused, ""},
+		{"network paused", pause.EventNetworkPause, NetworkEventPaused},
+		{"network wake", pause.EventNetworkWake, NetworkEventWake},
+		{"device wake ignored", pause.EventDeviceWake, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			got := make(chan NetworkEventType, 1)
+			events.SubscribeContext(ctx, func(evt NetworkEvent) { got <- evt.EventType })
+
+			(&tunnel{}).onPauseUpdate(tc.evt)
+
+			if tc.want == "" {
+				select {
+				case ev := <-got:
+					t.Fatalf("expected no NetworkEvent, got %q", ev)
+				case <-time.After(100 * time.Millisecond):
+				}
+				return
+			}
+			select {
+			case ev := <-got:
+				require.Equal(t, tc.want, ev)
+			case <-time.After(2 * time.Second):
+				t.Fatal("no NetworkEvent emitted")
+			}
+		})
+	}
 }

--- a/vpn/tunnel_test.go
+++ b/vpn/tunnel_test.go
@@ -207,25 +207,20 @@ func TestOnPauseUpdate(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			got := make(chan NetworkEventType, 1)
-			events.SubscribeContext(ctx, func(evt NetworkEvent) { got <- evt.EventType })
+			got := make(chan NetworkEventType, 2)
+			sub := events.Subscribe(func(evt NetworkEvent) { got <- evt.EventType })
+			defer sub.Unsubscribe()
 
 			(&tunnel{}).onPauseUpdate(tc.evt)
 
-			if tc.want == "" {
-				select {
-				case ev := <-got:
-					t.Fatalf("expected no NetworkEvent, got %q", ev)
-				case <-time.After(100 * time.Millisecond):
-				}
-				return
+			want := tc.want
+			if want == "" {
+				want = NetworkEventType("test_barrier")
+				events.Emit(NetworkEvent{EventType: want})
 			}
 			select {
 			case ev := <-got:
-				require.Equal(t, tc.want, ev)
+				require.Equal(t, want, ev)
 			case <-time.After(2 * time.Second):
 				t.Fatal("no NetworkEvent emitted")
 			}

--- a/vpn/types.go
+++ b/vpn/types.go
@@ -24,6 +24,24 @@ type ExhaustionEvent struct {
 	events.Event
 }
 
+// NetworkEventType is the availability state carried by a NetworkEvent.
+type NetworkEventType string
+
+const (
+	// NetworkEventPaused means the network is unusable: no default route, or the
+	// device suspended.
+	NetworkEventPaused NetworkEventType = "network_paused"
+	// NetworkEventWake means the default route is back.
+	NetworkEventWake NetworkEventType = "network_wake"
+)
+
+// NetworkEvent reports a change in network availability derived from the tunnel's
+// pause manager.
+type NetworkEvent struct {
+	events.Event
+	EventType NetworkEventType `json:"event_type"`
+}
+
 // Selector is helper interface to check if an outbound is a selector or wrapper of selector.
 type Selector interface {
 	adapter.OutboundGroup

--- a/vpn/types.go
+++ b/vpn/types.go
@@ -28,15 +28,13 @@ type ExhaustionEvent struct {
 type NetworkEventType string
 
 const (
-	// NetworkEventPaused means the network is unusable: no default route, or the
-	// device suspended.
+	// NetworkEventPaused means the pause manager reports a missing default route.
 	NetworkEventPaused NetworkEventType = "network_paused"
-	// NetworkEventWake means the default route is back.
+	// NetworkEventWake means the network pause ended or the tunnel is closing.
 	NetworkEventWake NetworkEventType = "network_wake"
 )
 
-// NetworkEvent reports a change in network availability derived from the tunnel's
-// pause manager.
+// NetworkEvent reports network pause transitions and tunnel teardown.
 type NetworkEvent struct {
 	events.Event
 	EventType NetworkEventType `json:"event_type"`

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -264,6 +264,34 @@ func (c *VPNClient) Restart(boxOptions BoxOptions) error {
 	return nil
 }
 
+// ResetNetwork drops the tunnel's connections and re-seeds its interface state,
+// for a platform to call on a network change. No-op if the tunnel is not running.
+func (c *VPNClient) ResetNetwork() {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.tunnel != nil {
+		c.tunnel.resetNetwork()
+	}
+}
+
+// Pause pauses the tunnel for a device sleep. No-op if the tunnel is not running.
+func (c *VPNClient) Pause() {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.tunnel != nil {
+		c.tunnel.devicePause()
+	}
+}
+
+// Wake wakes the tunnel after a device sleep. No-op if the tunnel is not running.
+func (c *VPNClient) Wake() {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.tunnel != nil {
+		c.tunnel.deviceWake()
+	}
+}
+
 // isOpen returns true if the tunnel is open, false otherwise.
 // Note, this does not check if the tunnel can connect to a server.
 func (c *VPNClient) isOpen() bool {


### PR DESCRIPTION
## What

Two related changes for the "connected but every dial fails" black-hole:

1. **Network-pause recovery supervisor** (`vpn/recovery.go`). While the sing-box pause manager reports the network paused (no default route), a per-tunnel goroutine re-polls interfaces on a backoff and resets the network once per empty-to-nonempty interface transition. A dial falls back to the interface list when there is no default interface, so re-seeding the list restores connectivity without waiting for a fresh platform callback — instead of staying dead until a manual restart. Gated on the authoritative `pm.IsNetworkPaused()`; resets only on empty→refilled transitions and keeps polling until an actual network wake or tunnel shutdown, allowing later outages to recover under the same latched pause without repeatedly resetting stable interfaces. During shutdown, box resources remain open until recovery exits, while the existing tunnel close timeout bounds the caller.

2. **Restored sing-box lifecycle hooks** on the IPC — `ResetNetwork` / `Pause` / `Wake`. radiance replaced sing-box's `CommandServer` with its own IPC server and dropped these; they are re-exposed as endpoints a platform can call on OS lifecycle events, with the iOS 1-minute auto-wake timer on `Pause`. Inert until the native side calls them.

## Why

`getlantern/engineering#3840` (iOS) and `#3856` (Android): the platform default-interface monitor can report an unsatisfied path, or miss an already-connected network after a VPN restart, latching `NetworkPause` with no default route so every dial fails `no available network interface` while the UI still shows Connected.

## Scope / honest caveats

- The supervisor engages only on the **nil-default / empty-list** latch (`missing default interface`). It does **not** address the Android variant where the default resolves to `tun0` (non-nil) — that never trips `NetworkPause` and needs a Kotlin-side fix.
- Whether the re-poll recovers iOS depends on whether `getInterfaces()` reads a live `currentPath`; if not, an iOS Swift fix is also required. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for pausing and resuming VPN activity during device sleep and wake events.
  - Added network reset controls to re-establish VPN connectivity after network changes.
  - Added automatic network recovery while paused, restoring connections when interfaces become available.
  - Added network pause and wake events for improved status and lifecycle reporting.

- **Bug Fixes**
  - Improved VPN handling across device and network pause/resume transitions.
  - Prevented stale connections from persisting after network interfaces return.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->