### PR TITLE
Bump tester Dockerfile's Go image to 1.26.2

### DIFF
--- a/tester/Dockerfile
+++ b/tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.1 AS builder
+FROM golang:1.26.2 AS builder
 
 RUN apt-get update && apt-get install -y git git-lfs bsdmainutils
 


### PR DESCRIPTION
## Summary
- `build_tester.yml` now runs and authenticates successfully, but the Docker build itself fails: `go.mod` requires `go 1.26.2` while `tester/Dockerfile`'s builder stage pins `golang:1.25.1`, and `GOTOOLCHAIN=local` (the image default) blocks fetching a newer toolchain.
- Bump the builder image to `golang:1.26.2` to match `go.mod`.

## Test plan
- [ ] Re-run `build_tester.yml` on `main` and confirm the docker build/push completes for both `linux/amd64` and `linux/arm64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)