### PR TITLE
Fix build_tester: switch off large-runners

### DIFF
--- a/.github/workflows/build_tester.yml
+++ b/.github/workflows/build_tester.yml
@@ -8,8 +8,7 @@ concurrency:
 jobs:
   docker_push:
     name: docker push
-    runs-on:
-      group: large-runners
+    runs-on: ubuntu-latest
     permissions:
       contents: "read"
       id-token: "write"


### PR DESCRIPTION
## Summary
- `build_tester.yml`'s `docker_push` job has been stuck `queued` (or immediately cancelled by the concurrency guard on the next push) on every run since it was added — `runs-on: group: large-runners` never gets a runner assigned in this repo, unlike `flashlight`'s identical workflow which runs fine on that group.
- Every other radiance workflow (`go.yml`, `stale.yml`, `refresh-fronted-config.yml`, `update-issue-status.yml`) uses `ubuntu-latest`, so switch this job back to that.

## Test plan
- [ ] Confirm the next push to `main` picks up a GitHub-hosted runner and the job actually starts (not just queues)
- [ ] Confirm the multi-arch (`linux/amd64,linux/arm64`) buildx push still completes successfully on `ubuntu-latest`

If we want the speed of `large-runners` back, an org admin needs to add `getlantern/radiance` to that runner group's allowed repositories — I don't have org-admin scope to check or change that from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build publishing process to run on a standard hosted runner.
  * Docker image build and publishing behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->