### PR TITLE
unbounded: expose runtime and peer snapshots for UI recovery

### DIFF
--- a/ipc/client.go
+++ b/ipc/client.go
@@ -854,7 +854,7 @@ func isConnectionError(err error) bool {
 
 // UnboundedSnapshot reads status and peers from the backend that owns the widget.
 func (c *Client) UnboundedSnapshot(ctx context.Context) (unbounded.Snapshot, error) {
-	data, err := c.do(ctx, http.MethodGet, "/unbounded/snapshot", nil)
+	data, err := c.do(ctx, http.MethodGet, unboundedSnapshotEndpoint, nil)
 	if err != nil {
 		return unbounded.Snapshot{}, err
 	}

--- a/ipc/client.go
+++ b/ipc/client.go
@@ -25,6 +25,7 @@ import (
 	rlog "github.com/getlantern/radiance/log"
 	"github.com/getlantern/radiance/peer"
 	"github.com/getlantern/radiance/servers"
+	"github.com/getlantern/radiance/unbounded"
 	"github.com/getlantern/radiance/usermessage"
 	"github.com/getlantern/radiance/vpn"
 
@@ -849,4 +850,15 @@ func isConnectionError(err error) bool {
 	}
 	// Also check the unwrapped error directly for cases where the wrapping differs by platform
 	return errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.ENOENT)
+}
+
+// UnboundedSnapshot reads status and peers from the backend that owns the widget.
+func (c *Client) UnboundedSnapshot(ctx context.Context) (unbounded.Snapshot, error) {
+	data, err := c.do(ctx, http.MethodGet, "/unbounded/snapshot", nil)
+	if err != nil {
+		return unbounded.Snapshot{}, err
+	}
+	var s unbounded.Snapshot
+	err = json.Unmarshal(data, &s)
+	return s, err
 }

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -81,6 +81,7 @@ const (
 	// JSON shape as /peer/connection/events but are emitted from a
 	// different in-process event type, so they need their own SSE bridge.
 	unboundedConnectionEventsEndpoint = "/unbounded/connection/events"
+	unboundedSnapshotEndpoint         = "/unbounded/snapshot"
 
 	// Split tunnel endpoint
 	splitTunnelEndpoint = "/split-tunnel"
@@ -261,9 +262,9 @@ func newLocalAPI(b *backend.LocalBackend, withAuth bool) *localapi {
 	mux.HandleFunc("GET "+peerConnectionEventsEndpoint, s.peerConnectionEventsHandler)
 	mux.HandleFunc("GET "+unboundedConnectionEventsEndpoint, s.unboundedConnectionEventsHandler)
 
-	mux.HandleFunc("GET /unbounded/snapshot", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET "+unboundedSnapshotEndpoint, traced(func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, unbounded.CurrentSnapshot())
-	})
+	}))
 
 	// Split tunnel
 	mux.HandleFunc(splitTunnelEndpoint, traced(s.splitTunnelHandler))

--- a/ipc/server.go
+++ b/ipc/server.go
@@ -261,6 +261,10 @@ func newLocalAPI(b *backend.LocalBackend, withAuth bool) *localapi {
 	mux.HandleFunc("GET "+peerConnectionEventsEndpoint, s.peerConnectionEventsHandler)
 	mux.HandleFunc("GET "+unboundedConnectionEventsEndpoint, s.unboundedConnectionEventsHandler)
 
+	mux.HandleFunc("GET /unbounded/snapshot", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, unbounded.CurrentSnapshot())
+	})
+
 	// Split tunnel
 	mux.HandleFunc(splitTunnelEndpoint, traced(s.splitTunnelHandler))
 

