### PR TITLE
Fix donor startup when the GitHub STUN list cannot resolve

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/alitto/pond v1.9.2
 	github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c
 	github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952
-	github.com/getlantern/common v1.2.1-0.20260828200436-eb05c571820d
+	github.com/getlantern/common v1.2.1-0.20260910145002-674a9909c9d4
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac
 	github.com/getlantern/domainfront v0.0.0-20260909200720-c902df092c5f
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/alitto/pond v1.9.2
 	github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c
 	github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952
-	github.com/getlantern/common v1.2.1-0.20260910153745-df1eba6911f8
+	github.com/getlantern/common v1.2.1-0.20260910154003-08e030318f24
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac
 	github.com/getlantern/domainfront v0.0.0-20260909200720-c902df092c5f
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/alitto/pond v1.9.2
 	github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c
 	github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952
-	github.com/getlantern/common v1.2.1-0.20260910153032-2a9a18d34114
+	github.com/getlantern/common v1.2.1-0.20260910153745-df1eba6911f8
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac
 	github.com/getlantern/domainfront v0.0.0-20260909200720-c902df092c5f
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/alitto/pond v1.9.2
 	github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c
 	github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952
-	github.com/getlantern/common v1.2.1-0.20260910145002-674a9909c9d4
+	github.com/getlantern/common v1.2.1-0.20260910153032-2a9a18d34114
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac
 	github.com/getlantern/domainfront v0.0.0-20260909200720-c902df092c5f
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,8 @@ github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c h1:ZzxuhIWO295y4eE6
 github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c/go.mod h1:b5teAOFT+vpBqc2CHoz74QTEM15iOv1PLdQogwXcfrM=
 github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952 h1:nD8iJ4IpaTq/09PhoOzmaGTwatOxsR41neSmbCY6RS8=
 github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952/go.mod h1:1+1kCIg9Zj+2CgN+vl868AlAZVUItuN4wLhFur5QakA=
-github.com/getlantern/common v1.2.1-0.20260910153032-2a9a18d34114 h1:Q9k6xvZmQwqRvpYaNGk5rZcdb+s7vkAfXUrFXGpTsgs=
-github.com/getlantern/common v1.2.1-0.20260910153032-2a9a18d34114/go.mod h1:9iL78jR5kZqr0E7oPxi38o6gPMhVa5dJBC5ngUgHzdg=
+github.com/getlantern/common v1.2.1-0.20260910153745-df1eba6911f8 h1:IwWvoHjwlpTlojI0zFKojR6ob30RsjrwKjn1JkoOeRQ=
+github.com/getlantern/common v1.2.1-0.20260910153745-df1eba6911f8/go.mod h1:9iL78jR5kZqr0E7oPxi38o6gPMhVa5dJBC5ngUgHzdg=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,8 @@ github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c h1:ZzxuhIWO295y4eE6
 github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c/go.mod h1:b5teAOFT+vpBqc2CHoz74QTEM15iOv1PLdQogwXcfrM=
 github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952 h1:nD8iJ4IpaTq/09PhoOzmaGTwatOxsR41neSmbCY6RS8=
 github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952/go.mod h1:1+1kCIg9Zj+2CgN+vl868AlAZVUItuN4wLhFur5QakA=
-github.com/getlantern/common v1.2.1-0.20260910153745-df1eba6911f8 h1:IwWvoHjwlpTlojI0zFKojR6ob30RsjrwKjn1JkoOeRQ=
-github.com/getlantern/common v1.2.1-0.20260910153745-df1eba6911f8/go.mod h1:9iL78jR5kZqr0E7oPxi38o6gPMhVa5dJBC5ngUgHzdg=
+github.com/getlantern/common v1.2.1-0.20260910154003-08e030318f24 h1:RrJsgaBsK+IspwFX7JwjFRItCWKZoKVY7UcsugheQvg=
+github.com/getlantern/common v1.2.1-0.20260910154003-08e030318f24/go.mod h1:9iL78jR5kZqr0E7oPxi38o6gPMhVa5dJBC5ngUgHzdg=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,8 @@ github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c h1:ZzxuhIWO295y4eE6
 github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c/go.mod h1:b5teAOFT+vpBqc2CHoz74QTEM15iOv1PLdQogwXcfrM=
 github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952 h1:nD8iJ4IpaTq/09PhoOzmaGTwatOxsR41neSmbCY6RS8=
 github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952/go.mod h1:1+1kCIg9Zj+2CgN+vl868AlAZVUItuN4wLhFur5QakA=
