### PR TITLE
feat(kindling): pause domain fronting while the network is paused

### DIFF
--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -503,9 +503,9 @@ func (r *LocalBackend) startVPNStatusListeners() {
 	events.SubscribeContext(r.ctx, func(evt vpn.NetworkEvent) {
 		switch evt.EventType {
 		case vpn.NetworkEventPaused:
-			kindling.Pause()
+			kindling.SetNetworkPaused(r.ctx, true)
 		case vpn.NetworkEventWake:
-			kindling.Resume()
+			kindling.SetNetworkPaused(r.ctx, false)
 		}
 	})
 	events.SubscribeContext(r.ctx, func(evt vpn.StatusUpdateEvent) {

--- a/backend/radiance.go
+++ b/backend/radiance.go
@@ -500,6 +500,14 @@ func (r *LocalBackend) startVPNStatusListeners() {
 	events.SubscribeContext(r.ctx, func(vpn.ExhaustionEvent) {
 		r.refetchOnExhaustion()
 	})
+	events.SubscribeContext(r.ctx, func(evt vpn.NetworkEvent) {
+		switch evt.EventType {
+		case vpn.NetworkEventPaused:
+			kindling.Pause()
+		case vpn.NetworkEventWake:
+			kindling.Resume()
+		}
+	})
 	events.SubscribeContext(r.ctx, func(evt vpn.StatusUpdateEvent) {
 		switch evt.Status {
 		case vpn.Disconnected, vpn.ErrorStatus, vpn.Restarting:

--- a/kindling/client.go
+++ b/kindling/client.go
@@ -42,6 +42,9 @@ var (
 	mu          sync.Mutex
 	initialized bool
 	k           *Client
+	// paused is the last network pause state, applied to a client when it is
+	// installed as the shared instance.
+	paused bool
 	// EnabledTransports gates which transports NewKindling wires up. AMP and DNS
 	// tunneling are parked off for every country; their builders stay wired
 	// behind these flags so turning either back on is a one-line change.
@@ -66,7 +69,7 @@ func initKindling() {
 		slog.Error("failed to create kindling client", slog.Any("error", err))
 	}
 	if newK != nil {
-		k = newK
+		setClient(newK)
 		transport = traces.NewRoundTripper(traces.NewHeaderAnnotatingRoundTripper(newK.NewHTTPClient().Transport))
 	} else {
 		slog.Warn("kindling unavailable, using default transport clone")
@@ -118,10 +121,48 @@ func Close() error {
 	}
 	transport = nil
 	initialized = false
+	// Wakes only ever come from a live tunnel, so a pause must not outlive one.
+	paused = false
 	return nil
 }
 
+// Pause suspends background work in the shared instance's pausable transports
+// and applies to the next instance installed. Pauses do not nest: one Resume
+// resumes regardless of how many Pause calls preceded it.
+func Pause() {
+	mu.Lock()
+	defer mu.Unlock()
+	paused = true
+	if k != nil {
+		k.Pause()
+	}
+}
+
+// Resume restarts the background work suspended by Pause.
+func Resume() {
+	mu.Lock()
+	defer mu.Unlock()
+	paused = false
+	if k != nil {
+		k.Resume()
+	}
+}
+
+// setClient installs c as the shared instance, applying any pause that arrived
+// before it existed. The caller must hold mu.
+func setClient(c *Client) {
+	k = c
+	if c != nil && paused {
+		c.Pause()
+	}
+}
+
 const tracerName = "github.com/getlantern/radiance/kindling"
+
+type pausable interface {
+	Pause()
+	Resume()
+}
 
 // Client is a kindling instance together with the transport resources its
 // construction created (config updaters, fronted/dnstt state).
@@ -129,7 +170,23 @@ type Client struct {
 	kindling.Kindling
 	cancel    context.CancelFunc
 	closers   []func() error
+	pausers   []pausable
 	closeOnce sync.Once
+}
+
+// Pause suspends the pausable transports' background work. Safe to call while
+// paused.
+func (c *Client) Pause() {
+	for _, p := range c.pausers {
+		p.Pause()
+	}
+}
+
+// Resume restarts the background work suspended by Pause.
+func (c *Client) Resume() {
+	for _, p := range c.pausers {
+		p.Resume()
+	}
 }
 
 // Close cancels the transports' config updaters and releases their resources.
@@ -179,6 +236,7 @@ func NewKindling(dataDir string) (*Client, error) {
 	}
 
 	var closers []func() error
+	var pausers []pausable
 	kindlingOptions := []kindling.Option{
 		kindling.WithPanicListener(reporting.PanicListener),
 		kindling.WithLogWriter(logger),
@@ -195,6 +253,7 @@ func NewKindling(dataDir string) (*Client, error) {
 		}
 		if f != nil {
 			closers = append(closers, func() error { f.Close(); return nil })
+			pausers = append(pausers, f)
 			kindlingOptions = append(kindlingOptions, kindling.WithDomainFronting(f))
 		}
 	}
@@ -237,7 +296,7 @@ func NewKindling(dataDir string) (*Client, error) {
 		}
 		return nil, errors.Join(errs...)
 	}
-	return &Client{Kindling: newK, cancel: cancel, closers: closers}, nil
+	return &Client{Kindling: newK, cancel: cancel, closers: closers, pausers: pausers}, nil
 }
 
 type slogWriter struct {
@@ -260,7 +319,7 @@ func SetKindling(c *Client) {
 	if initialized {
 		return
 	}
-	k = c
+	setClient(c)
 	if c != nil {
 		transport = traces.NewRoundTripper(traces.NewHeaderAnnotatingRoundTripper(c.NewHTTPClient().Transport))
 	} else {

--- a/kindling/client.go
+++ b/kindling/client.go
@@ -43,10 +43,9 @@ var (
 	pauseMu     sync.Mutex
 	initialized bool
 	k           *Client
-	// paused is separate from init state so pause events can land while the
-	// shared instance is still being built.
-	paused       bool
-	pauseApplied bool
+	// paused is the current pause state, kept here because a pause can arrive
+	// with no client to receive it.
+	paused bool
 	// EnabledTransports gates which transports NewKindling wires up. AMP and DNS
 	// tunneling are parked off for every country; their builders stay wired
 	// behind these flags so turning either back on is a one-line change.
@@ -66,7 +65,7 @@ var (
 )
 
 func initKindling() {
-	newK, err := newKindling(settings.GetString(settings.DataPathKey), isPaused)
+	newK, err := NewKindling(settings.GetString(settings.DataPathKey))
 	if err != nil {
 		slog.Error("failed to create kindling client", slog.Any("error", err))
 	}
@@ -127,7 +126,6 @@ func Close() error {
 	initialized = false
 	// Wakes only ever come from a live tunnel, so a pause must not outlive one.
 	paused = false
-	pauseApplied = false
 	return nil
 }
 
@@ -141,9 +139,8 @@ func Pause() {
 		return
 	}
 	paused = true
-	if k != nil && !pauseApplied {
-		k.Pause()
-		pauseApplied = true
+	if k != nil {
+		k.applyPause(true)
 	}
 }
 
@@ -156,31 +153,19 @@ func Resume() {
 	}
 	paused = false
 	if k != nil {
-		k.Resume()
+		k.applyPause(false)
 	}
-	pauseApplied = false
 }
 
-// setClient installs c as the shared instance, applying any pause that arrived
-// before it existed. The caller must hold mu.
+// setClient installs c as the shared instance, applying any pause held at
+// install time. The caller must hold mu.
 func setClient(c *Client) {
 	pauseMu.Lock()
 	defer pauseMu.Unlock()
 	k = c
-	pauseApplied = false
-	if c == nil || !paused {
-		return
+	if c != nil && paused {
+		c.applyPause(true)
 	}
-	if !c.pauseApplied {
-		c.Pause()
-	}
-	pauseApplied = true
-}
-
-func isPaused() bool {
-	pauseMu.Lock()
-	defer pauseMu.Unlock()
-	return paused
 }
 
 const tracerName = "github.com/getlantern/radiance/kindling"
@@ -195,24 +180,20 @@ type pausable interface {
 // construction created (config updaters, fronted/dnstt state).
 type Client struct {
 	kindling.Kindling
-	cancel       context.CancelFunc
-	closers      []func() error
-	pausers      []pausable
-	pauseApplied bool
-	closeOnce    sync.Once
+	cancel    context.CancelFunc
+	closers   []func() error
+	pausers   []pausable
+	closeOnce sync.Once
 }
 
-// Pause suspends the pausable transports' background work.
-func (c *Client) Pause() {
+// applyPause must be called with pauseMu held.
+func (c *Client) applyPause(pause bool) {
 	for _, p := range c.pausers {
-		p.Pause()
-	}
-}
-
-// Resume restarts the background work suspended by Pause.
-func (c *Client) Resume() {
-	for _, p := range c.pausers {
-		p.Resume()
+		if pause {
+			p.Pause()
+		} else {
+			p.Resume()
+		}
 	}
 }
 
@@ -235,10 +216,6 @@ func (c *Client) Close() error {
 // NewKindling builds a kindling client. On error, any partially built
 // transport state is released before returning.
 func NewKindling(dataDir string) (*Client, error) {
-	return newKindling(dataDir, func() bool { return false })
-}
-
-func newKindling(dataDir string, startPaused func() bool) (*Client, error) {
 	logger := &slogWriter{Logger: slog.Default()}
 
 	ctx, span := otel.Tracer(tracerName).Start(
@@ -276,23 +253,13 @@ func newKindling(dataDir string, startPaused func() bool) (*Client, error) {
 	}
 
 	updaterCtx, cancel := context.WithCancel(ctx)
-	initialPauseApplied := false
 	if enabled := EnabledTransports[kindling.TransportDomainfront]; enabled {
-		frontedPauseApplied := false
-		f, err := fronted.NewFronted(updaterCtx, filepath.Join(dataDir, "fronted_cache.json"), logger, func() bool {
-			frontedPauseApplied = startPaused()
-			return frontedPauseApplied
-		})
+		f, err := fronted.NewFronted(updaterCtx, filepath.Join(dataDir, "fronted_cache.json"), logger)
 		if err != nil {
 			slog.Error("failed to create fronted client", slog.Any("error", err))
 			span.RecordError(err)
 		}
 		if f != nil {
-			if startPaused() && !frontedPauseApplied {
-				f.Pause()
-				frontedPauseApplied = true
-			}
-			initialPauseApplied = frontedPauseApplied
 			closers = append(closers, func() error { f.Close(); return nil })
 			pausers = append(pausers, f)
 			kindlingOptions = append(kindlingOptions, kindling.WithDomainFronting(f))
@@ -338,11 +305,10 @@ func newKindling(dataDir string, startPaused func() bool) (*Client, error) {
 		return nil, errors.Join(errs...)
 	}
 	return &Client{
-		Kindling:     newK,
-		cancel:       cancel,
-		closers:      closers,
-		pausers:      pausers,
-		pauseApplied: initialPauseApplied,
+		Kindling: newK,
+		cancel:   cancel,
+		closers:  closers,
+		pausers:  pausers,
 	}, nil
 }
 

--- a/kindling/client.go
+++ b/kindling/client.go
@@ -127,11 +127,14 @@ func Close() error {
 }
 
 // Pause suspends background work in the shared instance's pausable transports
-// and applies to the next instance installed. Pauses do not nest: one Resume
-// resumes regardless of how many Pause calls preceded it.
+// and applies to the next instance installed. Redundant calls are dropped, so
+// duplicate events never reach a transport and one Resume always resumes.
 func Pause() {
 	mu.Lock()
 	defer mu.Unlock()
+	if paused {
+		return
+	}
 	paused = true
 	if k != nil {
 		k.Pause()
@@ -142,6 +145,9 @@ func Pause() {
 func Resume() {
 	mu.Lock()
 	defer mu.Unlock()
+	if !paused {
+		return
+	}
 	paused = false
 	if k != nil {
 		k.Resume()
@@ -159,6 +165,7 @@ func setClient(c *Client) {
 
 const tracerName = "github.com/getlantern/radiance/kindling"
 
+// pausable transports must tolerate repeated Pause and Resume calls.
 type pausable interface {
 	Pause()
 	Resume()
@@ -174,8 +181,7 @@ type Client struct {
 	closeOnce sync.Once
 }
 
-// Pause suspends the pausable transports' background work. Safe to call while
-// paused.
+// Pause suspends the pausable transports' background work.
 func (c *Client) Pause() {
 	for _, p := range c.pausers {
 		p.Pause()

--- a/kindling/client.go
+++ b/kindling/client.go
@@ -40,11 +40,13 @@ const (
 
 var (
 	mu          sync.Mutex
+	pauseMu     sync.Mutex
 	initialized bool
 	k           *Client
-	// paused is the last network pause state, applied to a client when it is
-	// installed as the shared instance.
-	paused bool
+	// paused is separate from init state so pause events can land while the
+	// shared instance is still being built.
+	paused       bool
+	pauseApplied bool
 	// EnabledTransports gates which transports NewKindling wires up. AMP and DNS
 	// tunneling are parked off for every country; their builders stay wired
 	// behind these flags so turning either back on is a one-line change.
@@ -64,7 +66,7 @@ var (
 )
 
 func initKindling() {
-	newK, err := NewKindling(settings.GetString(settings.DataPathKey))
+	newK, err := newKindling(settings.GetString(settings.DataPathKey), isPaused)
 	if err != nil {
 		slog.Error("failed to create kindling client", slog.Any("error", err))
 	}
@@ -113,6 +115,8 @@ func Close() error {
 	// extension stops, so Close must not be terminal.
 	mu.Lock()
 	defer mu.Unlock()
+	pauseMu.Lock()
+	defer pauseMu.Unlock()
 	if k != nil {
 		if err := k.Close(); err != nil {
 			slog.Error("failed to close kindling transports", slog.Any("error", err))
@@ -123,6 +127,7 @@ func Close() error {
 	initialized = false
 	// Wakes only ever come from a live tunnel, so a pause must not outlive one.
 	paused = false
+	pauseApplied = false
 	return nil
 }
 
@@ -130,21 +135,22 @@ func Close() error {
 // and applies to the next instance installed. Redundant calls are dropped, so
 // duplicate events never reach a transport and one Resume always resumes.
 func Pause() {
-	mu.Lock()
-	defer mu.Unlock()
+	pauseMu.Lock()
+	defer pauseMu.Unlock()
 	if paused {
 		return
 	}
 	paused = true
-	if k != nil {
+	if k != nil && !pauseApplied {
 		k.Pause()
+		pauseApplied = true
 	}
 }
 
 // Resume restarts the background work suspended by Pause.
 func Resume() {
-	mu.Lock()
-	defer mu.Unlock()
+	pauseMu.Lock()
+	defer pauseMu.Unlock()
 	if !paused {
 		return
 	}
@@ -152,15 +158,29 @@ func Resume() {
 	if k != nil {
 		k.Resume()
 	}
+	pauseApplied = false
 }
 
 // setClient installs c as the shared instance, applying any pause that arrived
 // before it existed. The caller must hold mu.
 func setClient(c *Client) {
+	pauseMu.Lock()
+	defer pauseMu.Unlock()
 	k = c
-	if c != nil && paused {
+	pauseApplied = false
+	if c == nil || !paused {
+		return
+	}
+	if !c.pauseApplied {
 		c.Pause()
 	}
+	pauseApplied = true
+}
+
+func isPaused() bool {
+	pauseMu.Lock()
+	defer pauseMu.Unlock()
+	return paused
 }
 
 const tracerName = "github.com/getlantern/radiance/kindling"
@@ -175,10 +195,11 @@ type pausable interface {
 // construction created (config updaters, fronted/dnstt state).
 type Client struct {
 	kindling.Kindling
-	cancel    context.CancelFunc
-	closers   []func() error
-	pausers   []pausable
-	closeOnce sync.Once
+	cancel       context.CancelFunc
+	closers      []func() error
+	pausers      []pausable
+	pauseApplied bool
+	closeOnce    sync.Once
 }
 
 // Pause suspends the pausable transports' background work.
@@ -214,6 +235,10 @@ func (c *Client) Close() error {
 // NewKindling builds a kindling client. On error, any partially built
 // transport state is released before returning.
 func NewKindling(dataDir string) (*Client, error) {
+	return newKindling(dataDir, func() bool { return false })
+}
+
+func newKindling(dataDir string, startPaused func() bool) (*Client, error) {
 	logger := &slogWriter{Logger: slog.Default()}
 
 	ctx, span := otel.Tracer(tracerName).Start(
@@ -251,13 +276,23 @@ func NewKindling(dataDir string) (*Client, error) {
 	}
 
 	updaterCtx, cancel := context.WithCancel(ctx)
+	initialPauseApplied := false
 	if enabled := EnabledTransports[kindling.TransportDomainfront]; enabled {
-		f, err := fronted.NewFronted(updaterCtx, filepath.Join(dataDir, "fronted_cache.json"), logger)
+		frontedPauseApplied := false
+		f, err := fronted.NewFronted(updaterCtx, filepath.Join(dataDir, "fronted_cache.json"), logger, func() bool {
+			frontedPauseApplied = startPaused()
+			return frontedPauseApplied
+		})
 		if err != nil {
 			slog.Error("failed to create fronted client", slog.Any("error", err))
 			span.RecordError(err)
 		}
 		if f != nil {
+			if startPaused() && !frontedPauseApplied {
+				f.Pause()
+				frontedPauseApplied = true
+			}
+			initialPauseApplied = frontedPauseApplied
 			closers = append(closers, func() error { f.Close(); return nil })
 			pausers = append(pausers, f)
 			kindlingOptions = append(kindlingOptions, kindling.WithDomainFronting(f))
@@ -302,7 +337,13 @@ func NewKindling(dataDir string) (*Client, error) {
 		}
 		return nil, errors.Join(errs...)
 	}
-	return &Client{Kindling: newK, cancel: cancel, closers: closers, pausers: pausers}, nil
+	return &Client{
+		Kindling:     newK,
+		cancel:       cancel,
+		closers:      closers,
+		pausers:      pausers,
+		pauseApplied: initialPauseApplied,
+	}, nil
 }
 
 type slogWriter struct {

--- a/kindling/client.go
+++ b/kindling/client.go
@@ -40,7 +40,6 @@ const (
 
 var (
 	mu          sync.Mutex
-	pauseMu     sync.Mutex
 	initialized bool
 	k           *Client
 	// paused is the current pause state, kept here because a pause can arrive
@@ -114,8 +113,6 @@ func Close() error {
 	// extension stops, so Close must not be terminal.
 	mu.Lock()
 	defer mu.Unlock()
-	pauseMu.Lock()
-	defer pauseMu.Unlock()
 	if k != nil {
 		if err := k.Close(); err != nil {
 			slog.Error("failed to close kindling transports", slog.Any("error", err))
@@ -129,42 +126,29 @@ func Close() error {
 	return nil
 }
 
-// Pause suspends background work in the shared instance's pausable transports
-// and applies to the next instance installed. Redundant calls are dropped, so
-// duplicate events never reach a transport and one Resume always resumes.
-func Pause() {
-	pauseMu.Lock()
-	defer pauseMu.Unlock()
-	if paused {
+// SetNetworkPaused sets whether the shared transports' background work is paused.
+//
+// The state also applies to clients installed later, until Close resets it.
+// Updates from canceled contexts are ignored.
+func SetNetworkPaused(ctx context.Context, next bool) {
+	mu.Lock()
+	defer mu.Unlock()
+	// Cancellation must be checked under mu to reject updates arriving after teardown.
+	if ctx.Err() != nil || paused == next {
 		return
 	}
-	paused = true
+	paused = next
 	if k != nil {
-		k.applyPause(true)
-	}
-}
-
-// Resume restarts the background work suspended by Pause.
-func Resume() {
-	pauseMu.Lock()
-	defer pauseMu.Unlock()
-	if !paused {
-		return
-	}
-	paused = false
-	if k != nil {
-		k.applyPause(false)
+		k.applyPauseLocked(next)
 	}
 }
 
 // setClient installs c as the shared instance, applying any pause held at
 // install time. The caller must hold mu.
 func setClient(c *Client) {
-	pauseMu.Lock()
-	defer pauseMu.Unlock()
 	k = c
 	if c != nil && paused {
-		c.applyPause(true)
+		c.applyPauseLocked(true)
 	}
 }
 
@@ -186,8 +170,8 @@ type Client struct {
 	closeOnce sync.Once
 }
 
-// applyPause must be called with pauseMu held.
-func (c *Client) applyPause(pause bool) {
+// applyPauseLocked must be called with mu held.
+func (c *Client) applyPauseLocked(pause bool) {
 	for _, p := range c.pausers {
 		if pause {
 			p.Pause()

--- a/kindling/client_test.go
+++ b/kindling/client_test.go
@@ -52,23 +52,13 @@ type fakePausable struct{ paused, resumed int }
 func (f *fakePausable) Pause()  { f.paused++ }
 func (f *fakePausable) Resume() { f.resumed++ }
 
-func TestClientPauseResumeDelegates(t *testing.T) {
-	p := &fakePausable{}
-	c := &Client{pausers: []pausable{p}}
-
-	c.Pause()
-	c.Pause()
-	c.Resume()
-
-	assert.Equal(t, 2, p.paused)
-	assert.Equal(t, 1, p.resumed)
-}
-
-func TestClientPauseResumeNoPausers(t *testing.T) {
+func TestApplyPauseNoPausers(t *testing.T) {
 	c := &Client{}
+	pauseMu.Lock()
+	defer pauseMu.Unlock()
 	// Must not panic with no pausable transports.
-	c.Pause()
-	c.Resume()
+	c.applyPause(true)
+	c.applyPause(false)
 }
 
 // restorePackageState isolates tests that touch the shared instance and its
@@ -77,15 +67,14 @@ func restorePackageState(t *testing.T) {
 	t.Helper()
 	mu.Lock()
 	pauseMu.Lock()
-	prevK, prevPaused, prevPauseApplied, prevInitialized, prevTransport := k, paused, pauseApplied, initialized, transport
-	k, paused, pauseApplied, initialized, transport = nil, false, false, false, nil
+	prevK, prevPaused, prevInitialized, prevTransport := k, paused, initialized, transport
+	k, paused, initialized, transport = nil, false, false, nil
 	pauseMu.Unlock()
 	mu.Unlock()
 	t.Cleanup(func() {
 		mu.Lock()
 		pauseMu.Lock()
-		k, pauseApplied, initialized, transport = prevK, prevPauseApplied, prevInitialized, prevTransport
-		paused = prevPaused
+		k, paused, initialized, transport = prevK, prevPaused, prevInitialized, prevTransport
 		pauseMu.Unlock()
 		mu.Unlock()
 	})
@@ -104,32 +93,20 @@ func TestPauseHeldForClientInstalledLater(t *testing.T) {
 	assert.Equal(t, 1, p.paused, "a client installed while paused must start paused")
 }
 
-func TestSetClientSkipsAlreadyAppliedHeldPause(t *testing.T) {
-	restorePackageState(t)
-	p := &fakePausable{paused: 1}
-	Pause()
-
-	mu.Lock()
-	setClient(&Client{pausers: []pausable{p}, pauseApplied: true})
-	mu.Unlock()
-	Resume()
-
-	assert.Equal(t, 1, p.paused, "a construction-applied pause must not be applied again")
-	assert.Equal(t, 1, p.resumed)
-}
-
 func TestPauseResumeDelegateToLiveClient(t *testing.T) {
 	restorePackageState(t)
-	p := &fakePausable{}
+	first, second := &fakePausable{}, &fakePausable{}
 	mu.Lock()
-	setClient(&Client{pausers: []pausable{p}})
+	setClient(&Client{pausers: []pausable{first, second}})
 	mu.Unlock()
 
 	Pause()
 	Resume()
 
-	assert.Equal(t, 1, p.paused)
-	assert.Equal(t, 1, p.resumed)
+	for _, p := range []*fakePausable{first, second} {
+		assert.Equal(t, 1, p.paused, "every pauser must receive the pause")
+		assert.Equal(t, 1, p.resumed, "every pauser must receive the resume")
+	}
 }
 
 func TestPauseResumeIgnoreRedundantCalls(t *testing.T) {
@@ -172,4 +149,5 @@ func TestResumeClearsHeldPause(t *testing.T) {
 	mu.Unlock()
 
 	assert.Equal(t, 0, p.paused, "a client installed after resume must start running")
+	assert.Equal(t, 0, p.resumed, "a client installed unpaused must not be touched")
 }

--- a/kindling/client_test.go
+++ b/kindling/client_test.go
@@ -76,12 +76,17 @@ func TestClientPauseResumeNoPausers(t *testing.T) {
 func restorePackageState(t *testing.T) {
 	t.Helper()
 	mu.Lock()
-	prevK, prevPaused, prevInitialized, prevTransport := k, paused, initialized, transport
-	k, paused, initialized, transport = nil, false, false, nil
+	pauseMu.Lock()
+	prevK, prevPaused, prevPauseApplied, prevInitialized, prevTransport := k, paused, pauseApplied, initialized, transport
+	k, paused, pauseApplied, initialized, transport = nil, false, false, false, nil
+	pauseMu.Unlock()
 	mu.Unlock()
 	t.Cleanup(func() {
 		mu.Lock()
-		k, paused, initialized, transport = prevK, prevPaused, prevInitialized, prevTransport
+		pauseMu.Lock()
+		k, pauseApplied, initialized, transport = prevK, prevPauseApplied, prevInitialized, prevTransport
+		paused = prevPaused
+		pauseMu.Unlock()
 		mu.Unlock()
 	})
 }
@@ -97,6 +102,20 @@ func TestPauseHeldForClientInstalledLater(t *testing.T) {
 	mu.Unlock()
 
 	assert.Equal(t, 1, p.paused, "a client installed while paused must start paused")
+}
+
+func TestSetClientSkipsAlreadyAppliedHeldPause(t *testing.T) {
+	restorePackageState(t)
+	p := &fakePausable{paused: 1}
+	Pause()
+
+	mu.Lock()
+	setClient(&Client{pausers: []pausable{p}, pauseApplied: true})
+	mu.Unlock()
+	Resume()
+
+	assert.Equal(t, 1, p.paused, "a construction-applied pause must not be applied again")
+	assert.Equal(t, 1, p.resumed)
 }
 
 func TestPauseResumeDelegateToLiveClient(t *testing.T) {

--- a/kindling/client_test.go
+++ b/kindling/client_test.go
@@ -46,3 +46,95 @@ func TestNewClient(t *testing.T) {
 		})
 	}
 }
+
+type fakePausable struct{ paused, resumed int }
+
+func (f *fakePausable) Pause()  { f.paused++ }
+func (f *fakePausable) Resume() { f.resumed++ }
+
+func TestClientPauseResumeDelegates(t *testing.T) {
+	p := &fakePausable{}
+	c := &Client{pausers: []pausable{p}}
+
+	c.Pause()
+	c.Pause()
+	c.Resume()
+
+	assert.Equal(t, 2, p.paused)
+	assert.Equal(t, 1, p.resumed)
+}
+
+func TestClientPauseResumeNoPausers(t *testing.T) {
+	c := &Client{}
+	// Must not panic with no pausable transports.
+	c.Pause()
+	c.Resume()
+}
+
+// restorePackageState isolates tests that touch the shared instance and its
+// held pause state.
+func restorePackageState(t *testing.T) {
+	t.Helper()
+	mu.Lock()
+	prevK, prevPaused := k, paused
+	k, paused = nil, false
+	mu.Unlock()
+	t.Cleanup(func() {
+		mu.Lock()
+		k, paused = prevK, prevPaused
+		mu.Unlock()
+	})
+}
+
+func TestPauseHeldForClientInstalledLater(t *testing.T) {
+	restorePackageState(t)
+	p := &fakePausable{}
+
+	// No shared instance yet, so this only records the state.
+	Pause()
+	mu.Lock()
+	setClient(&Client{pausers: []pausable{p}})
+	mu.Unlock()
+
+	assert.Equal(t, 1, p.paused, "a client installed while paused must start paused")
+}
+
+func TestPauseResumeDelegateToLiveClient(t *testing.T) {
+	restorePackageState(t)
+	p := &fakePausable{}
+	mu.Lock()
+	setClient(&Client{pausers: []pausable{p}})
+	mu.Unlock()
+
+	Pause()
+	Resume()
+
+	assert.Equal(t, 1, p.paused)
+	assert.Equal(t, 1, p.resumed)
+}
+
+func TestCloseClearsHeldPause(t *testing.T) {
+	restorePackageState(t)
+	p := &fakePausable{}
+
+	Pause()
+	require.NoError(t, Close())
+	mu.Lock()
+	setClient(&Client{pausers: []pausable{p}})
+	mu.Unlock()
+
+	assert.Equal(t, 0, p.paused, "Close must not leak the pause into the next instance")
+}
+
+func TestResumeClearsHeldPause(t *testing.T) {
+	restorePackageState(t)
+	p := &fakePausable{}
+
+	Pause()
+	Resume()
+	mu.Lock()
+	setClient(&Client{pausers: []pausable{p}})
+	mu.Unlock()
+
+	assert.Equal(t, 0, p.paused, "a client installed after resume must start running")
+}

--- a/kindling/client_test.go
+++ b/kindling/client_test.go
@@ -1,6 +1,7 @@
 package kindling
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -54,28 +55,21 @@ func (f *fakePausable) Resume() { f.resumed++ }
 
 func TestApplyPauseNoPausers(t *testing.T) {
 	c := &Client{}
-	pauseMu.Lock()
-	defer pauseMu.Unlock()
-	// Must not panic with no pausable transports.
-	c.applyPause(true)
-	c.applyPause(false)
+	mu.Lock()
+	defer mu.Unlock()
+	c.applyPauseLocked(true)
+	c.applyPauseLocked(false)
 }
 
-// restorePackageState isolates tests that touch the shared instance and its
-// held pause state.
 func restorePackageState(t *testing.T) {
 	t.Helper()
 	mu.Lock()
-	pauseMu.Lock()
 	prevK, prevPaused, prevInitialized, prevTransport := k, paused, initialized, transport
 	k, paused, initialized, transport = nil, false, false, nil
-	pauseMu.Unlock()
 	mu.Unlock()
 	t.Cleanup(func() {
 		mu.Lock()
-		pauseMu.Lock()
 		k, paused, initialized, transport = prevK, prevPaused, prevInitialized, prevTransport
-		pauseMu.Unlock()
 		mu.Unlock()
 	})
 }
@@ -84,8 +78,7 @@ func TestPauseHeldForClientInstalledLater(t *testing.T) {
 	restorePackageState(t)
 	p := &fakePausable{}
 
-	// No shared instance yet, so this only records the state.
-	Pause()
+	SetNetworkPaused(t.Context(), true)
 	mu.Lock()
 	setClient(&Client{pausers: []pausable{p}})
 	mu.Unlock()
@@ -100,8 +93,8 @@ func TestPauseResumeDelegateToLiveClient(t *testing.T) {
 	setClient(&Client{pausers: []pausable{first, second}})
 	mu.Unlock()
 
-	Pause()
-	Resume()
+	SetNetworkPaused(t.Context(), true)
+	SetNetworkPaused(t.Context(), false)
 
 	for _, p := range []*fakePausable{first, second} {
 		assert.Equal(t, 1, p.paused, "every pauser must receive the pause")
@@ -116,10 +109,10 @@ func TestPauseResumeIgnoreRedundantCalls(t *testing.T) {
 	setClient(&Client{pausers: []pausable{p}})
 	mu.Unlock()
 
-	Pause()
-	Pause()
-	Resume()
-	Resume()
+	SetNetworkPaused(t.Context(), true)
+	SetNetworkPaused(t.Context(), true)
+	SetNetworkPaused(t.Context(), false)
+	SetNetworkPaused(t.Context(), false)
 
 	assert.Equal(t, 1, p.paused, "a redundant Pause must not reach the transports")
 	assert.Equal(t, 1, p.resumed, "a redundant Resume must not reach the transports")
@@ -129,7 +122,7 @@ func TestCloseClearsHeldPause(t *testing.T) {
 	restorePackageState(t)
 	p := &fakePausable{}
 
-	Pause()
+	SetNetworkPaused(t.Context(), true)
 	require.NoError(t, Close())
 	mu.Lock()
 	setClient(&Client{pausers: []pausable{p}})
@@ -142,12 +135,57 @@ func TestResumeClearsHeldPause(t *testing.T) {
 	restorePackageState(t)
 	p := &fakePausable{}
 
-	Pause()
-	Resume()
+	SetNetworkPaused(t.Context(), true)
+	SetNetworkPaused(t.Context(), false)
 	mu.Lock()
 	setClient(&Client{pausers: []pausable{p}})
 	mu.Unlock()
 
 	assert.Equal(t, 0, p.paused, "a client installed after resume must start running")
 	assert.Equal(t, 0, p.resumed, "a client installed unpaused must not be touched")
+}
+
+func TestSetNetworkPausedIgnoresCanceledUpdates(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		next bool
+	}{
+		{name: "pause", next: true},
+		{name: "wake", next: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			restorePackageState(t)
+			ctx, cancel := context.WithCancel(t.Context())
+			cancel()
+			SetNetworkPaused(t.Context(), !tc.next)
+			p := &fakePausable{}
+			mu.Lock()
+			setClient(&Client{pausers: []pausable{p}})
+			mu.Unlock()
+			before := *p
+
+			SetNetworkPaused(ctx, tc.next)
+
+			assert.Equal(t, before, *p, "canceled updates must not reach a live transport")
+			assert.Equal(t, !tc.next, paused, "canceled updates must not change the held state")
+		})
+	}
+}
+
+func TestSetNetworkPausedCanceledPauseAfterClose(t *testing.T) {
+	restorePackageState(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	SetNetworkPaused(ctx, true)
+	cancel()
+	require.NoError(t, Close())
+
+	SetNetworkPaused(ctx, true)
+	p := &fakePausable{}
+	mu.Lock()
+	setClient(&Client{pausers: []pausable{p}})
+	mu.Unlock()
+
+	assert.Zero(t, p.paused, "a canceled backend must not pause the next client")
+	SetNetworkPaused(t.Context(), true)
+	assert.Equal(t, 1, p.paused, "the next backend must still be able to pause")
 }

--- a/kindling/client_test.go
+++ b/kindling/client_test.go
@@ -76,12 +76,12 @@ func TestClientPauseResumeNoPausers(t *testing.T) {
 func restorePackageState(t *testing.T) {
 	t.Helper()
 	mu.Lock()
-	prevK, prevPaused := k, paused
-	k, paused = nil, false
+	prevK, prevPaused, prevInitialized, prevTransport := k, paused, initialized, transport
+	k, paused, initialized, transport = nil, false, false, nil
 	mu.Unlock()
 	t.Cleanup(func() {
 		mu.Lock()
-		k, paused = prevK, prevPaused
+		k, paused, initialized, transport = prevK, prevPaused, prevInitialized, prevTransport
 		mu.Unlock()
 	})
 }
@@ -111,6 +111,22 @@ func TestPauseResumeDelegateToLiveClient(t *testing.T) {
 
 	assert.Equal(t, 1, p.paused)
 	assert.Equal(t, 1, p.resumed)
+}
+
+func TestPauseResumeIgnoreRedundantCalls(t *testing.T) {
+	restorePackageState(t)
+	p := &fakePausable{}
+	mu.Lock()
+	setClient(&Client{pausers: []pausable{p}})
+	mu.Unlock()
+
+	Pause()
+	Pause()
+	Resume()
+	Resume()
+
+	assert.Equal(t, 1, p.paused, "a redundant Pause must not reach the transports")
+	assert.Equal(t, 1, p.resumed, "a redundant Resume must not reach the transports")
 }
 
 func TestCloseClearsHeldPause(t *testing.T) {

--- a/kindling/fronted/fronted.go
+++ b/kindling/fronted/fronted.go
@@ -74,9 +74,8 @@ func retryableResponse(resp *http.Response) bool {
 // valid response wins. domainfront's config updater (WithConfigURL) fetches them
 // off the critical path, persists the result (WithConfigCacheFile), and
 // bootstraps from that persisted copy on the next start in preference to the
-// embedded seed. The smart HTTP client is tuned for both hosts. If startPaused
-// reports true during construction, background work starts paused.
-func NewFronted(ctx context.Context, cacheFile string, logWriter io.Writer, startPaused func() bool) (*domainfront.Client, error) {
+// embedded seed. The smart HTTP client is tuned for both hosts.
+func NewFronted(ctx context.Context, cacheFile string, logWriter io.Writer) (*domainfront.Client, error) {
 	_, span := otel.Tracer(tracerName).Start(ctx, "NewFronted")
 	defer span.End()
 
@@ -100,13 +99,6 @@ func NewFronted(ctx context.Context, cacheFile string, logWriter io.Writer, star
 		domainfront.WithConfigURL(configURL, mirrorConfigURL),
 		domainfront.WithHTTPClient(smartClient),
 		domainfront.WithRetryableResponse(retryableResponse),
-	}
-	if startPaused != nil {
-		opts = append(opts, func(c *domainfront.Client) {
-			if startPaused() {
-				c.Pause()
-			}
-		})
 	}
 	return domainfront.New(ctx, seed, opts...)
 }

--- a/kindling/fronted/fronted.go
+++ b/kindling/fronted/fronted.go
@@ -74,8 +74,9 @@ func retryableResponse(resp *http.Response) bool {
 // valid response wins. domainfront's config updater (WithConfigURL) fetches them
 // off the critical path, persists the result (WithConfigCacheFile), and
 // bootstraps from that persisted copy on the next start in preference to the
-// embedded seed. The smart HTTP client is tuned for both hosts.
-func NewFronted(ctx context.Context, cacheFile string, logWriter io.Writer) (*domainfront.Client, error) {
+// embedded seed. The smart HTTP client is tuned for both hosts. If startPaused
+// reports true during construction, background work starts paused.
+func NewFronted(ctx context.Context, cacheFile string, logWriter io.Writer, startPaused func() bool) (*domainfront.Client, error) {
 	_, span := otel.Tracer(tracerName).Start(ctx, "NewFronted")
 	defer span.End()
 
@@ -99,6 +100,13 @@ func NewFronted(ctx context.Context, cacheFile string, logWriter io.Writer) (*do
 		domainfront.WithConfigURL(configURL, mirrorConfigURL),
 		domainfront.WithHTTPClient(smartClient),
 		domainfront.WithRetryableResponse(retryableResponse),
+	}
+	if startPaused != nil {
+		opts = append(opts, func(c *domainfront.Client) {
+			if startPaused() {
+				c.Pause()
+			}
+		})
 	}
 	return domainfront.New(ctx, seed, opts...)
 }


### PR DESCRIPTION
## What

Wires the sing-box pause manager's network transitions through to the domainfront transport, so its background work stops while there is no usable network instead of dialing a whole pass of fronts and marking them failed on evidence that says nothing about the fronts.

Chain: pause manager → `tunnel.onPauseUpdate` → `vpn.NetworkEvent` → backend subscription → `kindling.Pause`/`Resume` → `kindling.Client` pausers → `domainfront.Client.Pause`/`Resume`.

- **`kindling/client.go`** — a `pausable` interface, `pausers` on `Client`, an unexported `Client.applyPause` fan-out, and package-level `Pause`/`Resume`. The domainfront client is the one pausable transport today.
- **`backend/radiance.go`** — subscribes to `vpn.NetworkEvent` and drives the above.

The `NetworkEvent` producer side already landed on `main` with the network-recovery work; this is the consumer half. Round trips are not gated, so API and config requests still work while background work is suspended.

## Held pause state

The pause manager emits only transitions, so a pause arriving before the shared kindling instance exists would be dropped with no replay, and the client built afterward would start crawling during the outage. `kindling` records the last pause state and applies it to a client as it is installed (`setClient`).

`Close` clears that state. Wakes only ever come from a live tunnel, and the teardown wake is not reliably delivered — `subscriber.run` drops still-queued events once stopped, and `LocalBackend.Close` cancels immediately after `DisconnectVPN` with no happens-before between the two. Without the reset, a pause in effect at teardown would leak into the next instance built in the same process (which mobile does) and suspend front crawling for that entire session.

The level lives at package scope and nowhere else: `Client` owns its `pausers` but keeps no copy of whether they are paused, so `setClient` is the single point where a held pause reaches a newly built client. An earlier revision also mirrored the state on `Client` and built the client pre-paused to suppress crawling during construction; that cost three copies of one boolean reconciled at construction, installation and teardown.

## Accepted window

A pause arriving between the start of transport construction and `setClient` is not suppressed, so `domainfront`'s crawler can complete one pass before the pause lands. This is deliberate. domainfront documents `Pause` as best-effort for work already running ("vets in flight when Pause lands run to completion and may still mark their fronts failed"), so pausing at construction never made the suppression complete — it removed one pass at cold start while leaving the same behavior at every later pause. Closing the window properly needs a caller-owned gate upstream (a `domainfront.WithPauseGate(g)` option) so the transport reads the level instead of being told; that is out of scope here.

closes getlantern/engineering#3873


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Network activity now automatically pauses when the device enters sleep or the VPN connection pauses, and resumes when the device wakes or connectivity returns.
  - Pause and resume state is preserved across client initialization, ensuring activity consistently reflects the current device and network state.
  - Network state changes are ignored when the associated operation has been canceled.

- **Bug Fixes**
  - Prevented redundant pause and resume operations while maintaining correct behavior for active connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
