### PR TITLE
Support service-owned mobile backends without IPC fallback

### DIFF
--- a/ipc/client_mobile.go
+++ b/ipc/client_mobile.go
@@ -47,6 +47,12 @@ func NewClient(ctx context.Context, opts backend.Options) (*Client, error) {
 	return c, nil
 }
 
+// NewRemoteClient creates a socket-only client that never starts or owns a backend.
+// An unavailable IPC server produces ErrIPCNotRunning instead of a local fallback.
+func NewRemoteClient() *Client {
+	return newClient()
+}
+
 // NewLoopbackClient creates a Client that serves all requests in-process
 // through the given LocalBackend without attempting IPC socket connections.
 // The backend is NOT owned by this client — Close will not shut it down.
@@ -71,6 +77,9 @@ func (c *Client) Close() {
 func (c *Client) stopLocal() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.localapi == nil {
+		return
+	}
 	if be := c.localapi.setBackend(nil); be != nil {
 		be.Close()
 	}
@@ -100,6 +109,9 @@ func (c *Client) do(ctx context.Context, method, endpoint string, body any) ([]b
 	resp, err := c.http.Do(req)
 	if err != nil {
 		if isConnectionError(err) {
+			if c.localapi == nil {
+				return nil, fmt.Errorf("ipc request %s %s: %w: %w", method, endpoint, ErrIPCNotRunning, err)
+			}
 			c.mu.Lock()
 			defer c.mu.Unlock()
 			if be := c.localapi.be.Load(); be == nil {
@@ -266,10 +278,7 @@ func (c *Client) sseStream(ctx context.Context, endpoint string, handler func([]
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		c.mu.RLock()
-		hasFallback := c.localapi != nil
-		c.mu.RUnlock()
-		if hasFallback && isConnectionError(err) {
+		if isConnectionError(err) {
 			return ErrIPCNotRunning
 		}
 		return fmt.Errorf("SSE connect %s: %w", endpoint, err)

--- a/ipc/client_mobile.go
+++ b/ipc/client_mobile.go
@@ -279,7 +279,7 @@ func (c *Client) sseStream(ctx context.Context, endpoint string, handler func([]
 	resp, err := c.http.Do(req)
 	if err != nil {
 		if isConnectionError(err) {
-			return ErrIPCNotRunning
+			return fmt.Errorf("SSE connect %s: %w: %w", endpoint, ErrIPCNotRunning, err)
 		}
 		return fmt.Errorf("SSE connect %s: %w", endpoint, err)
 	}

--- a/ipc/client_mobile_test.go
+++ b/ipc/client_mobile_test.go
@@ -3,6 +3,11 @@
 package ipc
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -32,4 +37,39 @@ func TestFallbackOptionsPreserveUserMessageCapabilities(t *testing.T) {
 	fallback.EnvOverrides["RADIANCE_ENV"] = "changed"
 	require.Equal(t, wire.SurfaceSnackbar, client.opts.UserMessageCapabilities.Surfaces[0])
 	require.Equal(t, "staging", client.opts.EnvOverrides["RADIANCE_ENV"])
+}
+
+type remoteTransport func(*http.Request) (*http.Response, error)
+
+func (f remoteTransport) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestRemoteClientNeverCreatesFallback(t *testing.T) {
+	client := NewRemoteClient()
+	require.Nil(t, client.localapi)
+	defer client.Close()
+	for _, connectionErr := range []error{syscall.ENOENT, syscall.ECONNREFUSED} {
+		client.http.Transport = remoteTransport(func(*http.Request) (*http.Response, error) {
+			return nil, connectionErr
+		})
+		_, err := client.do(context.Background(), http.MethodGet, "/settings", nil)
+		require.ErrorIs(t, err, ErrIPCNotRunning)
+		require.ErrorIs(t, err, connectionErr)
+		require.ErrorIs(t, client.sseStream(context.Background(), "/config/events", func([]byte) {}), ErrIPCNotRunning)
+		require.Nil(t, client.localapi)
+	}
+	client.http.Transport = remoteTransport(func(r *http.Request) (*http.Response, error) {
+		body := "{}"
+		if r.Header.Get("Accept") == "text/event-stream" {
+			body = "data: connected\n\n"
+		}
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
+	})
+	body, err := client.do(context.Background(), http.MethodGet, "/settings", nil)
+	require.NoError(t, err)
+	require.Equal(t, "{}", string(body))
+	var event string
+	require.NoError(t, client.sseStream(context.Background(), "/config/events", func(data []byte) { event = string(data) }))
+	require.Equal(t, "connected", event)
+	client.Close()
+	require.Nil(t, client.localapi)
 }

--- a/ipc/client_mobile_test.go
+++ b/ipc/client_mobile_test.go
@@ -54,7 +54,9 @@ func TestRemoteClientNeverCreatesFallback(t *testing.T) {
 		_, err := client.do(context.Background(), http.MethodGet, "/settings", nil)
 		require.ErrorIs(t, err, ErrIPCNotRunning)
 		require.ErrorIs(t, err, connectionErr)
-		require.ErrorIs(t, client.sseStream(context.Background(), "/config/events", func([]byte) {}), ErrIPCNotRunning)
+		err = client.sseStream(context.Background(), "/config/events", func([]byte) {})
+		require.ErrorIs(t, err, ErrIPCNotRunning)
+		require.ErrorIs(t, err, connectionErr)
 		require.Nil(t, client.localapi)
 	}
 	client.http.Transport = remoteTransport(func(r *http.Request) (*http.Response, error) {


### PR DESCRIPTION
Add `ipc.NewRemoteClient` for mobile hosts that already own a service backend in the same process. This client never creates or closes a fallback backend. Missing/refused sockets return `ErrIPCNotRunning`, and successful requests/event streams plus client closure safely handle the absence of a local API.

Android currently starts its service backend, then creates an eager fallback backend for the UI. The first successful IPC request closes that fallback, whose `LocalBackend.Close` disarms the process-wide Unbounded manager shared with the service. Ticket 182752 shows the new STUN config and dependency versions, but 97 snapshots remain `enabled:true,running:false`. The companion getlantern/lantern#9044 selects the new constructor only on Android; existing fallback clients retain their behavior.

```mermaid
sequenceDiagram
    autonumber
    participant A as Android<br/>LanternVpnService.kt
    participant L as Core<br/>init_mobile.go
    participant I as IPC<br/>client_mobile.go
    participant B as Backend<br/>radiance.go
    participant U as Donor<br/>unbounded.go
    A->>B: LanternVpnService.kt:375<br/>Start service backend
    A->>L: LanternVpnService.kt:376<br/>Set up UI client
    L->>I: init_mobile.go:17<br/>NewRemoteClient with no fallback backend ⚠️
    I->>B: client_mobile.go:109<br/>Request through service socket
    rect rgba(255, 200, 200, 0.3)
        Note over B,U: radiance.go:468<br/>Old fallback Close called process-wide Unbounded Stop 🐛
    end
    Note over I: client_mobile.go:80<br/>No local backend to close after IPC success
```

Line references use this PR, the companion Lantern branch, and Radiance backend at `50149728c3d0`.

Validation: `go test -race ./ipc ./unbounded -timeout=120s`; regression exercises absent/refused sockets, recovery to successful requests, SSE, and repeated close without creating a backend. On-device recovery is not yet verified.

Additional validation: `go vet ./ipc` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for remote-only clients that connect to an existing service without starting a local backend.

- **Bug Fixes**
  - Improved unavailable IPC error reporting with consistent `ErrIPCNotRunning` responses.
  - Prevented remote clients from creating unintended local fallback services.
  - Improved shutdown handling for clients without a local backend.
  - Preserved successful HTTP and SSE request handling for remote connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Review follow-up: SSE failures preserve both the IPC-unavailable sentinel and the underlying socket error. Race-enabled IPC tests and vet pass. The nil-backend reporting finding was verified against the existing nil-safe implementation and its passing metadata regression test.