-github.com/getlantern/common v1.2.1-0.20260910145002-674a9909c9d4 h1:ZwIisw7aRkHsPXtA/tVazWIjyhjKTVTaCNi9vbEeH+4=
-github.com/getlantern/common v1.2.1-0.20260910145002-674a9909c9d4/go.mod h1:9iL78jR5kZqr0E7oPxi38o6gPMhVa5dJBC5ngUgHzdg=
+github.com/getlantern/common v1.2.1-0.20260910153032-2a9a18d34114 h1:Q9k6xvZmQwqRvpYaNGk5rZcdb+s7vkAfXUrFXGpTsgs=
+github.com/getlantern/common v1.2.1-0.20260910153032-2a9a18d34114/go.mod h1:9iL78jR5kZqr0E7oPxi38o6gPMhVa5dJBC5ngUgHzdg=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,8 @@ github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c h1:ZzxuhIWO295y4eE6
 github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c/go.mod h1:b5teAOFT+vpBqc2CHoz74QTEM15iOv1PLdQogwXcfrM=
 github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952 h1:nD8iJ4IpaTq/09PhoOzmaGTwatOxsR41neSmbCY6RS8=
 github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952/go.mod h1:1+1kCIg9Zj+2CgN+vl868AlAZVUItuN4wLhFur5QakA=
-github.com/getlantern/common v1.2.1-0.20260828200436-eb05c571820d h1:ere/uJH2664qGRepjvircloQN7WWCY4eQ+oiw2C4Hno=
-github.com/getlantern/common v1.2.1-0.20260828200436-eb05c571820d/go.mod h1:9iL78jR5kZqr0E7oPxi38o6gPMhVa5dJBC5ngUgHzdg=
+github.com/getlantern/common v1.2.1-0.20260910145002-674a9909c9d4 h1:ZwIisw7aRkHsPXtA/tVazWIjyhjKTVTaCNi9vbEeH+4=
+github.com/getlantern/common v1.2.1-0.20260910145002-674a9909c9d4/go.mod h1:9iL78jR5kZqr0E7oPxi38o6gPMhVa5dJBC5ngUgHzdg=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=

--- a/unbounded/unbounded.go
+++ b/unbounded/unbounded.go
@@ -235,8 +235,9 @@ func donorSTUNPool(servers []string) []string {
 		}
 	}
 	if len(pool) == 0 {
-		return C.DefaultDonorSTUNServers()
+		pool = C.DefaultDonorSTUNServers()
 	}
+	slices.Sort(pool)
 	return pool
 }
 