--- a/unbounded/snapshot.go
+++ b/unbounded/snapshot.go
@@ -1,0 +1,67 @@
+package unbounded
+
+import (
+	"context"
+	"sort"
+	"strconv"
+	"time"
+)
+
+var snapshotEpoch = strconv.FormatInt(time.Now().UnixNano(), 10)
+
+// Snapshot describes the current widget state, including peers missed by event subscribers.
+type Snapshot struct {
+	Epoch    string   `json:"epoch"`
+	Arrivals uint64   `json:"arrivals"`
+	Enabled  bool     `json:"enabled"`
+	Running  bool     `json:"running"`
+	Peers    []string `json:"peers"`
+}
+
+// CurrentSnapshot returns an independent copy of the live widget state.
+func CurrentSnapshot() Snapshot {
+	return manager.snapshot()
+}
+
+func (m *unboundedManager) snapshot() Snapshot {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s := Snapshot{Epoch: snapshotEpoch, Arrivals: m.arrivals, Enabled: Enabled(), Running: m.running, Peers: []string{}}
+	if m.running {
+		for _, source := range m.peers {
+			if source != "" {
+				s.Peers = append(s.Peers, source)
+			}
+		}
+	}
+	sort.Strings(s.Peers)
+	return s
+}
+
+func (m *unboundedManager) recordConnection(ctx context.Context, state, slot int, source string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if ctx.Err() != nil {
+		return
+	}
+	if state > 0 {
+		if m.peers == nil {
+			m.peers = make(map[int]string)
+		}
+		if source != "" {
+			known := false
+			for _, existing := range m.peers {
+				if existing == source {
+					known = true
+					break
+				}
+			}
+			if !known {
+				m.arrivals++
+			}
+		}
+		m.peers[slot] = source
+	} else if state < 0 {
+		delete(m.peers, slot)
+	}
+}

--- a/unbounded/snapshot_test.go
+++ b/unbounded/snapshot_test.go
@@ -1,0 +1,53 @@
+package unbounded
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/getlantern/broflake/clientcore"
+	"github.com/getlantern/radiance/common/settings"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotRestoresPeersAndRejectsCancelledCallbacks(t *testing.T) {
+	m := &unboundedManager{running: true}
+	ctx, cancel := context.WithCancel(context.Background())
+	m.recordConnection(ctx, 1, 0, "192.0.2.1")
+	m.recordConnection(ctx, 1, 1, "192.0.2.1")
+	s := m.snapshot()
+	require.Equal(t, uint64(1), s.Arrivals)
+	require.Equal(t, []string{"192.0.2.1", "192.0.2.1"}, s.Peers)
+	s.Peers[0] = "changed"
+	require.Equal(t, "192.0.2.1", m.snapshot().Peers[0])
+	m.recordConnection(ctx, -1, 0, "")
+	require.Len(t, m.snapshot().Peers, 1)
+	m.recordConnection(ctx, -1, 1, "")
+	m.recordConnection(ctx, 1, 1, "192.0.2.1")
+	require.Equal(t, uint64(2), m.snapshot().Arrivals)
+	cancel()
+	m.recordConnection(ctx, 1, 2, "192.0.2.2")
+	require.Len(t, m.snapshot().Peers, 1)
+	m.running = false
+	require.Empty(t, m.snapshot().Peers)
+}
+
+func TestSnapshotReportsActualLifecycle(t *testing.T) {
+	resetManager(t, func(*clientcore.BroflakeOptions, *clientcore.WebRTCOptions, *clientcore.EgressOptions) (widget, error) {
+		return &fakeWidget{}, nil
+	})
+	require.NoError(t, settings.Set(settings.UnboundedKey, true))
+	require.NoError(t, Apply())
+	require.True(t, CurrentSnapshot().Enabled)
+	require.False(t, CurrentSnapshot().Running)
+	manager.mu.Lock()
+	manager.lastFeatureOn = true
+	manager.lastCfg = testCfg()
+	manager.mu.Unlock()
+	require.NoError(t, Apply())
+	require.Eventually(t, func() bool { return CurrentSnapshot().Running }, time.Second, time.Millisecond)
+	require.NoError(t, Stop(context.Background()))
+	require.True(t, CurrentSnapshot().Enabled)
+	require.False(t, CurrentSnapshot().Running)
+	require.Empty(t, CurrentSnapshot().Peers)
+}