--- a/unbounded/unbounded.go
+++ b/unbounded/unbounded.go
@@ -29,7 +29,6 @@ import (
 	"math/rand"
 	"net"
 	"slices"
-	"strings"
 	"sync"
 	"time"
 
@@ -213,36 +212,8 @@ func cfgUsable(cfg *C.UnboundedConfig) bool {
 		cfg.EgressAddr != "" && cfg.EgressEndpoint != ""
 }
 
-func cfgEqual(a, b *C.UnboundedConfig) bool {
-	if a == b {
-		return true
-	}
-	if a == nil || b == nil {
-		return false
-	}
-	return a.DiscoverySrv == b.DiscoverySrv && a.DiscoveryEndpoint == b.DiscoveryEndpoint &&
-		a.EgressAddr == b.EgressAddr && a.EgressEndpoint == b.EgressEndpoint &&
-		a.CTableSize == b.CTableSize && a.PTableSize == b.PTableSize &&
-		slices.Equal(donorSTUNPool(a.STUNServers), donorSTUNPool(b.STUNServers))
-}
-
-func donorSTUNPool(servers []string) []string {
-	pool := make([]string, 0, len(servers))
-	for _, server := range servers {
-		server = strings.TrimSpace(server)
-		if server != "" && !slices.Contains(pool, server) {
-			pool = append(pool, server)
-		}
-	}
-	if len(pool) == 0 {
-		pool = C.DefaultDonorSTUNServers()
-	}
-	slices.Sort(pool)
-	return pool
-}
-
 func donorSTUNBatch(servers []string) func(uint32) ([]string, error) {
-	pool := donorSTUNPool(servers)
+	pool := C.NormalizeDonorSTUNServers(servers)
 	return func(size uint32) ([]string, error) {
 		batch := slices.Clone(pool)
 		rand.Shuffle(len(batch), func(i, j int) { batch[i], batch[j] = batch[j], batch[i] })
@@ -371,7 +342,7 @@ func applyConfig(cfg config.Config) {
 	shouldRun := manager.shouldStart()
 	running := manager.cancel != nil
 	ucfg := manager.lastCfg
-	cfgChanged := running && !cfgEqual(manager.runningCfg, ucfg)
+	cfgChanged := running && !manager.runningCfg.Equal(ucfg)
 	manager.mu.Unlock()
 
 	switch {
@@ -524,11 +495,7 @@ func (m *unboundedManager) start() {
 	done := make(chan struct{})
 	m.cancel = cancel
 	m.done = done
-	// Snapshot the config the worker is being started with so a
-	// later applyConfig can detect parameter changes and restart.
-	// Pointer-stored (not value-stored) because the upstream
-	// lastCfg is also a pointer and equality is value-based via
-	// cfgEqual.
+	// Retain the immutable config snapshot to detect changes while this worker runs.
 	m.runningCfg = ucfg
 	m.peers = make(map[int]string)
 	m.mu.Unlock()

--- a/unbounded/unbounded.go
+++ b/unbounded/unbounded.go
@@ -26,7 +26,10 @@ package unbounded
 import (
 	"context"
 	"log/slog"
+	"math/rand"
 	"net"
+	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -210,11 +213,6 @@ func cfgUsable(cfg *C.UnboundedConfig) bool {
 		cfg.EgressAddr != "" && cfg.EgressEndpoint != ""
 }
 
-// cfgEqual reports whether two UnboundedConfig pointers refer to
-// configurations broflake would consume identically. UnboundedConfig
-// is a flat struct of strings and ints, so value equality is well-
-// defined. Nil pointers compare equal to themselves and unequal to
-// any non-nil pointer.
 func cfgEqual(a, b *C.UnboundedConfig) bool {
 	if a == b {
 		return true
@@ -222,7 +220,36 @@ func cfgEqual(a, b *C.UnboundedConfig) bool {
 	if a == nil || b == nil {
 		return false
 	}
-	return *a == *b
+	return a.DiscoverySrv == b.DiscoverySrv && a.DiscoveryEndpoint == b.DiscoveryEndpoint &&
+		a.EgressAddr == b.EgressAddr && a.EgressEndpoint == b.EgressEndpoint &&
+		a.CTableSize == b.CTableSize && a.PTableSize == b.PTableSize &&
+		slices.Equal(donorSTUNPool(a.STUNServers), donorSTUNPool(b.STUNServers))
+}
+
+func donorSTUNPool(servers []string) []string {
+	pool := make([]string, 0, len(servers))
+	for _, server := range servers {
+		server = strings.TrimSpace(server)
+		if server != "" && !slices.Contains(pool, server) {
+			pool = append(pool, server)
+		}
+	}
+	if len(pool) == 0 {
+		return C.DefaultDonorSTUNServers()
+	}
+	return pool
+}
+
+func donorSTUNBatch(servers []string) func(uint32) ([]string, error) {
+	pool := donorSTUNPool(servers)
+	return func(size uint32) ([]string, error) {
+		batch := slices.Clone(pool)
+		rand.Shuffle(len(batch), func(i, j int) { batch[i], batch[j] = batch[j], batch[i] })
+		if uint64(size) < uint64(len(batch)) {
+			batch = batch[:size]
+		}
+		return batch, nil
+	}
 }
 
 // Enabled reports whether the local opt-in is set. Doesn't say whether
@@ -326,22 +353,19 @@ func InitSubscription(initial *config.Config) {
 	}
 }
 
-// applyConfig caches the server-side half of the start predicate and
-// transitions the manager start/stop accordingly. Shared by
-// InitSubscription's NewConfigEvent handler and the initial-config
-// seeding path so cached and live configs follow identical logic.
-// No-op when the manager is disarmed (post-Stop) so a late event
-// arriving after backend shutdown doesn't revive the widget.
+// applyConfig ignores updates after Stop so late events cannot restart the widget.
 func applyConfig(cfg config.Config) {
 	manager.mu.Lock()
 	if !manager.armed {
 		manager.mu.Unlock()
 		return
 	}
-	// config.Config is a type alias for C.ConfigResponse on the
-	// current radiance branch — no nested .ConfigResponse field,
-	// just dereference and use directly.
 	manager.lastCfg = cfg.Unbounded
+	if cfg.Unbounded != nil {
+		copied := *cfg.Unbounded
+		copied.STUNServers = slices.Clone(cfg.Unbounded.STUNServers)
+		manager.lastCfg = &copied
+	}
 	manager.lastFeatureOn = cfg.Features[C.UNBOUNDED]
 	shouldRun := manager.shouldStart()
 	running := manager.cancel != nil
@@ -559,7 +583,9 @@ func (m *unboundedManager) start() {
 		}
 
 		rtcOpt := clientcore.NewDefaultWebRTCOptions()
+		rtcOpt.STUNBatch = donorSTUNBatch(nil)
 		if ucfg != nil {
+			rtcOpt.STUNBatch = donorSTUNBatch(ucfg.STUNServers)
 			if ucfg.DiscoverySrv != "" {
 				rtcOpt.DiscoverySrv = ucfg.DiscoverySrv
 			}

--- a/unbounded/unbounded_test.go
+++ b/unbounded/unbounded_test.go
@@ -762,7 +762,7 @@ func TestDonorSTUNConfiguration(t *testing.T) {
 			manager.start()
 			select {
 			case batch := <-received:
-				require.ElementsMatch(t, donorSTUNPool(servers), batch)
+				require.ElementsMatch(t, C.NormalizeDonorSTUNServers(servers), batch)
 				require.NotEmpty(t, batch)
 			case <-time.After(time.Second):
 				t.Fatal("donor startup blocked")
@@ -816,7 +816,6 @@ func TestApplyConfigRestartsOnSTUNChange(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("STUN change did not restart donor")
 	}
-	require.True(t, cfgEqual(&C.UnboundedConfig{}, &C.UnboundedConfig{STUNServers: C.DefaultDonorSTUNServers()}))
 }
 
 func TestApplyConfigDoesNotRestartOnSTUNReorder(t *testing.T) {

--- a/unbounded/unbounded_test.go
+++ b/unbounded/unbounded_test.go
@@ -818,3 +818,27 @@ func TestApplyConfigRestartsOnSTUNChange(t *testing.T) {
 	}
 	require.True(t, cfgEqual(&C.UnboundedConfig{}, &C.UnboundedConfig{STUNServers: C.DefaultDonorSTUNServers()}))
 }
+
+func TestApplyConfigDoesNotRestartOnSTUNReorder(t *testing.T) {
+	starts := atomic.Int32{}
+	resetManager(t, func(_ *clientcore.BroflakeOptions, _ *clientcore.WebRTCOptions, _ *clientcore.EgressOptions) (widget, error) {
+		starts.Add(1)
+		return &fakeWidget{}, nil
+	})
+	defer manager.stop()
+	require.NoError(t, settings.Set(settings.UnboundedKey, true))
+	cfg := testCfg()
+	cfg.STUNServers = []string{"stun:192.0.2.1:3478", "stun:192.0.2.2:3478"}
+	applyConfig(config.Config{Features: map[string]bool{C.UNBOUNDED: true}, Unbounded: cfg})
+	waitForCount(t, &starts, 1, time.Second)
+	manager.mu.Lock()
+	originalDone := manager.done
+	manager.mu.Unlock()
+	cfg.STUNServers = []string{"stun:192.0.2.2:3478", " stun:192.0.2.1:3478 ", "stun:192.0.2.2:3478"}
+	applyConfig(config.Config{Features: map[string]bool{C.UNBOUNDED: true}, Unbounded: cfg})
+	manager.mu.Lock()
+	currentDone := manager.done
+	manager.mu.Unlock()
+	require.Equal(t, originalDone, currentDone)
+	require.Equal(t, int32(1), starts.Load())
+}

--- a/unbounded/unbounded_test.go
+++ b/unbounded/unbounded_test.go
@@ -2,6 +2,7 @@ package unbounded
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os"
 	"sync"
@@ -743,4 +744,77 @@ func TestInternalStop_TimesOut(t *testing.T) {
 
 	// Release the worker so the test's cleanup wait completes.
 	close(block)
+}
+
+func TestDonorSTUNConfiguration(t *testing.T) {
+	for _, servers := range [][]string{nil, {}, {" ", ""}, {"stun:192.0.2.1:3478", "stun:192.0.2.2:3478"}} {
+		t.Run(fmt.Sprint(servers), func(t *testing.T) {
+			received := make(chan []string, 1)
+			resetManager(t, func(_ *clientcore.BroflakeOptions, rtc *clientcore.WebRTCOptions, _ *clientcore.EgressOptions) (widget, error) {
+				batch, err := rtc.STUNBatch(100)
+				received <- batch
+				return &fakeWidget{}, err
+			})
+			defer manager.stop()
+			cfg := testCfg()
+			cfg.STUNServers = servers
+			primeManager(t, cfg)
+			manager.start()
+			select {
+			case batch := <-received:
+				require.ElementsMatch(t, donorSTUNPool(servers), batch)
+				require.NotEmpty(t, batch)
+			case <-time.After(time.Second):
+				t.Fatal("donor startup blocked")
+			}
+		})
+	}
+}
+
+func TestDonorSTUNBatchIsolation(t *testing.T) {
+	pool := []string{" stun:192.0.2.1:3478 ", "stun:192.0.2.1:3478", "stun:192.0.2.2:3478"}
+	sample := donorSTUNBatch(pool)
+	pool[0] = "changed"
+	batch, err := sample(100)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"stun:192.0.2.1:3478", "stun:192.0.2.2:3478"}, batch)
+	batch[0] = "changed"
+	next, err := sample(100)
+	require.NoError(t, err)
+	require.NotContains(t, next, "changed")
+	empty, err := sample(0)
+	require.NoError(t, err)
+	require.Empty(t, empty)
+	one, err := sample(1)
+	require.NoError(t, err)
+	require.Len(t, one, 1)
+}
+
+func TestApplyConfigRestartsOnSTUNChange(t *testing.T) {
+	received := make(chan []string, 3)
+	resetManager(t, func(_ *clientcore.BroflakeOptions, rtc *clientcore.WebRTCOptions, _ *clientcore.EgressOptions) (widget, error) {
+		batch, err := rtc.STUNBatch(100)
+		received <- batch
+		return &fakeWidget{}, err
+	})
+	defer manager.stop()
+	require.NoError(t, settings.Set(settings.UnboundedKey, true))
+	cfg := testCfg()
+	cfg.STUNServers = []string{"stun:192.0.2.1:3478"}
+	applyConfig(config.Config{Features: map[string]bool{C.UNBOUNDED: true}, Unbounded: cfg})
+	select {
+	case batch := <-received:
+		require.Equal(t, cfg.STUNServers, batch)
+	case <-time.After(time.Second):
+		t.Fatal("first donor did not start")
+	}
+	cfg.STUNServers[0] = "stun:192.0.2.2:3478"
+	applyConfig(config.Config{Features: map[string]bool{C.UNBOUNDED: true}, Unbounded: cfg})
+	select {
+	case batch := <-received:
+		require.Equal(t, cfg.STUNServers, batch)
+	case <-time.After(time.Second):
+		t.Fatal("STUN change did not restart donor")
+	}
+	require.True(t, cfgEqual(&C.UnboundedConfig{}, &C.UnboundedConfig{STUNServers: C.DefaultDonorSTUNServers()}))
 }


### PR DESCRIPTION
Action Mode can report running while all donor workers retry a GitHub STUN-list download that cannot resolve through the active macOS tunnel. Use `UnboundedConfig.stun_servers` instead, with an eight-server IP-based fallback when the field is absent or empty. Donor startup no longer requires the GitHub request.

Use Common’s `UnboundedConfig.Equal` and `NormalizeDonorSTUNServers` for effective configuration comparison and STUN normalization. Sample without replacement, copy configuration slices, and restart the worker when its effective STUN pool changes. Older API responses use the compiled fallback. This changes the native donor; consumer outbounds and discovery HTTP transport are unchanged. The broader tunnel DNS/signaling issue remains separate.

Uses merged https://github.com/getlantern/common/pull/34 for shared equality and normalization, following merged https://github.com/getlantern/common/pull/33. Pins Common merge commit `08e030318f24` on `atavism/usermessage`; ran `go mod tidy`. Companion API PR: https://github.com/getlantern/lantern-cloud/pull/3324.

```mermaid
sequenceDiagram
    autonumber
    participant A as API<br/>config.go
    participant R as Donor<br/>unbounded.go
    participant P as WebRTC<br/>producer.go
    participant S as STUN list<br/>settings.go
    A->>R: config.go:913<br/>Send configured STUN pool
    Note over R: unbounded.go:556<br/>Install local sampler before worker creation ⚠️
    P->>R: producer.go:38<br/>Request STUN batch
    R-->>P: unbounded.go:215<br/>Configured pool or compiled fallback
    rect rgba(255, 200, 200, 0.3)
        Note over S: settings.go:115<br/>Old default fetched GitHub through system DNS 🐛
        Note over P: producer.go:41<br/>A fetch failure returned to initialization
    end
```

Line references use this PR, the companion API branch, and the pinned broflake commit `bef5e5234952`.

Validation: `go test -race ./unbounded -timeout=90s`; configured/default startup, batch isolation, and restart-on-STUN-change tests, plus a regression test ensuring reordered pools do not restart the worker. All eight fallback servers answered live STUN binding requests during investigation. Comment review completed. On-device recovery has not yet been verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added STUN server configuration support for the unbounded donor widget.
  - STUN server lists are cleaned up automatically by trimming entries, removing duplicates, and applying defaults when no servers are provided.
  - WebRTC connections use randomized STUN server batches.
  - Updated STUN settings are applied when the donor configuration changes.

- **Bug Fixes**
  - Improved configuration isolation to prevent unexpected changes caused by shared server lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Additional check: `go vet ./unbounded` reports existing `sync.Once` copy warnings in the unchanged `resetManager` test helper (lines 72 and 96); the race-enabled test suite passes.