--- a/unbounded/unbounded.go
+++ b/unbounded/unbounded.go
@@ -178,6 +178,9 @@ type unboundedManager struct {
 	// differ, with the predicate still otherwise satisfied. Nil
 	// whenever cancel is nil.
 	runningCfg *C.UnboundedConfig
+	running    bool
+	peers      map[int]string
+	arrivals   uint64
 }
 
 // shouldStart reports whether all three start conditions hold. Caller
@@ -438,6 +441,10 @@ func (m *unboundedManager) stopCtx(ctx context.Context, disarm bool) error {
 		return nil
 	}
 	cancel()
+	m.mu.Lock()
+	m.running = false
+	m.peers = nil
+	m.mu.Unlock()
 	select {
 	case <-done:
 		return nil
@@ -498,6 +505,7 @@ func (m *unboundedManager) start() {
 	// lastCfg is also a pointer and equality is value-based via
 	// cfgEqual.
 	m.runningCfg = ucfg
+	m.peers = make(map[int]string)
 	m.mu.Unlock()
 
 	go func() {
@@ -529,15 +537,7 @@ func (m *unboundedManager) start() {
 		// off. broflake exposes no registration point we could
 		// disarm directly (the callback IS the registration), so the
 		// inline ctx check is the next-best place.
-		// broflake hands us the consumer's addr on accept but a nil addr on
-		// close (the WebRTC session is already torn down, so the remote IP is
-		// gone). Consumers of ConnectionEvent identify a connection by its
-		// Source: the Flutter globe matches a close to the arc it should
-		// remove by source IP, and decrements its "people helped" counter the
-		// same way. A close with an empty Source can't be matched, so the arc
-		// orphans and the counter never comes back down. sources remembers
-		// each slot's addr on accept and restores it on close so every -1
-		// carries the same Source its +1 did.
+		// Close callbacks omit the address; preserve it for connection-event subscribers.
 		sources := newConnSources()
 		bfOpt.OnConnectionChangeFunc = func(state int, workerIdx int, addr net.IP) {
 			if ctx.Err() != nil {
@@ -548,6 +548,7 @@ func (m *unboundedManager) start() {
 				addrStr = addr.String()
 			}
 			addrStr = sources.resolve(state, workerIdx, addrStr)
+			m.recordConnection(ctx, state, workerIdx, addrStr)
 			slog.Debug("Unbounded: consumer connection change",
 				"state", state, "workerIdx", workerIdx, "source", addrStr)
 			events.Emit(ConnectionEvent{
@@ -589,6 +590,9 @@ func (m *unboundedManager) start() {
 			return
 		}
 
+		m.mu.Lock()
+		m.running = ctx.Err() == nil
+		m.mu.Unlock()
 		slog.Info("Unbounded: broflake widget proxy started")
 		<-ctx.Done()
 		slog.Info("Unbounded: stopping broflake widget proxy")


### PR DESCRIPTION
Unbounded can already be serving peers when a UI subscribes, leaving an event-only display at zero until another connection arrives. Add an IPC snapshot endpoint with local enablement, actual running status, current peer addresses, and a cumulative arrival counter scoped to a backend-process epoch.

Snapshots copy state under the manager lock, preserve multiple slots for the same peer, and exclude stopped workers. Cancelled callbacks cannot repopulate cleared state. The arrival counter lets a polling UI include sessions that finish between snapshots.

Validation: `go test -race ./unbounded ./ipc`; independent code/comment review. Tests cover snapshot isolation, repeated peer addresses, cancelled callbacks, arrival accounting, and enabled-versus-running lifecycle state.

Companion UI PR: https://github.com/getlantern/lantern/pull/9035. Merge this backend PR first.
